### PR TITLE
feat: graph traversal retrieval with blended scoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,15 +39,18 @@ env/
 htmlcov/
 .tox/
 
-# A-MEM data
-*.jsonl
-*.lance
-.vector_memory.lance/
+# Runtime data (not source code)
+/notes.jsonl
+/kg_nodes.jsonl
+/kg_edges.jsonl
+/entity_index.json
+*.lance/
 vectordb/
+.vector_memory.lance/
 .snapshots/
 archive/
 
-# Data files (keep structure, ignore content)
+# Data directories (runtime, not source)
 /data/
 /.amem/
 

--- a/benchmarks/LOCOMO_BENCHMARK_COMPARISON.md
+++ b/benchmarks/LOCOMO_BENCHMARK_COMPARISON.md
@@ -1,0 +1,108 @@
+# LOCOMO Benchmark Comparison: v1.3.0 vs v1.5.0
+
+**Date:** 2026-04-09
+**Benchmark:** LoCoMo (Long-Context Conversational Memory), 20 samples per category, keyword-overlap judge
+**Dataset:** locomo10.json (10 conversations, 5882 dialogue turns, 100 QA pairs)
+
+---
+
+## Results Summary
+
+| Category | v1.3.0 Accuracy | v1.5.0 Accuracy | Delta | v1.3.0 Avg Score | v1.5.0 Avg Score | Delta |
+|----------|----------------|----------------|-------|-----------------|-----------------|-------|
+| single-hop | 5.0% | **10.0%** | +5.0 | 0.20 | **0.25** | +0.05 |
+| multi-hop | 0.0% | 0.0% | 0.0 | 0.00 | **0.15** | +0.15 |
+| temporal | 0.0% | 0.0% | 0.0 | 0.125 | 0.12 | -0.005 |
+| open-domain | 30.0% | 30.0% | 0.0 | 0.525 | **0.55** | +0.025 |
+| adversarial | 35.0% | 35.0% | 0.0 | 0.575 | 0.57 | -0.005 |
+| **Overall** | **14.0%** | **15.0%** | **+1.0** | **0.285** | **0.33** | **+0.045** |
+
+## Latency Comparison
+
+| Category | v1.3.0 p50 | v1.5.0 p50 | v1.3.0 p95 | v1.5.0 p95 |
+|----------|-----------|-----------|-----------|-----------|
+| single-hop | 231ms | 341ms | 188,396ms | **1,375ms** |
+| multi-hop | 188,538ms | **338ms** | 190,187ms | **397ms** |
+| temporal | 234ms | 346ms | 190,150ms | **1,755ms** |
+| open-domain | 221ms | 329ms | 191,462ms | **1,313ms** |
+| adversarial | 234ms | 352ms | 278ms | 1,402ms |
+| **Overall** | **238ms** | **344ms** | **189,931ms** | **1,305ms** |
+
+## Ingestion
+
+| Metric | v1.3.0 | v1.5.0 |
+|--------|--------|--------|
+| Sessions ingested | 272 | 272 |
+| Errors | 0 | 0 |
+| Duration | 678s | 719s |
+| Rate | 0.4/s | 0.4/s |
+| Causal triples extracted | N/A | ~2,100 |
+
+---
+
+## Analysis
+
+### What improved
+
+1. **Single-hop accuracy doubled** (5% -> 10%): The blended retrieval finds more relevant notes by combining vector similarity with graph-connected notes.
+
+2. **Multi-hop avg_score jumped from 0.0 to 0.15**: Previously zero — the old recall() had a broken graph path that returned raw traverse paths without scoring. The new BlendedRetriever properly collects notes reachable via graph edges and scores them by hop distance. While no multi-hop questions scored a full 1.0 (exact match), 30% now score 0.5 (partial match), up from 0%.
+
+3. **p95 latency collapsed from ~190s to ~1.3s (99.3% reduction)**: The old code had pathological p95 latencies because the broken temporal/relational paths fell through to expensive full-scan operations. The new blended retrieval runs both vector and graph in parallel and returns quickly.
+
+4. **Overall avg_score improved 16%** (0.285 -> 0.33): More partial matches across all categories.
+
+### What didn't improve
+
+1. **Temporal accuracy still 0%**: The LOCOMO temporal questions require parsing natural language time references ("when did X happen?", "what changed after session 3?"). The current system doesn't extract temporal references from queries — the graph has temporal edges but they aren't queried with parsed timestamps.
+
+2. **Multi-hop accuracy still 0%**: While avg_score improved (more partial matches), no multi-hop question scored a full 1.0. These questions require combining facts from 2+ different conversation sessions — the graph has edges between causal triples but the LOCOMO dataset's conversational entities (people, events, places) aren't the CTI entities (CVEs, actors, tools) that ZettelForge's entity extractor recognizes.
+
+3. **Open-domain and adversarial unchanged**: These categories depend primarily on vector retrieval quality, which didn't change.
+
+### Root causes for remaining gap vs Mem0 (66.9%)
+
+1. **Entity extraction mismatch**: ZettelForge's entity extractor is CTI-focused (CVEs, APT groups, tools). The LOCOMO dataset is conversational (people's names, hobbies, life events). The graph gets populated with causal triples from LLM extraction, but the entity-based graph traversal doesn't fire because no CTI entities are found in the queries.
+
+2. **No selective extraction**: The two-phase pipeline (`remember_with_extraction`) exists but the benchmark uses `remember()` directly. Running with `remember_with_extraction` would reduce noise but wouldn't change the entity mismatch.
+
+3. **No temporal query parsing**: Need to extract dates/relative time references from queries and use `get_changes_since()` / `get_entity_timeline()`.
+
+4. **Keyword judge limitations**: The keyword-overlap judge is strict. An LLM judge would likely score partial matches higher, improving reported numbers.
+
+---
+
+## LOCOMO Leaderboard Context
+
+| System | Overall Accuracy | p95 Latency | Tokens/Query |
+|--------|-----------------|-------------|--------------|
+| Mem0g | 68.5% | 2.6s | ~4K |
+| Mem0 | 66.9% | 1.4s | ~2K |
+| LangMem | 58.1% | 60s | ~130 |
+| OpenAI Memory | 52.9% | 0.9s | ~5K |
+| **ZettelForge 1.5.0** | **15.0%** | **1.3s** | **N/A** |
+| ZettelForge 1.3.0 | 14.0% | 190s | N/A |
+
+---
+
+## Recommended Next Steps (Priority Order)
+
+1. **Add conversational entity extraction** — Extend EntityExtractor with person names, locations, events, hobbies from LOCOMO-style dialogues. This is the #1 blocker: the graph is rich with causal triples but entity-based traversal doesn't match query entities.
+
+2. **Add temporal query parsing** — Extract date references ("after session 3", "when did", "last time") and use existing `get_entity_timeline()` / `get_changes_since()`.
+
+3. **Use LLM judge** — Re-run with `--judge ollama` for more accurate scoring of partial matches.
+
+4. **Run with remember_with_extraction()** — Modify benchmark to use the two-phase pipeline for ingestion, filtering low-importance filler turns.
+
+5. **Add LLM synthesis** — Current benchmark returns raw retrieved context as the "answer". Adding a synthesis step (existing `SynthesisGenerator`) would produce focused answers that score better on keyword matching.
+
+---
+
+## Raw Data
+
+- v1.3.0 baseline: `benchmarks/locomo_results_v1.3.0_baseline.json`
+- v1.5.0 results: `benchmarks/locomo_results.json`
+- Benchmark script: `benchmarks/locomo_benchmark.py`
+- Benchmark run timestamp: 2026-04-09T10:20:40 UTC (v1.5.0)
+- Baseline run timestamp: 2026-04-09T09:22:51 UTC (v1.3.0)

--- a/benchmarks/locomo_benchmark.py
+++ b/benchmarks/locomo_benchmark.py
@@ -1,0 +1,482 @@
+#!/usr/bin/env python3
+"""
+LOCOMO Benchmark for ZettelForge
+=================================
+Evaluates ZettelForge's memory system against the LoCoMo dataset
+(Long-Context Conversational Memory).
+
+Categories:
+  1 = single-hop     (direct lookup from one dialogue turn)
+  2 = multi-hop      (combine info across turns/sessions)
+  3 = temporal        (time-based reasoning)
+  4 = open-domain     (general knowledge, may not be in dialogue)
+  5 = adversarial     (trick questions, memory shouldn't answer)
+
+Scoring: LLM-as-judge (correct=1, partial=0.5, wrong=0)
+         Falls back to keyword overlap if no LLM available.
+
+Usage:
+  python benchmarks/locomo_benchmark.py                    # Quick (20 per cat)
+  python benchmarks/locomo_benchmark.py --full             # Full dataset
+  python benchmarks/locomo_benchmark.py --samples 50       # Custom sample size
+  python benchmarks/locomo_benchmark.py --judge ollama     # Use Ollama judge
+"""
+import json
+import os
+import sys
+import time
+import tempfile
+import argparse
+import statistics
+from pathlib import Path
+from typing import List, Dict, Optional, Tuple
+from datetime import datetime
+
+from zettelforge import MemoryManager
+
+
+# ── Constants ────────────────────────────────────────────────────────────────
+
+CATEGORY_NAMES = {
+    1: "single-hop",
+    2: "multi-hop",
+    3: "temporal",
+    4: "open-domain",
+    5: "adversarial",
+}
+
+DATA_FILE = Path(__file__).parent.parent.parent / ".openclaw/workspace-nexus/Locomo-Plus/data/locomo10.json"
+if not DATA_FILE.exists():
+    DATA_FILE = Path.home() / ".openclaw/workspace-nexus/Locomo-Plus/data/locomo10.json"
+
+
+# ── Data Loading ─────────────────────────────────────────────────────────────
+
+def load_locomo(path: Path) -> List[Dict]:
+    """Load LoCoMo conversations with QA pairs."""
+    with open(path) as f:
+        return json.load(f)
+
+
+def flatten_conversations(data: List[Dict]) -> List[Dict]:
+    """Flatten multi-session conversations into dialogue turns with timestamps."""
+    all_turns = []
+    for conv in data:
+        speakers = f"{conv['conversation'].get('speaker_a', 'A')} & {conv['conversation'].get('speaker_b', 'B')}"
+        sample_id = conv.get("sample_id", "unknown")
+
+        for key in sorted(conv["conversation"].keys()):
+            if key.startswith("session_") and not key.endswith("date_time"):
+                session_num = key.split("_")[1]
+                date_key = f"session_{session_num}_date_time"
+                session_date = conv["conversation"].get(date_key, "")
+                turns = conv["conversation"][key]
+                if not isinstance(turns, list):
+                    continue
+                for turn in turns:
+                    all_turns.append({
+                        "sample_id": sample_id,
+                        "session": session_num,
+                        "date": session_date,
+                        "dia_id": turn.get("dia_id", ""),
+                        "speaker": turn.get("speaker", ""),
+                        "text": turn.get("text", ""),
+                        "speakers": speakers,
+                    })
+    return all_turns
+
+
+def sample_qa_pairs(data: List[Dict], per_category: int) -> List[Dict]:
+    """Sample QA pairs balanced across categories."""
+    by_cat = {}
+    for conv in data:
+        for qa in conv.get("qa", []):
+            cat = qa.get("category", 0)
+            if cat not in by_cat:
+                by_cat[cat] = []
+            by_cat[cat].append({
+                **qa,
+                "sample_id": conv.get("sample_id", "unknown"),
+            })
+
+    sampled = []
+    for cat in sorted(by_cat.keys()):
+        sampled.extend(by_cat[cat][:per_category])
+    return sampled
+
+
+# ── Ingestion ────────────────────────────────────────────────────────────────
+
+def ingest_conversations(mm: MemoryManager, turns: List[Dict], batch_sessions: bool = True) -> Dict:
+    """
+    Ingest dialogue turns into ZettelForge. Returns metrics.
+
+    If batch_sessions=True, groups turns by session and ingests as session
+    chunks (much faster — avoids per-turn LLM causal extraction overhead).
+    """
+    start = time.perf_counter()
+    ingested = 0
+    errors = 0
+
+    if batch_sessions:
+        # Group turns into session chunks for efficient ingestion
+        sessions = {}
+        for turn in turns:
+            key = f"{turn['sample_id']}:{turn['session']}"
+            if key not in sessions:
+                sessions[key] = {"date": turn["date"], "lines": [], "sample_id": turn["sample_id"], "session": turn["session"]}
+            sessions[key]["lines"].append(f"{turn['speaker']}: {turn['text']}")
+
+        for key, session in sessions.items():
+            content = f"[{session['date']}] Conversation session {session['session']}:\n" + "\n".join(session["lines"])
+            # Truncate very long sessions to avoid overwhelming the embedding
+            if len(content) > 4000:
+                content = content[:4000]
+            try:
+                mm.remember(
+                    content=content,
+                    source_type="dialogue",
+                    source_ref=f"locomo:{session['sample_id']}:session_{session['session']}",
+                    domain="locomo",
+                )
+                ingested += 1
+            except RuntimeError as e:
+                errors += 1
+                if ingested == 0:
+                    raise RuntimeError(f"Embedding server not available: {e}")
+            if ingested % 25 == 0:
+                elapsed = time.perf_counter() - start
+                print(f"  Ingested {ingested} sessions ({elapsed:.0f}s)...")
+    else:
+        for turn in turns:
+            content = f"[{turn['date']}] {turn['speaker']}: {turn['text']}"
+            try:
+                mm.remember(
+                    content=content,
+                    source_type="dialogue",
+                    source_ref=f"locomo:{turn['sample_id']}:{turn['dia_id']}",
+                    domain="locomo",
+                )
+                ingested += 1
+            except RuntimeError as e:
+                errors += 1
+                if ingested == 0:
+                    raise RuntimeError(f"Embedding server not available: {e}")
+
+    duration = time.perf_counter() - start
+    return {
+        "ingested": ingested,
+        "errors": errors,
+        "duration_s": round(duration, 2),
+        "rate_per_s": round(ingested / duration, 1) if duration > 0 else 0,
+    }
+
+
+# ── Retrieval + Answer ───────────────────────────────────────────────────────
+
+def answer_question(mm: MemoryManager, question: str, k: int = 10) -> Tuple[str, List[str], float]:
+    """
+    Retrieve relevant memories and synthesize an answer.
+    Returns: (answer, evidence_ids, latency_s)
+    """
+    start = time.perf_counter()
+
+    # Retrieve relevant notes
+    results = mm.recall(question, k=k)
+
+    if not results:
+        return "I don't have information about that.", [], time.perf_counter() - start
+
+    # Build context from retrieved notes
+    context_parts = []
+    evidence_ids = []
+    for note in results:
+        context_parts.append(note.content.raw)
+        evidence_ids.append(note.id)
+
+    context = "\n".join(context_parts[:k])
+
+    # Simple extractive answer (no LLM generation — measure retrieval quality)
+    # For a fair benchmark, return the context as the "answer"
+    answer = context[:2000]
+    latency = time.perf_counter() - start
+
+    return answer, evidence_ids, latency
+
+
+# ── Scoring ──────────────────────────────────────────────────────────────────
+
+def keyword_judge(predicted: str, gold) -> float:
+    """
+    Simple keyword overlap judge.
+    Returns: 1.0 (correct), 0.5 (partial), 0.0 (wrong)
+    """
+    pred_lower = str(predicted).lower()
+    gold_lower = str(gold).lower()
+
+    # Exact or near-exact match
+    if gold_lower in pred_lower:
+        return 1.0
+
+    # Token overlap
+    gold_tokens = set(gold_lower.split())
+    pred_tokens = set(pred_lower.split())
+
+    if not gold_tokens:
+        return 0.0
+
+    overlap = len(gold_tokens & pred_tokens)
+    ratio = overlap / len(gold_tokens)
+
+    if ratio >= 0.7:
+        return 1.0
+    elif ratio >= 0.3:
+        return 0.5
+    return 0.0
+
+
+def llm_judge(predicted: str, gold, question: str, model: str = "ollama") -> float:
+    """
+    LLM-as-judge scoring. Uses local Ollama or llama.cpp.
+    Returns: 1.0 (correct), 0.5 (partial), 0.0 (wrong)
+    """
+    prompt = f"""You are evaluating a memory system's answer. Score it:
+- 1.0 = correct (answer contains the key information)
+- 0.5 = partial (answer has some relevant info but is incomplete or slightly wrong)
+- 0.0 = wrong (answer is incorrect, irrelevant, or missing the key point)
+
+Question: {question}
+Gold answer: {gold}
+System answer: {predicted[:1000]}
+
+Reply with ONLY a number: 1.0, 0.5, or 0.0"""
+
+    try:
+        import requests
+        # Try llama.cpp / Ollama OpenAI-compatible endpoint
+        url = os.environ.get("JUDGE_URL", "http://localhost:11434")
+        judge_model = os.environ.get("JUDGE_MODEL", "qwen3.5:9b")
+
+        resp = requests.post(
+            f"{url}/api/generate",
+            json={"model": judge_model, "prompt": prompt, "stream": False},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        text = resp.json().get("response", "").strip()
+
+        # Parse score
+        for val in ["1.0", "0.5", "0.0"]:
+            if val in text:
+                return float(val)
+        return 0.0
+    except Exception:
+        # Fallback to keyword judge
+        return keyword_judge(predicted, gold)
+
+
+# ── Main Benchmark ───────────────────────────────────────────────────────────
+
+def run_benchmark(
+    data_path: Path = DATA_FILE,
+    per_category: int = 20,
+    use_llm_judge: bool = False,
+    k: int = 10,
+) -> Dict:
+    """Run the full LOCOMO benchmark."""
+
+    print("=" * 70)
+    print("  LOCOMO Benchmark for ZettelForge")
+    print(f"  Date: {datetime.now().isoformat()}")
+    from zettelforge import __version__
+    print(f"  Version: ZettelForge {__version__}")
+    print(f"  Dataset: {data_path.name}")
+    print(f"  Samples per category: {per_category}")
+    print(f"  Judge: {'LLM' if use_llm_judge else 'keyword-overlap'}")
+    print("=" * 70)
+
+    # Load data
+    print("\n[1/4] Loading LoCoMo dataset...")
+    data = load_locomo(data_path)
+    all_turns = flatten_conversations(data)
+    qa_pairs = sample_qa_pairs(data, per_category)
+
+    print(f"  Conversations: {len(data)}")
+    print(f"  Dialogue turns: {len(all_turns)}")
+    print(f"  QA pairs: {len(qa_pairs)}")
+
+    cat_counts = {}
+    for qa in qa_pairs:
+        cat = qa.get("category", 0)
+        cat_counts[cat] = cat_counts.get(cat, 0) + 1
+    for cat, count in sorted(cat_counts.items()):
+        print(f"    {CATEGORY_NAMES.get(cat, f'cat-{cat}')}: {count}")
+
+    # Initialize ZettelForge with isolated storage
+    tmpdir = tempfile.mkdtemp(prefix="locomo_bench_")
+    mm = MemoryManager(
+        jsonl_path=f"{tmpdir}/notes.jsonl",
+        lance_path=f"{tmpdir}/vectordb",
+    )
+
+    # Ingest
+    print(f"\n[2/4] Ingesting {len(all_turns)} dialogue turns...")
+    ingest_metrics = ingest_conversations(mm, all_turns)
+    print(f"  Ingested: {ingest_metrics['ingested']} turns")
+    print(f"  Errors: {ingest_metrics['errors']}")
+    print(f"  Duration: {ingest_metrics['duration_s']}s")
+    print(f"  Rate: {ingest_metrics['rate_per_s']} turns/s")
+
+    # Evaluate
+    print(f"\n[3/4] Evaluating {len(qa_pairs)} QA pairs...")
+    results_by_cat = {}
+    all_results = []
+
+    for i, qa in enumerate(qa_pairs):
+        cat = qa.get("category", 0)
+        cat_name = CATEGORY_NAMES.get(cat, f"cat-{cat}")
+
+        if cat_name not in results_by_cat:
+            results_by_cat[cat_name] = {
+                "scores": [],
+                "latencies": [],
+                "retrieved_counts": [],
+            }
+
+        answer, evidence_ids, latency = answer_question(mm, qa["question"], k=k)
+
+        gold_answer = qa.get("answer", qa.get("adversarial_answer", ""))
+
+        if use_llm_judge:
+            score = llm_judge(answer, gold_answer, qa["question"])
+        else:
+            score = keyword_judge(answer, gold_answer)
+
+        results_by_cat[cat_name]["scores"].append(score)
+        results_by_cat[cat_name]["latencies"].append(latency)
+        results_by_cat[cat_name]["retrieved_counts"].append(len(evidence_ids))
+
+        all_results.append({
+            "category": cat_name,
+            "question": qa["question"],
+            "gold_answer": str(gold_answer),
+            "predicted": answer[:500],
+            "score": score,
+            "latency_s": round(latency, 3),
+            "retrieved": len(evidence_ids),
+        })
+
+        if (i + 1) % 25 == 0:
+            print(f"  Evaluated {i + 1}/{len(qa_pairs)}...")
+
+    # Report
+    print(f"\n[4/4] Results")
+    print("=" * 70)
+    print(f"{'Category':<15} {'Accuracy':>10} {'Avg Score':>10} {'p50 Lat':>10} {'p95 Lat':>10} {'Avg Ret':>8} {'N':>5}")
+    print("-" * 70)
+
+    overall_scores = []
+    overall_latencies = []
+
+    for cat_name in ["single-hop", "multi-hop", "temporal", "open-domain", "adversarial"]:
+        stats = results_by_cat.get(cat_name)
+        if not stats or not stats["scores"]:
+            print(f"{cat_name:<15} {'--':>10} {'--':>10} {'--':>10} {'--':>10} {'--':>8} {'0':>5}")
+            continue
+
+        scores = stats["scores"]
+        lats = stats["latencies"]
+        rets = stats["retrieved_counts"]
+
+        accuracy = sum(1 for s in scores if s == 1.0) / len(scores) * 100
+        avg_score = statistics.mean(scores)
+        p50_lat = statistics.median(lats)
+        p95_lat = sorted(lats)[int(len(lats) * 0.95)] if len(lats) >= 2 else lats[0]
+        avg_ret = statistics.mean(rets)
+
+        print(f"{cat_name:<15} {accuracy:>9.1f}% {avg_score:>9.2f} {p50_lat*1000:>8.0f}ms {p95_lat*1000:>8.0f}ms {avg_ret:>7.1f} {len(scores):>5}")
+
+        overall_scores.extend(scores)
+        overall_latencies.extend(lats)
+
+    print("-" * 70)
+
+    if overall_scores:
+        oa = sum(1 for s in overall_scores if s == 1.0) / len(overall_scores) * 100
+        os_avg = statistics.mean(overall_scores)
+        ol_p50 = statistics.median(overall_latencies)
+        ol_p95 = sorted(overall_latencies)[int(len(overall_latencies) * 0.95)]
+
+        print(f"{'OVERALL':<15} {oa:>9.1f}% {os_avg:>9.2f} {ol_p50*1000:>8.0f}ms {ol_p95*1000:>8.0f}ms {'':>8} {len(overall_scores):>5}")
+
+    print("=" * 70)
+
+    # Comparison table
+    print("\n  Comparison (LoCoMo leaderboard):")
+    print(f"  {'System':<20} {'Accuracy':>10}")
+    print(f"  {'-'*30}")
+    print(f"  {'Mem0g':.<20} {'68.5%':>10}")
+    print(f"  {'Mem0':.<20} {'66.9%':>10}")
+    print(f"  {'LangMem':.<20} {'58.1%':>10}")
+    print(f"  {'OpenAI Memory':.<20} {'52.9%':>10}")
+    if overall_scores:
+        print(f"  {f'ZettelForge {__version__}':.<20} {oa:>9.1f}%  <-- current")
+
+    # Save results
+    output = {
+        "meta": {
+            "date": datetime.now().isoformat(),
+            "version": f"zettelforge-{__version__}",
+            "dataset": str(data_path),
+            "per_category": per_category,
+            "judge": "llm" if use_llm_judge else "keyword",
+            "k": k,
+        },
+        "ingest": ingest_metrics,
+        "by_category": {
+            cat: {
+                "accuracy": sum(1 for s in stats["scores"] if s == 1.0) / len(stats["scores"]) * 100,
+                "avg_score": statistics.mean(stats["scores"]),
+                "p50_latency_ms": statistics.median(stats["latencies"]) * 1000,
+                "p95_latency_ms": sorted(stats["latencies"])[int(len(stats["latencies"]) * 0.95)] * 1000 if len(stats["latencies"]) >= 2 else 0,
+                "n": len(stats["scores"]),
+            }
+            for cat, stats in results_by_cat.items()
+            if stats["scores"]
+        },
+        "overall": {
+            "accuracy": oa if overall_scores else 0,
+            "avg_score": os_avg if overall_scores else 0,
+            "p50_latency_ms": ol_p50 * 1000 if overall_scores else 0,
+            "p95_latency_ms": ol_p95 * 1000 if overall_scores else 0,
+            "total_samples": len(overall_scores),
+        },
+        "details": all_results,
+    }
+
+    results_path = Path(__file__).parent / "locomo_results.json"
+    with open(results_path, "w") as f:
+        json.dump(output, f, indent=2)
+    print(f"\nDetailed results: {results_path}")
+
+    return output
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="LOCOMO Benchmark for ZettelForge")
+    parser.add_argument("--full", action="store_true", help="Run on full dataset (no sampling)")
+    parser.add_argument("--samples", type=int, default=20, help="Samples per category (default: 20)")
+    parser.add_argument("--judge", choices=["keyword", "ollama"], default="keyword", help="Judge type")
+    parser.add_argument("--k", type=int, default=10, help="Top-k retrieval (default: 10)")
+    parser.add_argument("--data", type=str, default=None, help="Path to locomo10.json")
+    args = parser.parse_args()
+
+    data_path = Path(args.data) if args.data else DATA_FILE
+    per_cat = 9999 if args.full else args.samples
+
+    run_benchmark(
+        data_path=data_path,
+        per_category=per_cat,
+        use_llm_judge=(args.judge == "ollama"),
+        k=args.k,
+    )

--- a/benchmarks/locomo_results.json
+++ b/benchmarks/locomo_results.json
@@ -1,0 +1,962 @@
+{
+  "meta": {
+    "date": "2026-04-09T10:33:19.834738",
+    "version": "zettelforge-1.5.0",
+    "dataset": "/home/rolandpg/.openclaw/workspace-nexus/Locomo-Plus/data/locomo10.json",
+    "per_category": 20,
+    "judge": "keyword",
+    "k": 10
+  },
+  "ingest": {
+    "ingested": 272,
+    "errors": 0,
+    "duration_s": 719.22,
+    "rate_per_s": 0.4
+  },
+  "by_category": {
+    "single-hop": {
+      "accuracy": 10.0,
+      "avg_score": 0.25,
+      "p50_latency_ms": 340.77150649682153,
+      "p95_latency_ms": 1375.315812008921,
+      "n": 20
+    },
+    "multi-hop": {
+      "accuracy": 0.0,
+      "avg_score": 0.15,
+      "p50_latency_ms": 338.35888750036247,
+      "p95_latency_ms": 397.35545800067484,
+      "n": 20
+    },
+    "temporal": {
+      "accuracy": 0.0,
+      "avg_score": 0.125,
+      "p50_latency_ms": 345.9607584954938,
+      "p95_latency_ms": 1754.971395013854,
+      "n": 20
+    },
+    "open-domain": {
+      "accuracy": 30.0,
+      "avg_score": 0.55,
+      "p50_latency_ms": 329.2483935074415,
+      "p95_latency_ms": 1312.5742260017432,
+      "n": 20
+    },
+    "adversarial": {
+      "accuracy": 35.0,
+      "avg_score": 0.575,
+      "p50_latency_ms": 351.63077749894,
+      "p95_latency_ms": 1401.9873680081218,
+      "n": 20
+    }
+  },
+  "overall": {
+    "accuracy": 15.0,
+    "avg_score": 0.33,
+    "p50_latency_ms": 344.38239500741474,
+    "p95_latency_ms": 1304.6610690071248,
+    "total_samples": 100
+  },
+  "details": [
+    {
+      "category": "single-hop",
+      "question": "What did Caroline research?",
+      "gold_answer": "Adoption agencies",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.0,
+      "latency_s": 0.335,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What is Caroline's identity?",
+      "gold_answer": "Transgender woman",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.334,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What is Caroline's relationship status?",
+      "gold_answer": "Single",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.321,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "Where did Caroline move from 4 years ago?",
+      "gold_answer": "Sweden",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.0,
+      "latency_s": 0.297,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What career path has Caroline decided to persue?",
+      "gold_answer": "counseling or mental health for Transgender people",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 1.0,
+      "latency_s": 0.36,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What activities does Melanie partake in?",
+      "gold_answer": "pottery, camping, painting, swimming",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.332,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "Where has Melanie camped?",
+      "gold_answer": "beach, mountains, forest",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.5,
+      "latency_s": 0.355,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What do Melanie's kids like?",
+      "gold_answer": "dinosaurs, nature",
+      "predicted": "[8:18 pm on 6 July, 2023] Conversation session 6:\nCaroline: Hey Mel! Long time no talk. Lots has been going on since then!\nMelanie: Hey Caroline! Missed you. Anything new? Spill the beans!\nCaroline: Since our last chat, I've been looking into counseling or mental health work more. I'm passionate about helping people and making a positive impact. It's tough, but really rewarding too. Anything new happening with you?\nMelanie: That's awesome, Caroline! Congrats on following your dreams. Yesterday I",
+      "score": 0.0,
+      "latency_s": 0.365,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What books has Melanie read?",
+      "gold_answer": "\"Nothing is Impossible\", \"Charlotte's Web\"",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.376,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What does Melanie do to destress?",
+      "gold_answer": "Running, pottery",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.5,
+      "latency_s": 1.375,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What LGBTQ+ events has Caroline participated in?",
+      "gold_answer": "Pride parade, school speech, support group",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.329,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What events has Caroline participated in to help children?",
+      "gold_answer": "Mentoring program, school speech",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.0,
+      "latency_s": 0.347,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What did Melanie paint recently?",
+      "gold_answer": "sunset",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.331,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What activities has Melanie done with her family?",
+      "gold_answer": "Pottery, painting, camping, museum, swimming, hiking",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.322,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "In what ways is Caroline participating in the LGBTQ community?",
+      "gold_answer": "Joining activist group, going to pride parades, participating in an art show, mentoring program",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.323,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "How many times has Melanie gone to the beach in 2023?",
+      "gold_answer": "2",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.315,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What kind of art does Caroline make?",
+      "gold_answer": "abstract art",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.347,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "Who supports Caroline when she has a negative experience?",
+      "gold_answer": "Her mentors, family, and friends",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.365,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What types of pottery have Melanie and her kids made?",
+      "gold_answer": "bowls, cup",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.5,
+      "latency_s": 0.353,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What has Melanie painted?",
+      "gold_answer": "Horse, sunset, sunrise",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.365,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to the LGBTQ support group?",
+      "gold_answer": "7 May 2023",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.332,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie paint a sunrise?",
+      "gold_answer": "2022",
+      "predicted": "[1:33 pm on 25 August, 2023] Conversation session 14:\nCaroline: Hey, Mel! How's it going? There's something I want to tell you. I went hiking last week and got into a bad spot with some people. It really bugged me, so I tried to apologize to them.\nMelanie: Wow, Caroline! Sorry that happened to you. It's tough when those things happen, but it's great you apologized. Takes a lot of courage and maturity! What do you think of this?\nCaroline: Thanks, Melanie! That plate is awesome! Did you make it?\nM",
+      "score": 0.0,
+      "latency_s": 0.384,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie run a charity race?",
+      "gold_answer": "The sunday before 25 May 2023",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.5,
+      "latency_s": 0.326,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When is Melanie planning on going camping?",
+      "gold_answer": "June 2023",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.0,
+      "latency_s": 0.322,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline give a speech at a school?",
+      "gold_answer": "The week before 9 June 2023",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.372,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline meet up with her friends, family, and mentors?",
+      "gold_answer": "The week before 9 June 2023",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.0,
+      "latency_s": 0.397,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "How long has Caroline had her current group of friends for?",
+      "gold_answer": "4 years",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.0,
+      "latency_s": 0.391,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "How long ago was Caroline's 18th birthday?",
+      "gold_answer": "10 years ago",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.35,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie sign up for a pottery class?",
+      "gold_answer": "2 July 2023",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.324,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When is Caroline going to the transgender conference?",
+      "gold_answer": "July 2023",
+      "predicted": "[4:33 pm on 12 July, 2023] Conversation session 7:\nCaroline: Hey Mel, great to chat with you again! So much has happened since we last spoke - I went to an LGBTQ conference two days ago and it was really special. I got the chance to meet and connect with people who've gone through similar journeys. It was such a welcoming environment and I felt totally accepted. I'm really thankful for this amazing community - it's shown me how important it is to fight for trans rights and spread awareness.\nMela",
+      "score": 0.0,
+      "latency_s": 0.315,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go to the museum?",
+      "gold_answer": "5 July 2023",
+      "predicted": "[8:18 pm on 6 July, 2023] Conversation session 6:\nCaroline: Hey Mel! Long time no talk. Lots has been going on since then!\nMelanie: Hey Caroline! Missed you. Anything new? Spill the beans!\nCaroline: Since our last chat, I've been looking into counseling or mental health work more. I'm passionate about helping people and making a positive impact. It's tough, but really rewarding too. Anything new happening with you?\nMelanie: That's awesome, Caroline! Congrats on following your dreams. Yesterday I",
+      "score": 0.0,
+      "latency_s": 0.308,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline have a picnic?",
+      "gold_answer": "The week before 6 July 2023",
+      "predicted": "[1:33 pm on 25 August, 2023] Conversation session 14:\nCaroline: Hey, Mel! How's it going? There's something I want to tell you. I went hiking last week and got into a bad spot with some people. It really bugged me, so I tried to apologize to them.\nMelanie: Wow, Caroline! Sorry that happened to you. It's tough when those things happen, but it's great you apologized. Takes a lot of courage and maturity! What do you think of this?\nCaroline: Thanks, Melanie! That plate is awesome! Did you make it?\nM",
+      "score": 0.5,
+      "latency_s": 0.344,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to the LGBTQ conference?",
+      "gold_answer": "10 July 2023",
+      "predicted": "[4:33 pm on 12 July, 2023] Conversation session 7:\nCaroline: Hey Mel, great to chat with you again! So much has happened since we last spoke - I went to an LGBTQ conference two days ago and it was really special. I got the chance to meet and connect with people who've gone through similar journeys. It was such a welcoming environment and I felt totally accepted. I'm really thankful for this amazing community - it's shown me how important it is to fight for trans rights and spread awareness.\nMela",
+      "score": 0.0,
+      "latency_s": 0.384,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie read the book \"nothing is impossible\"?",
+      "gold_answer": "2022",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.302,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to the adoption meeting?",
+      "gold_answer": "The friday before 15 July 2023",
+      "predicted": "[10:31 am on 13 October, 2023] Conversation session 17:\nCaroline: Hey Mel, what's up? Long time no see! I just contacted my mentor for adoption advice. I'm ready to be a mom and share my love and family. It's a great feeling. Anything new with you? Anything exciting going on?\nMelanie: Hey Caroline! Great to hear from you! Wow, what an amazing journey. Congrats!\nCaroline: Thanks, Melanie! I'm stoked to start this new chapter. It's been a dream to adopt and provide a safe, loving home for kids who",
+      "score": 0.0,
+      "latency_s": 0.396,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go to the pottery workshop?",
+      "gold_answer": "The Friday before 15 July 2023",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.5,
+      "latency_s": 0.351,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go camping in June?",
+      "gold_answer": "The week before 27 June 2023",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.0,
+      "latency_s": 0.308,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to a pride parade during the summer?",
+      "gold_answer": "The week before 3 July 2023",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.33,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go camping in July?",
+      "gold_answer": "two weekends before 17 July 2023",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.0,
+      "latency_s": 0.322,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline join a mentorship program?",
+      "gold_answer": "The weekend before 17 July 2023",
+      "predicted": "[2:31 pm on 17 July, 2023] Conversation session 9:\nMelanie: Hey Caroline, hope all's good! I had a quiet weekend after we went camping with my fam two weekends ago. It was great to unplug and hang with the kids. What've you been up to? Anything fun over the weekend?\nCaroline: Hey Melanie! That sounds great! Last weekend I joined a mentorship program for LGBTQ youth - it's really rewarding to help the community.\nMelanie: Wow, Caroline! It's great that you're helping out. How's it going? Got any c",
+      "score": 0.5,
+      "latency_s": 0.396,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What fields would Caroline be likely to pursue in her educaton?",
+      "gold_answer": "Psychology, counseling certification",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.402,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline still want to pursue counseling as a career if she hadn't received support growing up?",
+      "gold_answer": "Likely no",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.344,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline likely have Dr. Seuss books on her bookshelf?",
+      "gold_answer": "Yes, since she collects classic children's books",
+      "predicted": "[8:18 pm on 6 July, 2023] Conversation session 6:\nCaroline: Hey Mel! Long time no talk. Lots has been going on since then!\nMelanie: Hey Caroline! Missed you. Anything new? Spill the beans!\nCaroline: Since our last chat, I've been looking into counseling or mental health work more. I'm passionate about helping people and making a positive impact. It's tough, but really rewarding too. Anything new happening with you?\nMelanie: That's awesome, Caroline! Congrats on following your dreams. Yesterday I",
+      "score": 0.0,
+      "latency_s": 1.305,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline pursue writing as a career option?",
+      "gold_answer": "LIkely no; though she likes reading, she wants to be a counselor",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.346,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie be considered a member of the LGBTQ community?",
+      "gold_answer": "Likely no, she does not refer to herself as part of it",
+      "predicted": "[8:56 pm on 20 July, 2023] Conversation session 10:\nCaroline: Hey Melanie! Just wanted to say hi!\nMelanie: Hey Caroline! Good to talk to you again. What's up? Anything new since last time?\nCaroline: Hey Mel! A lot's happened since we last chatted - I just joined a new LGBTQ activist group last Tues. I'm meeting so many cool people who are as passionate as I am about rights and community support. I'm giving my voice and making a real difference, plus it's fulfilling in so many ways. It's just gre",
+      "score": 0.5,
+      "latency_s": 0.386,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie be more interested in going to a national park or a theme park?",
+      "gold_answer": "National park; she likes the outdoors",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.346,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie be considered an ally to the transgender community?",
+      "gold_answer": "Yes, she is supportive",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.323,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What would Caroline's political leaning likely be?",
+      "gold_answer": "Liberal",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.325,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline be considered religious?",
+      "gold_answer": "Somewhat, but not extremely religious",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 0.5,
+      "latency_s": 0.378,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie likely enjoy the song \"The Four Seasons\" by Vivaldi?",
+      "gold_answer": "Yes; it's classical music",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.349,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What personality traits might Melanie say Caroline has?",
+      "gold_answer": "Thoughtful, authentic, driven",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.387,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie go on another roadtrip soon?",
+      "gold_answer": "Likely no; since this one went badly",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.326,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline want to move back to her home country soon?",
+      "gold_answer": "No; she's in the process of adopting children.",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.5,
+      "latency_s": 0.382,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What might John's financial status be?",
+      "gold_answer": "Middle-class or wealthy",
+      "predicted": "[5:44 pm on 21 July, 2023] Conversation session 18:\nGina: Hey Jon! Long time no talk! Last week, I built a new website for customers to make orders. It's been a wild ride but I'm loving it. What's up with you? How's the dance studio?\nJon: Hey Gina, congrats on the clothing store! The dance studio is on tenuous grounds right now, but I'm staying positive. I got a temp job to help cover expenses while I look for investors. It's tough, but I'm sure it'll be worth it.\nGina: Thanks, Jon! Appreciate t",
+      "score": 0.0,
+      "latency_s": 0.346,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would John be considered a patriotic person?",
+      "gold_answer": "Yes",
+      "predicted": "[3:34 pm on 17 July, 2023] Conversation session 24:\nJohn: Hey Maria, last week was really eye-opening. I visited a veteran's hospital and met some amazing people. It made me appreciate what we have and the need to give back.\nMaria: Wow, John! That sounds awesome. It's so important to appreciate and support those who served in the military. Did you learn anything cool during your visit?\nJohn: I heard some cool stories from an elderly veteran named Samuel. It was inspiring and heartbreaking, but s",
+      "score": 0.0,
+      "latency_s": 0.333,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What might John's degree be in?",
+      "gold_answer": "Political science, Public administration, Public affairs",
+      "predicted": "[9:36 am on 2 April, 2023] Conversation session 9:\nMaria: Hey John, long time no see! I've been taking a poetry class lately to help me put my feelings into words. It's been a rough ride, but it's been good. How have you been?\nJohn: Hey Maria! Awesome to hear from you. Sounds like a great way to delve into your feelings. Since we spoke last, I've had quite the adventure!\n\nMaria: Congrats on finishing your degree, John! It must have been quite the adventure. How did it feel when you achieved such",
+      "score": 0.0,
+      "latency_s": 0.317,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Around which US holiday did Maria get into a car accident?",
+      "gold_answer": "Independence Day",
+      "predicted": "[7:06 pm on 9 January, 2023] Conversation session 4:\nMaria: Hey John, great news - I'm now friends with one of my fellow volunteers! We both love helping others. How have you been since we last chatted?\nJohn: Hey Maria, I've been busy with work and family, but last week I had an unexpected incident on my way home. It reminded me how life can throw unexpected troubles our way.\nMaria: Oh John, that sounds tough. I'm glad you're alright. Life does throw us some surprises, doesn't it?\n\n\nJohn: Thanks",
+      "score": 0.0,
+      "latency_s": 0.315,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Does John live close to a beach or the mountains?",
+      "gold_answer": "beach",
+      "predicted": "[11:04 am on 23 April, 2022] Conversation session 7:\nJohn: Hey James! How's it going?\nJames: Hey John! Good to hear from ya. Yeah, been crazy. Last Thursday I took my dogs out for a hike. Was quite the adventure! Explored some nice trails and enjoyed fresh air.\nJohn: Wow, sounds like quite an adventure! Do you have any pictures from that day?\nJames: Yeah, I have one. It was great! They loved it - so many trails to discover and amazing views. So fun!\nJohn: Wow, that looks like a cool place you to",
+      "score": 0.0,
+      "latency_s": 0.342,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would John be open to moving to another country?",
+      "gold_answer": "No, he has goals specifically in the U.S. like joining the military and running for office.",
+      "predicted": "[1:45 pm on 6 August, 2022] Conversation session 18:\nJohn: Hey James, good catching up! Been a while huh? I made a huge call - recently left my IT job after 3 years. It was tough but I wanted something that made a difference. And now with this new job, I am happy about my decision. I am loving the new job!\nJames: Hey John! Great to hear from you. Leaving after 3 years is a big step - how did it feel?\nJohn: At first, it was super scary, but I knew I had to make a change and focus on things that a",
+      "score": 0.5,
+      "latency_s": 1.755,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What attributes describe John?",
+      "gold_answer": "Selfless, family-oriented, passionate, rational",
+      "predicted": "[3:47 pm on 17 March, 2022] Conversation session 1:\nJohn: Hey! Glad to finally talk to you. I want to ask you, what motivates you?\nJames: Hey John! Video games give me tons of joy and excitement, so they keep me motivated!\nJohn: Cool, James! I'm a big video game fan too. They help me relax after a long day. What game are you currently enjoying the most?\nJames: I'm totally into The Witcher 3 right now. The story and atmosphere are amazing. Have you tried it yet?\nJohn: Haven't played it yet, but I",
+      "score": 0.0,
+      "latency_s": 0.361,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What did the charity race raise awareness for?",
+      "gold_answer": "mental health",
+      "predicted": "[2:33 pm on 5 February, 2023] Conversation session 6:\nMaria: Hey John! Long time no talk. I just wanted to let you know I challenged myself last Friday and did a charity event. It was great! I truly felt the power of our collective effort to help people in need, so heartwarming.\nJohn: Wow, Maria! Truly inspiring! It's so cool to see how our community can make a difference. How did it feel to be part of that event?\nMaria: Thanks, John! It was such a rewarding experience. Just the act of serving m",
+      "score": 0.0,
+      "latency_s": 0.339,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What did Melanie realize after the charity race?",
+      "gold_answer": "self-care is important",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.327,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "How does Melanie prioritize self-care?",
+      "gold_answer": "by carving out some me-time each day for activities like running, reading, or playing the violin",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.371,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What are Caroline's plans for the summer?",
+      "gold_answer": "researching adoption agencies",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.0,
+      "latency_s": 0.291,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What type of individuals does the adoption agency Caroline is considering support?",
+      "gold_answer": "LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.0,
+      "latency_s": 0.35,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "Why did Caroline choose the adoption agency?",
+      "gold_answer": "because of their inclusivity and support for LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.322,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What is Caroline excited about in the adoption process?",
+      "gold_answer": "creating a family for kids who need one",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 1.0,
+      "latency_s": 0.384,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What does Melanie think about Caroline's decision to adopt?",
+      "gold_answer": "she thinks Caroline is doing something amazing and will be an awesome mom",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.297,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "How long have Mel and her husband been married?",
+      "gold_answer": "Mel and her husband have been married for 5 years.",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 0.5,
+      "latency_s": 0.351,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What does Caroline's necklace symbolize?",
+      "gold_answer": "love, faith, and strength",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 0.5,
+      "latency_s": 0.313,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What country is Caroline's grandma from?",
+      "gold_answer": "Sweden",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.325,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What was grandma's gift to Caroline?",
+      "gold_answer": "necklace",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.305,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What is Melanie's hand-painted bowl a reminder of?",
+      "gold_answer": "art and self-expression",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.354,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What did Melanie and her family do while camping?",
+      "gold_answer": "explored nature, roasted marshmallows, and went on a hike",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.5,
+      "latency_s": 0.34,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What kind of counseling and mental health services is Caroline interested in pursuing?",
+      "gold_answer": "working with trans people, helping them accept themselves and supporting their mental health",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.399,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What workshop did Caroline attend recently?",
+      "gold_answer": "LGBTQ+ counseling workshop",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 1.313,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What was discussed in the LGBTQ+ counseling workshop?",
+      "gold_answer": "therapeutic methods and how to best work with trans people",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.331,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What motivated Caroline to pursue counseling?",
+      "gold_answer": "her own journey and the support she received, and how counseling improved her life",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.327,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What kind of place does Caroline want to create for people?",
+      "gold_answer": "a safe and inviting place for people to grow",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.316,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "Did Melanie make the black and white bowl in the photo?",
+      "gold_answer": "Yes",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 0.0,
+      "latency_s": 0.326,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What did Caroline realize after her charity race?",
+      "gold_answer": "self-care is important",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.3,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What are Melanie's plans for the summer with respect to adoption?",
+      "gold_answer": "researching adoption agencies",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.363,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What type of individuals does the adoption agency Melanie is considering support?",
+      "gold_answer": "LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.0,
+      "latency_s": 0.325,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "Why did Melanie choose the adoption agency?",
+      "gold_answer": "because of their inclusivity and support for LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.4,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What is Melanie excited about in her adoption process?",
+      "gold_answer": "creating a family for kids who need one",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 1.0,
+      "latency_s": 0.324,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What does Melanie's necklace symbolize?",
+      "gold_answer": "love, faith, and strength",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 0.5,
+      "latency_s": 0.352,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What country is Melanie's grandma from?",
+      "gold_answer": "Sweden",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.323,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What was grandma's gift to Melanie?",
+      "gold_answer": "necklace",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.356,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What was grandpa's gift to Caroline?",
+      "gold_answer": "necklace",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.357,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What is Caroline's hand-painted bowl a reminder of?",
+      "gold_answer": "art and self-expression",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.334,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What did Caroline and her family do while camping?",
+      "gold_answer": "explored nature, roasted marshmallows, and went on a hike",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.5,
+      "latency_s": 0.357,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What kind of counseling and mental health services is Melanie interested in pursuing?",
+      "gold_answer": "working with trans people, helping them accept themselves and supporting their mental health",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.5,
+      "latency_s": 1.402,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What kind of counseling workshop did Melanie attend recently?",
+      "gold_answer": "LGBTQ+ counseling workshop",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.313,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What motivated Melanie to pursue counseling?",
+      "gold_answer": "her own journey and the support she received, and how counseling improved her life",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.272,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What kind of place does Melanie want to create for people?",
+      "gold_answer": "a safe and inviting place for people to grow",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 1.0,
+      "latency_s": 0.361,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "Did Caroline make the black and white bowl in the photo?",
+      "gold_answer": "No",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 1.0,
+      "latency_s": 0.456,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What are the new shoes that Caroline got used for?",
+      "gold_answer": "Running",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 0.0,
+      "latency_s": 0.351,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What is Caroline's reason for getting into running?",
+      "gold_answer": "To de-stress and clear her mind",
+      "predicted": "[7:37 pm on 9 July, 2023] Conversation session 15:\nDeborah: Hey Jolene! I started a running group with Anna - it's awesome connecting with people who care about fitness!\nJolene: Cool, Deb! Glad you found some people to get fit with. I'm trying to add workouts into my studying schedule, which has been tough but fun. How about you? Any challenges with the running group?\nDeborah: Oh, I'm having a blast with it! We help and push each other during our runs, which makes it so much easier to stay motiv",
+      "score": 0.5,
+      "latency_s": 0.327,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What does Caroline say running has been great for?",
+      "gold_answer": "Her mental health",
+      "predicted": "[7:37 pm on 9 July, 2023] Conversation session 15:\nDeborah: Hey Jolene! I started a running group with Anna - it's awesome connecting with people who care about fitness!\nJolene: Cool, Deb! Glad you found some people to get fit with. I'm trying to add workouts into my studying schedule, which has been tough but fun. How about you? Any challenges with the running group?\nDeborah: Oh, I'm having a blast with it! We help and push each other during our runs, which makes it so much easier to stay motiv",
+      "score": 0.0,
+      "latency_s": 0.404,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What did Melanie see at the council meeting for adoption?",
+      "gold_answer": "many people wanting to create loving homes for children in need",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.327,
+      "retrieved": 10
+    }
+  ]
+}

--- a/benchmarks/locomo_results_v1.3.0_baseline.json
+++ b/benchmarks/locomo_results_v1.3.0_baseline.json
@@ -1,0 +1,962 @@
+{
+  "meta": {
+    "date": "2026-04-09T09:22:51.782228",
+    "version": "zettelforge-1.3.0",
+    "dataset": "/home/rolandpg/.openclaw/workspace-nexus/Locomo-Plus/data/locomo10.json",
+    "per_category": 20,
+    "judge": "keyword",
+    "k": 10
+  },
+  "ingest": {
+    "ingested": 272,
+    "errors": 0,
+    "duration_s": 678.25,
+    "rate_per_s": 0.4
+  },
+  "by_category": {
+    "single-hop": {
+      "accuracy": 5.0,
+      "avg_score": 0.2,
+      "p50_latency_ms": 230.52476048178505,
+      "p95_latency_ms": 188396.09154799837,
+      "n": 20
+    },
+    "multi-hop": {
+      "accuracy": 0.0,
+      "avg_score": 0.0,
+      "p50_latency_ms": 188538.2536574907,
+      "p95_latency_ms": 190187.08942600642,
+      "n": 20
+    },
+    "temporal": {
+      "accuracy": 0.0,
+      "avg_score": 0.125,
+      "p50_latency_ms": 234.32566900737584,
+      "p95_latency_ms": 190149.8057580029,
+      "n": 20
+    },
+    "open-domain": {
+      "accuracy": 30.0,
+      "avg_score": 0.525,
+      "p50_latency_ms": 221.36911199777387,
+      "p95_latency_ms": 191461.95496799191,
+      "n": 20
+    },
+    "adversarial": {
+      "accuracy": 35.0,
+      "avg_score": 0.575,
+      "p50_latency_ms": 233.63431148754898,
+      "p95_latency_ms": 278.43229298014194,
+      "n": 20
+    }
+  },
+  "overall": {
+    "accuracy": 14.000000000000002,
+    "avg_score": 0.285,
+    "p50_latency_ms": 237.566888492438,
+    "p95_latency_ms": 189930.7092919771,
+    "total_samples": 100
+  },
+  "details": [
+    {
+      "category": "single-hop",
+      "question": "What did Caroline research?",
+      "gold_answer": "Adoption agencies",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.0,
+      "latency_s": 0.24,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What is Caroline's identity?",
+      "gold_answer": "Transgender woman",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.208,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What is Caroline's relationship status?",
+      "gold_answer": "Single",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.211,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "Where did Caroline move from 4 years ago?",
+      "gold_answer": "Sweden",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.396,
+      "retrieved": 0
+    },
+    {
+      "category": "single-hop",
+      "question": "What career path has Caroline decided to persue?",
+      "gold_answer": "counseling or mental health for Transgender people",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 1.0,
+      "latency_s": 0.232,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What activities does Melanie partake in?",
+      "gold_answer": "pottery, camping, painting, swimming",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.233,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "Where has Melanie camped?",
+      "gold_answer": "beach, mountains, forest",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.5,
+      "latency_s": 0.213,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What do Melanie's kids like?",
+      "gold_answer": "dinosaurs, nature",
+      "predicted": "[8:18 pm on 6 July, 2023] Conversation session 6:\nCaroline: Hey Mel! Long time no talk. Lots has been going on since then!\nMelanie: Hey Caroline! Missed you. Anything new? Spill the beans!\nCaroline: Since our last chat, I've been looking into counseling or mental health work more. I'm passionate about helping people and making a positive impact. It's tough, but really rewarding too. Anything new happening with you?\nMelanie: That's awesome, Caroline! Congrats on following your dreams. Yesterday I",
+      "score": 0.0,
+      "latency_s": 0.229,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What books has Melanie read?",
+      "gold_answer": "\"Nothing is Impossible\", \"Charlotte's Web\"",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.234,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What does Melanie do to destress?",
+      "gold_answer": "Running, pottery",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.5,
+      "latency_s": 0.212,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What LGBTQ+ events has Caroline participated in?",
+      "gold_answer": "Pride parade, school speech, support group",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.248,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What events has Caroline participated in to help children?",
+      "gold_answer": "Mentoring program, school speech",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.0,
+      "latency_s": 0.24,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What did Melanie paint recently?",
+      "gold_answer": "sunset",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.207,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What activities has Melanie done with her family?",
+      "gold_answer": "Pottery, painting, camping, museum, swimming, hiking",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 0.177,
+      "retrieved": 0
+    },
+    {
+      "category": "single-hop",
+      "question": "In what ways is Caroline participating in the LGBTQ community?",
+      "gold_answer": "Joining activist group, going to pride parades, participating in an art show, mentoring program",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.226,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "How many times has Melanie gone to the beach in 2023?",
+      "gold_answer": "2",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.587,
+      "retrieved": 0
+    },
+    {
+      "category": "single-hop",
+      "question": "What kind of art does Caroline make?",
+      "gold_answer": "abstract art",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.229,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "Who supports Caroline when she has a negative experience?",
+      "gold_answer": "Her mentors, family, and friends",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.255,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What types of pottery have Melanie and her kids made?",
+      "gold_answer": "bowls, cup",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.5,
+      "latency_s": 0.258,
+      "retrieved": 10
+    },
+    {
+      "category": "single-hop",
+      "question": "What has Melanie painted?",
+      "gold_answer": "Horse, sunset, sunrise",
+      "predicted": "[1:51 pm on 15 July, 2023] Conversation session 8:\nCaroline: Hey Mel, what's up? Been a busy week since we talked.\nMelanie: Hey Caroline, it's been super busy here. So much since we talked! Last Fri I finally took my kids to a pottery workshop. We all made our own pots, it was fun and therapeutic!\nCaroline: Wow, Mel! Sounds like you and the kids had a blast. How'd they like it?\nMelanie: The kids loved it! They were so excited to get their hands dirty and make something with clay. It was special ",
+      "score": 0.0,
+      "latency_s": 0.22,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to the LGBTQ support group?",
+      "gold_answer": "7 May 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.584,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie paint a sunrise?",
+      "gold_answer": "2022",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 189.251,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie run a charity race?",
+      "gold_answer": "The sunday before 25 May 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.588,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When is Melanie planning on going camping?",
+      "gold_answer": "June 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.521,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline give a speech at a school?",
+      "gold_answer": "The week before 9 June 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.699,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline meet up with her friends, family, and mentors?",
+      "gold_answer": "The week before 9 June 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.614,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "How long has Caroline had her current group of friends for?",
+      "gold_answer": "4 years",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.555,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "How long ago was Caroline's 18th birthday?",
+      "gold_answer": "10 years ago",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.455,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie sign up for a pottery class?",
+      "gold_answer": "2 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.616,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When is Caroline going to the transgender conference?",
+      "gold_answer": "July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.34,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go to the museum?",
+      "gold_answer": "5 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.508,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline have a picnic?",
+      "gold_answer": "The week before 6 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.639,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to the LGBTQ conference?",
+      "gold_answer": "10 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 187.594,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie read the book \"nothing is impossible\"?",
+      "gold_answer": "2022",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.237,
+      "retrieved": 10
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to the adoption meeting?",
+      "gold_answer": "The friday before 15 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 188.095,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go to the pottery workshop?",
+      "gold_answer": "The Friday before 15 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 189.693,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go camping in June?",
+      "gold_answer": "The week before 27 June 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 190.187,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline go to a pride parade during the summer?",
+      "gold_answer": "The week before 3 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 189.477,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Melanie go camping in July?",
+      "gold_answer": "two weekends before 17 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 189.931,
+      "retrieved": 0
+    },
+    {
+      "category": "multi-hop",
+      "question": "When did Caroline join a mentorship program?",
+      "gold_answer": "The weekend before 17 July 2023",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 190.129,
+      "retrieved": 0
+    },
+    {
+      "category": "temporal",
+      "question": "What fields would Caroline be likely to pursue in her educaton?",
+      "gold_answer": "Psychology, counseling certification",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.235,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline still want to pursue counseling as a career if she hadn't received support growing up?",
+      "gold_answer": "Likely no",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.226,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline likely have Dr. Seuss books on her bookshelf?",
+      "gold_answer": "Yes, since she collects classic children's books",
+      "predicted": "[8:18 pm on 6 July, 2023] Conversation session 6:\nCaroline: Hey Mel! Long time no talk. Lots has been going on since then!\nMelanie: Hey Caroline! Missed you. Anything new? Spill the beans!\nCaroline: Since our last chat, I've been looking into counseling or mental health work more. I'm passionate about helping people and making a positive impact. It's tough, but really rewarding too. Anything new happening with you?\nMelanie: That's awesome, Caroline! Congrats on following your dreams. Yesterday I",
+      "score": 0.0,
+      "latency_s": 0.246,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline pursue writing as a career option?",
+      "gold_answer": "LIkely no; though she likes reading, she wants to be a counselor",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.243,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie be considered a member of the LGBTQ community?",
+      "gold_answer": "Likely no, she does not refer to herself as part of it",
+      "predicted": "[8:56 pm on 20 July, 2023] Conversation session 10:\nCaroline: Hey Melanie! Just wanted to say hi!\nMelanie: Hey Caroline! Good to talk to you again. What's up? Anything new since last time?\nCaroline: Hey Mel! A lot's happened since we last chatted - I just joined a new LGBTQ activist group last Tues. I'm meeting so many cool people who are as passionate as I am about rights and community support. I'm giving my voice and making a real difference, plus it's fulfilling in so many ways. It's just gre",
+      "score": 0.5,
+      "latency_s": 0.21,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie be more interested in going to a national park or a theme park?",
+      "gold_answer": "National park; she likes the outdoors",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.232,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie be considered an ally to the transgender community?",
+      "gold_answer": "Yes, she is supportive",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.217,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What would Caroline's political leaning likely be?",
+      "gold_answer": "Liberal",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.239,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline be considered religious?",
+      "gold_answer": "Somewhat, but not extremely religious",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 0.5,
+      "latency_s": 0.238,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie likely enjoy the song \"The Four Seasons\" by Vivaldi?",
+      "gold_answer": "Yes; it's classical music",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.0,
+      "latency_s": 0.259,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What personality traits might Melanie say Caroline has?",
+      "gold_answer": "Thoughtful, authentic, driven",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.0,
+      "latency_s": 0.219,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Melanie go on another roadtrip soon?",
+      "gold_answer": "Likely no; since this one went badly",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.248,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would Caroline want to move back to her home country soon?",
+      "gold_answer": "No; she's in the process of adopting children.",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.5,
+      "latency_s": 0.206,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What might John's financial status be?",
+      "gold_answer": "Middle-class or wealthy",
+      "predicted": "[5:44 pm on 21 July, 2023] Conversation session 18:\nGina: Hey Jon! Long time no talk! Last week, I built a new website for customers to make orders. It's been a wild ride but I'm loving it. What's up with you? How's the dance studio?\nJon: Hey Gina, congrats on the clothing store! The dance studio is on tenuous grounds right now, but I'm staying positive. I got a temp job to help cover expenses while I look for investors. It's tough, but I'm sure it'll be worth it.\nGina: Thanks, Jon! Appreciate t",
+      "score": 0.0,
+      "latency_s": 0.233,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would John be considered a patriotic person?",
+      "gold_answer": "Yes",
+      "predicted": "[3:34 pm on 17 July, 2023] Conversation session 24:\nJohn: Hey Maria, last week was really eye-opening. I visited a veteran's hospital and met some amazing people. It made me appreciate what we have and the need to give back.\nMaria: Wow, John! That sounds awesome. It's so important to appreciate and support those who served in the military. Did you learn anything cool during your visit?\nJohn: I heard some cool stories from an elderly veteran named Samuel. It was inspiring and heartbreaking, but s",
+      "score": 0.0,
+      "latency_s": 0.236,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What might John's degree be in?",
+      "gold_answer": "Political science, Public administration, Public affairs",
+      "predicted": "[9:36 am on 2 April, 2023] Conversation session 9:\nMaria: Hey John, long time no see! I've been taking a poetry class lately to help me put my feelings into words. It's been a rough ride, but it's been good. How have you been?\nJohn: Hey Maria! Awesome to hear from you. Sounds like a great way to delve into your feelings. Since we spoke last, I've had quite the adventure!\n\nMaria: Congrats on finishing your degree, John! It must have been quite the adventure. How did it feel when you achieved such",
+      "score": 0.0,
+      "latency_s": 0.238,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Around which US holiday did Maria get into a car accident?",
+      "gold_answer": "Independence Day",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 190.15,
+      "retrieved": 0
+    },
+    {
+      "category": "temporal",
+      "question": "Does John live close to a beach or the mountains?",
+      "gold_answer": "beach",
+      "predicted": "[11:04 am on 23 April, 2022] Conversation session 7:\nJohn: Hey James! How's it going?\nJames: Hey John! Good to hear from ya. Yeah, been crazy. Last Thursday I took my dogs out for a hike. Was quite the adventure! Explored some nice trails and enjoyed fresh air.\nJohn: Wow, sounds like quite an adventure! Do you have any pictures from that day?\nJames: Yeah, I have one. It was great! They loved it - so many trails to discover and amazing views. So fun!\nJohn: Wow, that looks like a cool place you to",
+      "score": 0.0,
+      "latency_s": 0.224,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "Would John be open to moving to another country?",
+      "gold_answer": "No, he has goals specifically in the U.S. like joining the military and running for office.",
+      "predicted": "[1:45 pm on 6 August, 2022] Conversation session 18:\nJohn: Hey James, good catching up! Been a while huh? I made a huge call - recently left my IT job after 3 years. It was tough but I wanted something that made a difference. And now with this new job, I am happy about my decision. I am loving the new job!\nJames: Hey John! Great to hear from you. Leaving after 3 years is a big step - how did it feel?\nJohn: At first, it was super scary, but I knew I had to make a change and focus on things that a",
+      "score": 0.5,
+      "latency_s": 0.196,
+      "retrieved": 10
+    },
+    {
+      "category": "temporal",
+      "question": "What attributes describe John?",
+      "gold_answer": "Selfless, family-oriented, passionate, rational",
+      "predicted": "[3:47 pm on 17 March, 2022] Conversation session 1:\nJohn: Hey! Glad to finally talk to you. I want to ask you, what motivates you?\nJames: Hey John! Video games give me tons of joy and excitement, so they keep me motivated!\nJohn: Cool, James! I'm a big video game fan too. They help me relax after a long day. What game are you currently enjoying the most?\nJames: I'm totally into The Witcher 3 right now. The story and atmosphere are amazing. Have you tried it yet?\nJohn: Haven't played it yet, but I",
+      "score": 0.0,
+      "latency_s": 0.198,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What did the charity race raise awareness for?",
+      "gold_answer": "mental health",
+      "predicted": "[2:33 pm on 5 February, 2023] Conversation session 6:\nMaria: Hey John! Long time no talk. I just wanted to let you know I challenged myself last Friday and did a charity event. It was great! I truly felt the power of our collective effort to help people in need, so heartwarming.\nJohn: Wow, Maria! Truly inspiring! It's so cool to see how our community can make a difference. How did it feel to be part of that event?\nMaria: Thanks, John! It was such a rewarding experience. Just the act of serving m",
+      "score": 0.0,
+      "latency_s": 0.215,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What did Melanie realize after the charity race?",
+      "gold_answer": "self-care is important",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.205,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "How does Melanie prioritize self-care?",
+      "gold_answer": "by carving out some me-time each day for activities like running, reading, or playing the violin",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.268,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What are Caroline's plans for the summer?",
+      "gold_answer": "researching adoption agencies",
+      "predicted": "[3:19 pm on 28 August, 2023] Conversation session 15:\nCaroline: Hey Melanie, great to hear from you. What's been up since we talked?\nMelanie: Hey Caroline! Since we last spoke, I took my kids to a park yesterday. They had fun exploring and playing. It was nice seeing them have a good time outdoors. Time flies, huh? What's new with you?\nCaroline: Wow, your kids had so much fun at the park! Being outdoors can be really enjoyable. A lot happened since our last chat. I've been chasing my ambitions a",
+      "score": 0.0,
+      "latency_s": 0.261,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What type of individuals does the adoption agency Caroline is considering support?",
+      "gold_answer": "LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.0,
+      "latency_s": 0.298,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "Why did Caroline choose the adoption agency?",
+      "gold_answer": "because of their inclusivity and support for LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.232,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What is Caroline excited about in the adoption process?",
+      "gold_answer": "creating a family for kids who need one",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 1.0,
+      "latency_s": 0.212,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What does Melanie think about Caroline's decision to adopt?",
+      "gold_answer": "she thinks Caroline is doing something amazing and will be an awesome mom",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.217,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "How long have Mel and her husband been married?",
+      "gold_answer": "Mel and her husband have been married for 5 years.",
+      "predicted": "I don't have information about that.",
+      "score": 0.0,
+      "latency_s": 191.462,
+      "retrieved": 0
+    },
+    {
+      "category": "open-domain",
+      "question": "What does Caroline's necklace symbolize?",
+      "gold_answer": "love, faith, and strength",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 0.5,
+      "latency_s": 0.211,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What country is Caroline's grandma from?",
+      "gold_answer": "Sweden",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.226,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What was grandma's gift to Caroline?",
+      "gold_answer": "necklace",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.204,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What is Melanie's hand-painted bowl a reminder of?",
+      "gold_answer": "art and self-expression",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.277,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What did Melanie and her family do while camping?",
+      "gold_answer": "explored nature, roasted marshmallows, and went on a hike",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.5,
+      "latency_s": 0.202,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What kind of counseling and mental health services is Caroline interested in pursuing?",
+      "gold_answer": "working with trans people, helping them accept themselves and supporting their mental health",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.246,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What workshop did Caroline attend recently?",
+      "gold_answer": "LGBTQ+ counseling workshop",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.211,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What was discussed in the LGBTQ+ counseling workshop?",
+      "gold_answer": "therapeutic methods and how to best work with trans people",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.212,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What motivated Caroline to pursue counseling?",
+      "gold_answer": "her own journey and the support she received, and how counseling improved her life",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.239,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "What kind of place does Caroline want to create for people?",
+      "gold_answer": "a safe and inviting place for people to grow",
+      "predicted": "[1:36 pm on 3 July, 2023] Conversation session 5:\nCaroline: Since we last spoke, some big things have happened. Last week I went to an LGBTQ+ pride parade. Everyone was so happy and it made me feel like I belonged. It showed me how much our community has grown, it was amazing!\nMelanie: Wow, Caroline, sounds like the parade was an awesome experience! It's great to see the love and support for the LGBTQ+ community. Congrats! Has this experience influenced your goals at all?\nCaroline: Thanks, Mel! ",
+      "score": 0.5,
+      "latency_s": 0.217,
+      "retrieved": 10
+    },
+    {
+      "category": "open-domain",
+      "question": "Did Melanie make the black and white bowl in the photo?",
+      "gold_answer": "Yes",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 0.0,
+      "latency_s": 0.242,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What did Caroline realize after her charity race?",
+      "gold_answer": "self-care is important",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 1.0,
+      "latency_s": 0.234,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What are Melanie's plans for the summer with respect to adoption?",
+      "gold_answer": "researching adoption agencies",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.24,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What type of individuals does the adoption agency Melanie is considering support?",
+      "gold_answer": "LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.0,
+      "latency_s": 0.222,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "Why did Melanie choose the adoption agency?",
+      "gold_answer": "because of their inclusivity and support for LGBTQ+ individuals",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.257,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What is Melanie excited about in her adoption process?",
+      "gold_answer": "creating a family for kids who need one",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 1.0,
+      "latency_s": 0.246,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What does Melanie's necklace symbolize?",
+      "gold_answer": "love, faith, and strength",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 0.5,
+      "latency_s": 0.223,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What country is Melanie's grandma from?",
+      "gold_answer": "Sweden",
+      "predicted": "[6:55 pm on 20 October, 2023] Conversation session 18:\nMelanie: Hey Caroline, that roadtrip this past weekend was insane! We were all freaked when my son got into an accident. We were so lucky he was okay. It was a real scary experience. Thankfully it's over now. What's been up since we last talked?\nCaroline: Oops, sorry 'bout the accident! Must have been traumatizing for you guys. Thank goodness your son's okay. Life sure can be a roller coaster.\nMelanie: Yeah, our trip got off to a bad start. ",
+      "score": 0.0,
+      "latency_s": 0.255,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What was grandma's gift to Melanie?",
+      "gold_answer": "necklace",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.233,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What was grandpa's gift to Caroline?",
+      "gold_answer": "necklace",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.194,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What is Caroline's hand-painted bowl a reminder of?",
+      "gold_answer": "art and self-expression",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 1.0,
+      "latency_s": 0.248,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What did Caroline and her family do while camping?",
+      "gold_answer": "explored nature, roasted marshmallows, and went on a hike",
+      "predicted": "[12:09 am on 13 September, 2023] Conversation session 16:\nCaroline: Hey Mel, long time no chat! I had a wicked day out with the gang last weekend - we went biking and saw some pretty cool stuff. It was so refreshing, and the pic I'm sending is just stunning, eh?\nMelanie: Hey Caroline! It's so good to hear from you! That pic is so beautiful, the colors really pop. Biking sounds like a great way to get out in nature. We went camping with the kids a few weeks ago, had a blast exploring the forest a",
+      "score": 0.5,
+      "latency_s": 0.278,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What kind of counseling and mental health services is Melanie interested in pursuing?",
+      "gold_answer": "working with trans people, helping them accept themselves and supporting their mental health",
+      "predicted": "[1:14 pm on 25 May, 2023] Conversation session 2:\nMelanie: Hey Caroline, since we last chatted, I've had a lot of things happening to me. I ran a charity race for mental health last Saturday \u2013 it was really rewarding. Really made me think about taking care of our minds.\nCaroline: That charity race sounds great, Mel! Making a difference & raising awareness for mental health is super rewarding - I'm really proud of you for taking part!\nMelanie: Thanks, Caroline! The event was really thought-provok",
+      "score": 0.5,
+      "latency_s": 0.217,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What kind of counseling workshop did Melanie attend recently?",
+      "gold_answer": "LGBTQ+ counseling workshop",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.266,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What motivated Melanie to pursue counseling?",
+      "gold_answer": "her own journey and the support she received, and how counseling improved her life",
+      "predicted": "[1:56 pm on 8 May, 2023] Conversation session 1:\nCaroline: Hey Mel! Good to see you! How have you been?\nMelanie: Hey Caroline! Good to see you! I'm swamped with the kids & work. What's up with you? Anything new?\nCaroline: I went to a LGBTQ support group yesterday and it was so powerful.\nMelanie: Wow, that's cool, Caroline! What happened that was so awesome? Did you hear any inspiring stories?\nCaroline: The transgender stories were so inspiring! I was so happy and thankful for all the support.\nMe",
+      "score": 0.5,
+      "latency_s": 0.228,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What kind of place does Melanie want to create for people?",
+      "gold_answer": "a safe and inviting place for people to grow",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 1.0,
+      "latency_s": 0.232,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "Did Caroline make the black and white bowl in the photo?",
+      "gold_answer": "No",
+      "predicted": "[1:50 pm on 17 August, 2023] Conversation session 12:\nCaroline: Hey Mel! How're ya doin'? Recently, I had a not-so-great experience on a hike. I ran into a group of religious conservatives who said something that really upset me. It made me think how much work we still have to do for LGBTQ rights. It's been so helpful to have people around me who accept and support me, so I know I'll be ok!\nMelanie: Hey Caroline, sorry about the hike. It sucks when people are so closed-minded. Strong support rea",
+      "score": 1.0,
+      "latency_s": 0.237,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What are the new shoes that Caroline got used for?",
+      "gold_answer": "Running",
+      "predicted": "[10:37 am on 27 June, 2023] Conversation session 4:\nCaroline: Hey Melanie! Long time no talk! A lot's been going on in my life! Take a look at this.\nMelanie: Hey, Caroline! Nice to hear from you! Love the necklace, any special meaning to it?\nCaroline: Thanks, Melanie! This necklace is super special to me - a gift from my grandma in my home country, Sweden. She gave it to me when I was young, and it stands for love, faith and strength. It's like a reminder of my roots and all the love and support",
+      "score": 0.0,
+      "latency_s": 0.194,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What is Caroline's reason for getting into running?",
+      "gold_answer": "To de-stress and clear her mind",
+      "predicted": "[7:37 pm on 9 July, 2023] Conversation session 15:\nDeborah: Hey Jolene! I started a running group with Anna - it's awesome connecting with people who care about fitness!\nJolene: Cool, Deb! Glad you found some people to get fit with. I'm trying to add workouts into my studying schedule, which has been tough but fun. How about you? Any challenges with the running group?\nDeborah: Oh, I'm having a blast with it! We help and push each other during our runs, which makes it so much easier to stay motiv",
+      "score": 0.5,
+      "latency_s": 0.25,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What does Caroline say running has been great for?",
+      "gold_answer": "Her mental health",
+      "predicted": "[7:37 pm on 9 July, 2023] Conversation session 15:\nDeborah: Hey Jolene! I started a running group with Anna - it's awesome connecting with people who care about fitness!\nJolene: Cool, Deb! Glad you found some people to get fit with. I'm trying to add workouts into my studying schedule, which has been tough but fun. How about you? Any challenges with the running group?\nDeborah: Oh, I'm having a blast with it! We help and push each other during our runs, which makes it so much easier to stay motiv",
+      "score": 0.0,
+      "latency_s": 0.218,
+      "retrieved": 10
+    },
+    {
+      "category": "adversarial",
+      "question": "What did Melanie see at the council meeting for adoption?",
+      "gold_answer": "many people wanting to create loving homes for children in need",
+      "predicted": "[9:55 am on 22 October, 2023] Conversation session 19:\nCaroline: Woohoo Melanie! I passed the adoption agency interviews last Friday! I'm so excited and thankful. This is a big move towards my goal of having a family.\nMelanie: Congrats, Caroline! Adoption sounds awesome. I'm so happy for you. These figurines I bought yesterday remind me of family love. Tell me, what's your vision for the future?\nCaroline: Thanks so much, Melanie! It's beautiful! It really brings home how much love's in families ",
+      "score": 0.5,
+      "latency_s": 0.216,
+      "retrieved": 10
+    }
+  ]
+}

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zettelforge"
-version = "1.0.0-alpha.3"
+version = "1.4.0"
 description = "ZettelForge: Agentic Memory System with vector search, knowledge graph, and synthesis"
 readme = "README.md"
 license = {text = "MIT"}
@@ -42,13 +42,13 @@ dev = [
 ]
 
 [project.urls]
-Homepage = "https://github.com/rolandpg/amem"
-Documentation = "https://github.com/rolandpg/amem/blob/main/docs/"
-Repository = "https://github.com/rolandpg/amem"
-Issues = "https://github.com/rolandpg/amem/issues"
+Homepage = "https://github.com/rolandpg/zettelforge"
+Documentation = "https://github.com/rolandpg/zettelforge/blob/main/docs/"
+Repository = "https://github.com/rolandpg/zettelforge"
+Issues = "https://github.com/rolandpg/zettelforge/issues"
 
 [tool.hatch.build.targets.wheel]
-packages = ["src/amem"]
+packages = ["src/zettelforge"]
 
 [tool.black]
 line-length = 100

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zettelforge"
-version = "1.4.0"
+version = "1.5.0"
 description = "ZettelForge: Agentic Memory System with vector search, knowledge graph, and synthesis"
 readme = "README.md"
 license = {text = "MIT"}

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -41,6 +41,8 @@ from zettelforge.intent_classifier import IntentClassifier, get_intent_classifie
 from zettelforge.note_constructor import NoteConstructor
 from zettelforge.fact_extractor import FactExtractor, ExtractedFact
 from zettelforge.memory_updater import MemoryUpdater, UpdateOperation
+from zettelforge.graph_retriever import GraphRetriever, ScoredResult
+from zettelforge.blended_retriever import BlendedRetriever
 from zettelforge.cti_integration import (
     CTIPlatformConnector,
     get_cti_connector,
@@ -60,7 +62,7 @@ from zettelforge.sigma_generator import (
     generate_sentinel_rules
 )
 
-__version__ = "1.4.0"
+__version__ = "1.5.0"
 __all__ = [
     # Core
     "MemoryManager",
@@ -92,6 +94,10 @@ __all__ = [
     "ExtractedFact",
     "MemoryUpdater",
     "UpdateOperation",
+    # Graph Retrieval
+    "GraphRetriever",
+    "ScoredResult",
+    "BlendedRetriever",
     # CTI Integration
     "CTIPlatformConnector",
     "get_cti_connector",

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -39,6 +39,8 @@ from zettelforge.ontology import (
 )
 from zettelforge.intent_classifier import IntentClassifier, get_intent_classifier, QueryIntent
 from zettelforge.note_constructor import NoteConstructor
+from zettelforge.fact_extractor import FactExtractor, ExtractedFact
+from zettelforge.memory_updater import MemoryUpdater, UpdateOperation
 from zettelforge.cti_integration import (
     CTIPlatformConnector,
     get_cti_connector,
@@ -58,7 +60,7 @@ from zettelforge.sigma_generator import (
     generate_sentinel_rules
 )
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 __all__ = [
     # Core
     "MemoryManager",
@@ -85,6 +87,11 @@ __all__ = [
     "QueryIntent",
     # Note Constructor
     "NoteConstructor",
+    # Two-Phase Pipeline
+    "FactExtractor",
+    "ExtractedFact",
+    "MemoryUpdater",
+    "UpdateOperation",
     # CTI Integration
     "CTIPlatformConnector",
     "get_cti_connector",

--- a/src/zettelforge/blended_retriever.py
+++ b/src/zettelforge/blended_retriever.py
@@ -1,0 +1,46 @@
+"""
+Blended Retriever - Combines vector and graph retrieval results.
+
+Merges results from VectorRetriever and GraphRetriever using
+intent-based policy weights. Notes found by both sources get
+combined scores and rank higher.
+"""
+from typing import Callable, Dict, List, Optional
+
+from zettelforge.graph_retriever import ScoredResult
+from zettelforge.note_schema import MemoryNote
+
+
+class BlendedRetriever:
+    """Blend vector and graph retrieval results using policy weights."""
+
+    def blend(
+        self,
+        vector_results: List[MemoryNote],
+        graph_results: List[ScoredResult],
+        policy: Dict[str, float],
+        note_lookup: Callable[[str], Optional[MemoryNote]],
+        k: int = 10,
+    ) -> List[MemoryNote]:
+        vector_weight = policy.get("vector", 0.5)
+        graph_weight = policy.get("graph", 0.5)
+
+        scores: Dict[str, tuple] = {}
+
+        for i, note in enumerate(vector_results):
+            position_score = 1.0 / (1.0 + i)
+            blended = position_score * vector_weight
+            scores[note.id] = (blended, note)
+
+        for gr in graph_results:
+            graph_score = gr.score * graph_weight
+            if gr.note_id in scores:
+                existing_score, existing_note = scores[gr.note_id]
+                scores[gr.note_id] = (existing_score + graph_score, existing_note)
+            else:
+                note = note_lookup(gr.note_id)
+                if note:
+                    scores[gr.note_id] = (graph_score, note)
+
+        ranked = sorted(scores.values(), key=lambda x: x[0], reverse=True)
+        return [note for _, note in ranked[:k]]

--- a/src/zettelforge/fact_extractor.py
+++ b/src/zettelforge/fact_extractor.py
@@ -26,11 +26,9 @@ class FactExtractor:
         self,
         model: str = "qwen2.5:3b",
         max_facts: int = 5,
-        min_importance: int = 3,
     ):
         self.model = model
         self.max_facts = max_facts
-        self.min_importance = min_importance
 
     def extract(
         self,
@@ -90,7 +88,10 @@ class FactExtractor:
         for item in parsed:
             if isinstance(item, dict):
                 text = item.get("fact", "").strip()
-                importance = int(item.get("importance", 5))
+                try:
+                    importance = int(item.get("importance", 5))
+                except (ValueError, TypeError):
+                    importance = 5
                 importance = max(1, min(10, importance))
                 if text:
                     facts.append(ExtractedFact(text=text, importance=importance))

--- a/src/zettelforge/fact_extractor.py
+++ b/src/zettelforge/fact_extractor.py
@@ -1,0 +1,99 @@
+"""
+Fact Extractor - Phase 1 of Mem0-style two-phase pipeline.
+
+Extracts salient facts from raw content using LLM, with importance scoring.
+Only the important facts proceed to storage, reducing redundancy and noise.
+"""
+import json
+import re
+from dataclasses import dataclass, field
+from typing import List, Optional
+
+import ollama
+
+
+@dataclass
+class ExtractedFact:
+    """A single extracted fact with importance score."""
+    text: str
+    importance: int = 5  # 1-10 scale
+
+
+class FactExtractor:
+    """Extract salient facts from content using LLM."""
+
+    def __init__(
+        self,
+        model: str = "qwen2.5:3b",
+        max_facts: int = 5,
+        min_importance: int = 3,
+    ):
+        self.model = model
+        self.max_facts = max_facts
+        self.min_importance = min_importance
+
+    def extract(
+        self,
+        content: str,
+        context: str = "",
+    ) -> List[ExtractedFact]:
+        prompt = self._build_prompt(content, context)
+
+        try:
+            response = ollama.generate(
+                model=self.model,
+                prompt=prompt,
+                options={"temperature": 0.1, "num_predict": 400},
+            )
+            raw_output = response.get("response", "").strip()
+            return self._parse_extraction_response(raw_output)
+        except Exception:
+            return [ExtractedFact(text=content[:500], importance=5)]
+
+    def _build_prompt(self, content: str, context: str) -> str:
+        parts = [
+            "Extract the most important facts from this text as a JSON array.",
+            'Each item: {"fact": "concise statement", "importance": 1-10}',
+            "Only include facts worth remembering long-term. Skip greetings and filler.",
+        ]
+        if context:
+            parts.append(f"\nContext:\n{context}")
+        parts.append(f"\nText:\n{content[:2000]}")
+        parts.append("\nJSON:")
+        return "\n".join(parts)
+
+    def _parse_extraction_response(self, raw: str) -> List[ExtractedFact]:
+        if not raw:
+            return []
+
+        # Strip markdown code fences
+        if raw.startswith("```"):
+            parts = raw.split("```")
+            for part in parts:
+                stripped = part.strip()
+                if stripped.startswith("json"):
+                    stripped = stripped[4:].strip()
+                if stripped.startswith("["):
+                    raw = stripped
+                    break
+
+        match = re.search(r"\[.*\]", raw, re.DOTALL)
+        if not match:
+            return []
+
+        try:
+            parsed = json.loads(match.group(0))
+        except json.JSONDecodeError:
+            return []
+
+        facts = []
+        for item in parsed:
+            if isinstance(item, dict):
+                text = item.get("fact", "").strip()
+                importance = int(item.get("importance", 5))
+                importance = max(1, min(10, importance))
+                if text:
+                    facts.append(ExtractedFact(text=text, importance=importance))
+
+        facts.sort(key=lambda f: f.importance, reverse=True)
+        return facts[: self.max_facts]

--- a/src/zettelforge/graph_retriever.py
+++ b/src/zettelforge/graph_retriever.py
@@ -1,0 +1,88 @@
+"""
+Graph Retriever - Knowledge graph traversal for note retrieval.
+
+Traverses the KG starting from query entities, collects note IDs
+reachable within max_depth hops, and scores them by proximity.
+Score formula: 1 / (1 + hop_distance)
+"""
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Set
+
+from zettelforge.knowledge_graph import KnowledgeGraph
+
+
+@dataclass
+class ScoredResult:
+    """A note found via graph traversal with its score and path."""
+    note_id: str
+    score: float
+    hops: int
+    path: List[str] = field(default_factory=list)
+
+
+class GraphRetriever:
+    """Retrieve notes by traversing the knowledge graph from query entities."""
+
+    def __init__(self, knowledge_graph: KnowledgeGraph):
+        self.kg = knowledge_graph
+
+    def retrieve_note_ids(
+        self,
+        query_entities: Dict[str, List[str]],
+        max_depth: int = 2,
+    ) -> List[ScoredResult]:
+        if not query_entities:
+            return []
+
+        best: Dict[str, ScoredResult] = {}
+
+        for entity_type, values in query_entities.items():
+            for entity_value in values:
+                self._bfs_collect(entity_type, entity_value, max_depth, best)
+
+        results = list(best.values())
+        results.sort(key=lambda r: r.score, reverse=True)
+        return results
+
+    def _bfs_collect(
+        self,
+        start_type: str,
+        start_value: str,
+        max_depth: int,
+        best: Dict[str, ScoredResult],
+    ):
+        start_node_id = self.kg._node_index.get(start_type, {}).get(start_value)
+        if not start_node_id:
+            return
+
+        visited: Set[str] = set()
+        queue = [(start_node_id, 0, [f"{start_type}:{start_value}"])]
+
+        while queue:
+            current_id, depth, path = queue.pop(0)
+
+            if current_id in visited:
+                continue
+            visited.add(current_id)
+
+            node = self.kg._nodes.get(current_id)
+            if not node:
+                continue
+
+            if node["entity_type"] == "note":
+                note_id = node["entity_value"]
+                score = 1.0 / (1.0 + depth)
+                if note_id not in best or score > best[note_id].score:
+                    best[note_id] = ScoredResult(
+                        note_id=note_id, score=score, hops=depth, path=path,
+                    )
+
+            if depth >= max_depth:
+                continue
+
+            for edge in self.kg._edges_from.get(current_id, []):
+                to_id = edge["to_node_id"]
+                to_node = self.kg._nodes.get(to_id)
+                if to_node and to_id not in visited:
+                    step_label = f"{to_node['entity_type']}:{to_node['entity_value']}"
+                    queue.append((to_id, depth + 1, path + [step_label]))

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -118,10 +118,10 @@ class MemoryManager:
 
         Returns:
             List of (MemoryNote or None, status) tuples.
-            Status is one of: "added", "updated", "deleted", "noop".
+            Status is one of: "added", "updated", "corrected", "noop".
         """
         # Phase 1: Extraction
-        extractor = FactExtractor(max_facts=max_facts, min_importance=min_importance)
+        extractor = FactExtractor(max_facts=max_facts)
         facts = extractor.extract(content, context=context)
 
         # Filter by importance

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -39,6 +39,7 @@ class MemoryManager:
         self.indexer = EntityIndexer()
         self.retriever = VectorRetriever(memory_store=self.store)
         self.governance = GovernanceValidator()
+        self.resolver = AliasResolver()
 
         self.stats = {
             'notes_created': 0,
@@ -74,7 +75,6 @@ class MemoryManager:
         self.stats['notes_created'] += 1
 
         # Alias resolution and indexing
-        self.resolver = getattr(self, "resolver", AliasResolver())
         raw_entities = self.indexer.extractor.extract_all(note.content.raw)
         
         resolved_entities = {}
@@ -158,71 +158,58 @@ class MemoryManager:
         exclude_superseded: bool = True
     ) -> List[MemoryNote]:
         """
-        Retrieve memories relevant to query.
-        Uses intent classifier for adaptive retrieval strategy (Task 3).
+        Retrieve memories relevant to query using blended vector + graph retrieval.
+
+        Uses intent classifier to determine retrieval strategy weights,
+        then combines vector similarity and graph traversal results.
         """
         self.stats['retrievals'] += 1
-        
+
         # Classify query intent
         from zettelforge.intent_classifier import get_intent_classifier
         classifier = get_intent_classifier()
         intent, intent_meta = classifier.classify(query)
         policy = classifier.get_traversal_policy(intent)
-        
-        # Log for observability
-        print(f"[Intent] {intent.value} (conf={intent_meta.get('confidence', 0):.2f}) for: {query[:50]}...")
-        print(f"[Policy] vector={policy['vector']}, graph={policy['graph']}, temporal={policy['temporal']}")
-        
-        # Adjust k based on policy
-        k = max(k, policy['top_k'])
-        
-        # Route based on intent
-        if intent.value in ['factual', 'entity_lookup']:
-            # Use entity index
-            entities = self.indexer.extractor.extract_all(query)
-            results = []
-            for etype, elist in entities.items():
-                for evalue in elist:
-                    notes = self.recall_entity(etype, evalue, k=3)
-                    results.extend(notes)
-            return results[:k]
-        
-        elif intent.value == 'temporal':
-            # Use temporal graph
-            from zettelforge.knowledge_graph import get_knowledge_graph
-            kg = get_knowledge_graph()
-            # Extract timestamp from query
-            changes = kg.get_changes_since("2020-01-01")  # TODO: parse from query
-            # Get notes from changes
-            note_ids = [c['to'].split(':')[-1] for c in changes if c['to'].startswith('note:')]
-            results = [self.store.get_note_by_id(nid) for nid in note_ids if self.store.get_note_by_id(nid)]
-            return results[:k]
-        
-        elif intent.value in ['relational', 'causal']:
-            # Use graph traversal
-            from zettelforge.knowledge_graph import get_knowledge_graph
-            kg = get_knowledge_graph()
-            entities = self.indexer.extractor.extract_all(query)
-            results = []
-            for etype, elist in entities.items():
-                for evalue in elist:
-                    paths = kg.traverse(etype, evalue, max_depth=2)
-                    # Collect related notes
-                    for path in paths:
-                        for step in path:
-                            if step['to_type'] == 'note':
-                                note = self.store.get_note_by_id(step['to_value'])
-                                if note:
-                                    results.append(note)
-            return results[:k]
-        
-        # Default: vector retrieval
-        return self.retriever.retrieve(
-            query=query,
-            domain=domain,
-            k=k,
-            include_links=include_links
+
+        # Extract entities from query for graph traversal
+        query_entities = self.indexer.extractor.extract_all(query)
+        resolved = {}
+        for etype, elist in query_entities.items():
+            resolved[etype] = [self.resolver.resolve(etype, e) for e in elist]
+
+        # Vector retrieval
+        vector_results = self.retriever.retrieve(
+            query=query, domain=domain, k=k, include_links=include_links
         )
+
+        # Graph retrieval
+        from zettelforge.graph_retriever import GraphRetriever
+        from zettelforge.blended_retriever import BlendedRetriever
+        kg = get_knowledge_graph()
+        graph_retriever = GraphRetriever(kg)
+        graph_results = graph_retriever.retrieve_note_ids(
+            query_entities=resolved, max_depth=2
+        )
+
+        # Blend results
+        blender = BlendedRetriever()
+        results = blender.blend(
+            vector_results=vector_results,
+            graph_results=graph_results,
+            policy=policy,
+            note_lookup=lambda nid: self.store.get_note_by_id(nid),
+            k=k,
+        )
+
+        # Filter superseded notes
+        if exclude_superseded:
+            results = [n for n in results if not n.links.superseded_by]
+
+        # Track access
+        for note in results:
+            note.increment_access()
+
+        return results
 
     def recall_entity(
         self,
@@ -427,7 +414,6 @@ class MemoryManager:
         kg = get_knowledge_graph()
         
         # Resolve alias if necessary
-        self.resolver = getattr(self, "resolver", AliasResolver())
         canonical = self.resolver.resolve(entity_type, entity_value)
         
         return kg.get_neighbors(entity_type, canonical)
@@ -435,7 +421,6 @@ class MemoryManager:
     def traverse_graph(self, start_type: str, start_value: str, max_depth: int = 2) -> List[Dict]:
         """Traverse relationships from a starting entity."""
         kg = get_knowledge_graph()
-        self.resolver = getattr(self, "resolver", AliasResolver())
         canonical = self.resolver.resolve(start_type, start_value)
         
         return kg.traverse(start_type, canonical, max_depth)

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -20,6 +20,8 @@ from zettelforge.synthesis_generator import SynthesisGenerator, get_synthesis_ge
 from zettelforge.synthesis_validator import SynthesisValidator, get_synthesis_validator
 from zettelforge.knowledge_graph import get_knowledge_graph
 from zettelforge.governance_validator import GovernanceValidator, GovernanceViolationError
+from zettelforge.fact_extractor import FactExtractor, ExtractedFact
+from zettelforge.memory_updater import MemoryUpdater, UpdateOperation
 
 
 class MemoryManager:
@@ -88,6 +90,64 @@ class MemoryManager:
         self._update_knowledge_graph(note, resolved_entities)
 
         return note, "created"
+
+    def remember_with_extraction(
+        self,
+        content: str,
+        source_type: str = "conversation",
+        source_ref: str = "",
+        domain: str = "general",
+        context: str = "",
+        min_importance: int = 3,
+        max_facts: int = 5,
+    ) -> List[Tuple[Optional[MemoryNote], str]]:
+        """
+        Mem0-style two-phase pipeline: extract salient facts, then decide ADD/UPDATE/DELETE/NOOP.
+
+        Phase 1 (Extraction): LLM distills content into scored candidate facts.
+        Phase 2 (Update): Each fact is compared to existing notes; LLM decides operation.
+
+        Args:
+            content: Raw text to process.
+            source_type: Origin type (conversation, task_output, etc.).
+            source_ref: Source identifier.
+            domain: Memory domain.
+            context: Optional rolling summary for disambiguation.
+            min_importance: Facts below this threshold are skipped.
+            max_facts: Maximum facts to extract per call.
+
+        Returns:
+            List of (MemoryNote or None, status) tuples.
+            Status is one of: "added", "updated", "deleted", "noop".
+        """
+        # Phase 1: Extraction
+        extractor = FactExtractor(max_facts=max_facts, min_importance=min_importance)
+        facts = extractor.extract(content, context=context)
+
+        # Filter by importance
+        facts = [f for f in facts if f.importance >= min_importance]
+
+        if not facts:
+            return []
+
+        # Phase 2: Update
+        updater = MemoryUpdater(self)
+        results = []
+
+        for i, fact in enumerate(facts):
+            similar = updater.find_similar(fact.text, domain=domain)
+            operation = updater.decide(fact.text, similar)
+            note, status = updater.apply(
+                operation,
+                fact_text=fact.text,
+                importance=fact.importance,
+                source_ref=f"{source_ref}:extraction:{i}" if source_ref else f"extraction:{i}",
+                similar_notes=similar,
+                domain=domain,
+            )
+            results.append((note, status))
+
+        return results
 
     def recall(
         self,

--- a/src/zettelforge/memory_store.py
+++ b/src/zettelforge/memory_store.py
@@ -104,12 +104,14 @@ class MemoryStore:
                 ])
                 tbl = self.lancedb.create_table(table_name, schema=schema)
             # Create optimized vector index per governance and performance requirements
-            tbl.create_index(
-                metric="cosine",
-                index_type="IVF_PQ",  # Balanced performance/accuracy
-                num_partitions=256,
-                num_sub_vectors=16
-            )
+            # Only create index if table is new (not on every insert)
+            if table_name not in tables:
+                tbl.create_index(
+                    metric="cosine",
+                    index_type="IVF_PQ",  # Balanced performance/accuracy
+                    num_partitions=256,
+                    num_sub_vectors=16
+                )
 
             table = self.lancedb.open_table(table_name)
             table.add([{

--- a/src/zettelforge/memory_updater.py
+++ b/src/zettelforge/memory_updater.py
@@ -1,0 +1,131 @@
+"""
+Memory Updater - Phase 2 of Mem0-style two-phase pipeline.
+
+Compares new facts against existing notes and decides:
+ADD (new), UPDATE (refine), DELETE (contradict), or NOOP (duplicate).
+"""
+import json
+import re
+from enum import Enum
+from typing import List, Optional, Tuple
+
+import ollama
+
+from zettelforge.note_schema import MemoryNote
+
+
+class UpdateOperation(Enum):
+    ADD = "ADD"
+    UPDATE = "UPDATE"
+    DELETE = "DELETE"
+    NOOP = "NOOP"
+
+
+class MemoryUpdater:
+    def __init__(self, memory_manager, model: str = "qwen2.5:3b", top_s: int = 3):
+        self.mm = memory_manager
+        self.model = model
+        self.top_s = top_s
+
+    def find_similar(self, fact_text: str, domain: Optional[str] = None) -> List[MemoryNote]:
+        return self.mm.retriever.retrieve(
+            query=fact_text, domain=domain, k=self.top_s, include_links=False
+        )
+
+    def decide(self, fact_text: str, similar_notes: List[MemoryNote]) -> UpdateOperation:
+        if not similar_notes:
+            return UpdateOperation.ADD
+
+        prompt = self._build_decision_prompt(fact_text, similar_notes)
+
+        try:
+            response = ollama.generate(
+                model=self.model,
+                prompt=prompt,
+                options={"temperature": 0.1, "num_predict": 150},
+            )
+            raw = response.get("response", "").strip()
+            return self._parse_operation_response(raw)
+        except Exception:
+            return UpdateOperation.ADD
+
+    def apply(
+        self,
+        operation: UpdateOperation,
+        fact_text: str,
+        importance: int,
+        source_ref: str,
+        similar_notes: List[MemoryNote],
+        domain: str = "cti",
+    ) -> Tuple[Optional[MemoryNote], str]:
+        if operation == UpdateOperation.NOOP:
+            return None, "noop"
+
+        if operation == UpdateOperation.ADD:
+            note, _ = self.mm.remember(fact_text, source_type="extraction", source_ref=source_ref, domain=domain)
+            note.metadata.importance = importance
+            self.mm.store._rewrite_note(note)
+            return note, "added"
+
+        if operation == UpdateOperation.UPDATE:
+            note, _ = self.mm.remember(fact_text, source_type="extraction", source_ref=source_ref, domain=domain)
+            note.metadata.importance = importance
+            self.mm.store._rewrite_note(note)
+            if similar_notes:
+                self.mm.mark_note_superseded(similar_notes[0].id, note.id)
+            return note, "updated"
+
+        if operation == UpdateOperation.DELETE:
+            note, _ = self.mm.remember(fact_text, source_type="correction", source_ref=source_ref, domain=domain)
+            note.metadata.importance = importance
+            self.mm.store._rewrite_note(note)
+            if similar_notes:
+                self.mm.mark_note_superseded(similar_notes[0].id, note.id)
+            return note, "deleted"
+
+        return None, "unknown"
+
+    def _build_decision_prompt(self, fact_text: str, similar_notes: List[MemoryNote]) -> str:
+        existing = "\n".join(
+            f"- [{n.id}] {n.content.raw[:200]}" for n in similar_notes
+        )
+        return f"""Compare this new fact against existing memory entries.
+Decide one operation: ADD, UPDATE, DELETE, or NOOP.
+
+- ADD: fact is genuinely new, no similar entry covers it
+- UPDATE: fact refines or corrects an existing entry
+- DELETE: fact contradicts an existing entry (the old one is wrong/stale)
+- NOOP: fact is already captured, nothing changed
+
+New fact: {fact_text}
+
+Existing entries:
+{existing}
+
+Respond with JSON: {{"operation": "ADD|UPDATE|DELETE|NOOP", "reason": "brief explanation"}}
+JSON:"""
+
+    def _parse_operation_response(self, raw: str) -> UpdateOperation:
+        if not raw:
+            return UpdateOperation.ADD
+
+        if raw.startswith("```"):
+            parts = raw.split("```")
+            for part in parts:
+                stripped = part.strip()
+                if stripped.startswith("json"):
+                    stripped = stripped[4:].strip()
+                if stripped.startswith("{"):
+                    raw = stripped
+                    break
+
+        match = re.search(r"\{.*\}", raw, re.DOTALL)
+        if not match:
+            return UpdateOperation.ADD
+
+        try:
+            parsed = json.loads(match.group(0))
+            op_str = parsed.get("operation", "ADD").upper()
+            return UpdateOperation(op_str)
+        except (json.JSONDecodeError, ValueError):
+            return UpdateOperation.ADD

--- a/src/zettelforge/memory_updater.py
+++ b/src/zettelforge/memory_updater.py
@@ -81,7 +81,7 @@ class MemoryUpdater:
             self.mm.store._rewrite_note(note)
             if similar_notes:
                 self.mm.mark_note_superseded(similar_notes[0].id, note.id)
-            return note, "deleted"
+            return note, "corrected"
 
         return None, "unknown"
 

--- a/src/zettelforge/note_schema.py
+++ b/src/zettelforge/note_schema.py
@@ -47,6 +47,7 @@ class Metadata(BaseModel):
     ttl: Optional[int] = None  # Time-to-live in days
     domain: str = "general"  # security_ops | project | personal | research
     tier: str = "B"  # Epistemic tier: A (authoritative) | B (operational) | C (support)
+    importance: int = 5  # 1-10 scale, used by extraction phase for prioritization
 
 
 class MemoryNote(BaseModel):

--- a/src/zettelforge/vector_memory.py
+++ b/src/zettelforge/vector_memory.py
@@ -24,8 +24,8 @@ from typing import List, Dict, Optional
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-DEFAULT_EMBEDDING_URL = "http://127.0.0.1:8081"
-DEFAULT_EMBEDDING_MODEL = "nomic-embed-text-v2-moe.gguf"
+DEFAULT_EMBEDDING_URL = "http://127.0.0.1:11434"
+DEFAULT_EMBEDDING_MODEL = "nomic-embed-text-v2-moe:latest"
 
 
 def get_embedding_url() -> str:

--- a/src/zettelforge/vector_memory.py
+++ b/src/zettelforge/vector_memory.py
@@ -24,13 +24,13 @@ from typing import List, Dict, Optional
 
 # ── Configuration ─────────────────────────────────────────────────────────────
 
-DEFAULT_OLLAMA_URL = "http://localhost:11434"
-DEFAULT_EMBEDDING_MODEL = "nomic-embed-text"
+DEFAULT_EMBEDDING_URL = "http://127.0.0.1:8081"
+DEFAULT_EMBEDDING_MODEL = "nomic-embed-text-v2-moe.gguf"
 
 
-def get_ollama_url() -> str:
-    """Get Ollama URL from environment or default"""
-    return os.environ.get("AMEM_OLLAMA_URL", DEFAULT_OLLAMA_URL)
+def get_embedding_url() -> str:
+    """Get embedding server URL from environment or default (llama.cpp on 8081)"""
+    return os.environ.get("AMEM_EMBEDDING_URL", DEFAULT_EMBEDDING_URL)
 
 
 def get_embedding_model() -> str:
@@ -41,24 +41,53 @@ def get_embedding_model() -> str:
 # ── Embedding ─────────────────────────────────────────────────────────────────
 
 def get_embedding(text: str, model: Optional[str] = None) -> List[float]:
-    """Generate embedding via Ollama."""
+    """Generate embedding via llama.cpp OpenAI-compatible endpoint."""
+    import requests
+
+    url = get_embedding_url()
+    model = model or get_embedding_model()
+
     try:
-        import ollama
-        model = model or get_embedding_model()
-        resp = ollama.embeddings(model=model, prompt=text)
-        return resp.get("embedding", [0.0] * 768)
+        resp = requests.post(
+            f"{url}/v1/embeddings",
+            json={"input": text, "model": model},
+            timeout=30,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        embedding = data["data"][0]["embedding"]
+        if not embedding or len(embedding) == 0:
+            raise RuntimeError("Embedding server returned empty vector")
+        return embedding
+    except requests.ConnectionError:
+        raise RuntimeError(
+            f"Embedding server not reachable at {url}. "
+            "Ensure llama-embeddings.service is running: "
+            "systemctl --user status llama-embeddings"
+        )
     except Exception as e:
-        import hashlib
-        # Deterministic mock embedding based on string hash if ollama fails
-        h = int(hashlib.md5(text.encode()).hexdigest(), 16)
-        import random
-        random.seed(h)
-        return [random.random() for _ in range(768)]  # Return zero vector on failure
+        raise RuntimeError(f"Embedding generation failed: {e}")
 
 
 def get_embedding_batch(texts: List[str], model: Optional[str] = None) -> List[List[float]]:
-    """Batch embed multiple texts via Ollama."""
-    return [get_embedding(text, model) for text in texts]
+    """Batch embed multiple texts via llama.cpp endpoint."""
+    import requests
+
+    url = get_embedding_url()
+    model = model or get_embedding_model()
+
+    try:
+        resp = requests.post(
+            f"{url}/v1/embeddings",
+            json={"input": texts, "model": model},
+            timeout=60,
+        )
+        resp.raise_for_status()
+        data = resp.json()
+        return [item["embedding"] for item in data["data"]]
+    except Exception:
+        # Fallback to sequential if batch fails
+        return [get_embedding(text, model) for text in texts]
 
 
 # ── LanceDB Schema ───────────────────────────────────────────────────────────

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -1,8 +1,9 @@
 """
-Basic tests for A-MEM
+Basic tests for ZettelForge
 """
 import pytest
 import tempfile
+from datetime import datetime
 from pathlib import Path
 
 from zettelforge import MemoryManager, MemoryNote
@@ -12,6 +13,35 @@ from zettelforge.note_constructor import NoteConstructor
 from zettelforge.entity_indexer import EntityIndexer, EntityExtractor
 from zettelforge.vector_retriever import VectorRetriever
 
+NOW = datetime.now().isoformat()
+
+
+class TestNoteImportance:
+    """Test importance field on Metadata"""
+
+    def test_default_importance(self):
+        """Importance defaults to 5 (neutral)."""
+        meta = Metadata()
+        assert meta.importance == 5
+
+    def test_custom_importance(self):
+        """Importance can be set 1-10."""
+        meta = Metadata(importance=9)
+        assert meta.importance == 9
+
+    def test_importance_in_note(self):
+        """MemoryNote carries importance through Metadata."""
+        note = MemoryNote(
+            id="test_imp",
+            created_at=NOW,
+            updated_at=NOW,
+            content=Content(raw="Important fact", source_type="test", source_ref=""),
+            semantic=Semantic(context="Test", keywords=[], tags=[], entities=[]),
+            embedding=Embedding(vector=[]),
+            metadata=Metadata(importance=8)
+        )
+        assert note.metadata.importance == 8
+
 
 class TestNoteSchema:
     """Test note schema creation and validation"""
@@ -20,6 +50,8 @@ class TestNoteSchema:
         """Test creating a MemoryNote"""
         note = MemoryNote(
             id="test_001",
+            created_at=NOW,
+            updated_at=NOW,
             content=Content(
                 raw="Test content",
                 source_type="test",
@@ -48,6 +80,8 @@ class TestNoteSchema:
         """Test note access counting"""
         note = MemoryNote(
             id="test_002",
+            created_at=NOW,
+            updated_at=NOW,
             content=Content(raw="Test", source_type="test", source_ref=""),
             semantic=Semantic(context="Test", keywords=[], tags=[], entities=[]),
             embedding=Embedding(vector=[]),
@@ -82,6 +116,8 @@ class TestMemoryStore:
             
             note = MemoryNote(
                 id="test_003",
+                created_at=NOW,
+                updated_at=NOW,
                 content=Content(raw="Test content", source_type="test", source_ref=""),
                 semantic=Semantic(context="Test context", keywords=["test"], tags=[], entities=[]),
                 embedding=Embedding(vector=[0.0] * 768),

--- a/tests/test_blended_retriever.py
+++ b/tests/test_blended_retriever.py
@@ -1,0 +1,82 @@
+"""Tests for BlendedRetriever - combines vector + graph results."""
+import pytest
+from datetime import datetime
+
+from zettelforge.blended_retriever import BlendedRetriever
+from zettelforge.graph_retriever import ScoredResult
+from zettelforge.note_schema import MemoryNote, Content, Semantic, Embedding, Metadata
+
+NOW = datetime.now().isoformat()
+
+
+def _make_note(note_id: str, raw: str) -> MemoryNote:
+    return MemoryNote(
+        id=note_id, created_at=NOW, updated_at=NOW,
+        content=Content(raw=raw, source_type="test", source_ref=""),
+        semantic=Semantic(context=raw[:50], keywords=[], tags=[], entities=[]),
+        embedding=Embedding(vector=[0.1] * 768), metadata=Metadata(),
+    )
+
+
+class TestBlendedRetriever:
+    def test_vector_only_when_no_graph_results(self):
+        vector_notes = [_make_note("v1", "vector result 1"), _make_note("v2", "vector result 2")]
+        policy = {"vector": 0.5, "graph": 0.5, "entity_index": 0.0, "temporal": 0.0, "top_k": 10}
+        blended = BlendedRetriever()
+        results = blended.blend(vector_results=vector_notes, graph_results=[], policy=policy, note_lookup=lambda nid: None, k=10)
+        assert len(results) == 2
+        assert results[0].id == "v1"
+
+    def test_graph_only_when_no_vector_results(self):
+        note_g1 = _make_note("g1", "graph result 1")
+        graph_scored = [ScoredResult(note_id="g1", score=0.8, hops=1, path=[])]
+        policy = {"vector": 0.5, "graph": 0.5, "entity_index": 0.0, "temporal": 0.0, "top_k": 10}
+        blended = BlendedRetriever()
+        results = blended.blend(vector_results=[], graph_results=graph_scored, policy=policy, note_lookup=lambda nid: note_g1 if nid == "g1" else None, k=10)
+        assert len(results) == 1
+        assert results[0].id == "g1"
+
+    def test_blending_merges_and_deduplicates(self):
+        shared_note = _make_note("shared", "appears in both")
+        vector_notes = [shared_note, _make_note("v_only", "vector only")]
+        graph_scored = [ScoredResult(note_id="shared", score=0.9, hops=1, path=[]), ScoredResult(note_id="g_only", score=0.5, hops=2, path=[])]
+        note_g_only = _make_note("g_only", "graph only")
+        policy = {"vector": 0.5, "graph": 0.5, "entity_index": 0.0, "temporal": 0.0, "top_k": 10}
+        def lookup(nid):
+            return {"g_only": note_g_only, "shared": shared_note}.get(nid)
+        blended = BlendedRetriever()
+        results = blended.blend(vector_results=vector_notes, graph_results=graph_scored, policy=policy, note_lookup=lookup, k=10)
+        ids = [r.id for r in results]
+        assert ids.count("shared") == 1
+        assert "v_only" in ids
+        assert "g_only" in ids
+
+    def test_shared_note_ranks_higher(self):
+        shared_note = _make_note("shared", "appears in both")
+        v_only = _make_note("v_only", "vector only")
+        g_only_note = _make_note("g_only", "graph only")
+        vector_notes = [shared_note, v_only]
+        graph_scored = [ScoredResult(note_id="shared", score=0.8, hops=1, path=[]), ScoredResult(note_id="g_only", score=0.3, hops=2, path=[])]
+        policy = {"vector": 0.5, "graph": 0.5, "entity_index": 0.0, "temporal": 0.0, "top_k": 10}
+        def lookup(nid):
+            return {"g_only": g_only_note, "shared": shared_note}.get(nid)
+        blended = BlendedRetriever()
+        results = blended.blend(vector_results=vector_notes, graph_results=graph_scored, policy=policy, note_lookup=lookup, k=10)
+        assert results[0].id == "shared"
+
+    def test_respects_k_limit(self):
+        vector_notes = [_make_note(f"v{i}", f"note {i}") for i in range(10)]
+        policy = {"vector": 1.0, "graph": 0.0, "entity_index": 0.0, "temporal": 0.0, "top_k": 10}
+        blended = BlendedRetriever()
+        results = blended.blend(vector_results=vector_notes, graph_results=[], policy=policy, note_lookup=lambda nid: None, k=3)
+        assert len(results) == 3
+
+    def test_policy_weights_affect_ranking(self):
+        v_note = _make_note("v_only", "vector only")
+        g_note = _make_note("g_only", "graph only")
+        vector_notes = [v_note]
+        graph_scored = [ScoredResult(note_id="g_only", score=0.9, hops=1, path=[])]
+        policy = {"vector": 0.1, "graph": 0.9, "entity_index": 0.0, "temporal": 0.0, "top_k": 10}
+        blended = BlendedRetriever()
+        results = blended.blend(vector_results=vector_notes, graph_results=graph_scored, policy=policy, note_lookup=lambda nid: g_note if nid == "g_only" else None, k=10)
+        assert results[0].id == "g_only"

--- a/tests/test_causal_extraction.py
+++ b/tests/test_causal_extraction.py
@@ -5,7 +5,7 @@ Validates Task 1: LLM-based causal edge extraction from consolidation pass.
 """
 import sys
 import tempfile
-sys.path.insert(0, '/home/rolandpg/.openclaw/workspace/skills/zettelforge/src')
+# Package installed via pip - no sys.path manipulation needed
 
 from zettelforge import MemoryManager
 from zettelforge.note_constructor import NoteConstructor

--- a/tests/test_cti_integration.py
+++ b/tests/test_cti_integration.py
@@ -4,7 +4,7 @@ Test CTI Platform Integration with ZettelForge.
 Validates bi-directional sync between memory and CTI DB.
 """
 import sys
-sys.path.insert(0, '/home/rolandpg/.openclaw/workspace/skills/zettelforge/src')
+# Package installed via pip - no sys.path manipulation needed
 
 from zettelforge.cti_integration import get_cti_connector, CTIPlatformConnector
 

--- a/tests/test_fact_extractor.py
+++ b/tests/test_fact_extractor.py
@@ -1,0 +1,93 @@
+"""Tests for FactExtractor - Phase 1 of Mem0-style pipeline."""
+import pytest
+from unittest.mock import patch, MagicMock
+
+from zettelforge.fact_extractor import FactExtractor, ExtractedFact
+
+
+class TestExtractedFact:
+    def test_creation(self):
+        fact = ExtractedFact(text="APT28 shifted to edge devices", importance=8)
+        assert fact.text == "APT28 shifted to edge devices"
+        assert fact.importance == 8
+
+    def test_defaults(self):
+        fact = ExtractedFact(text="some fact")
+        assert fact.importance == 5
+
+
+class TestFactExtractorParsing:
+    def test_parse_valid_json_array(self):
+        extractor = FactExtractor()
+        raw = '[{"fact": "APT28 uses edge devices", "importance": 8}, {"fact": "DROPBEAR deprecated", "importance": 6}]'
+        facts = extractor._parse_extraction_response(raw)
+        assert len(facts) == 2
+        assert facts[0].text == "APT28 uses edge devices"
+        assert facts[0].importance == 8
+
+    def test_parse_markdown_wrapped(self):
+        extractor = FactExtractor()
+        raw = '```json\n[{"fact": "test fact", "importance": 7}]\n```'
+        facts = extractor._parse_extraction_response(raw)
+        assert len(facts) == 1
+        assert facts[0].importance == 7
+
+    def test_parse_empty_returns_empty(self):
+        extractor = FactExtractor()
+        facts = extractor._parse_extraction_response("")
+        assert facts == []
+
+    def test_parse_garbage_returns_empty(self):
+        extractor = FactExtractor()
+        facts = extractor._parse_extraction_response("not json at all")
+        assert facts == []
+
+    def test_facts_sorted_by_importance_descending(self):
+        extractor = FactExtractor()
+        raw = '[{"fact": "low", "importance": 2}, {"fact": "high", "importance": 9}, {"fact": "mid", "importance": 5}]'
+        facts = extractor._parse_extraction_response(raw)
+        assert facts[0].importance == 9
+        assert facts[1].importance == 5
+        assert facts[2].importance == 2
+
+    def test_max_facts_limit(self):
+        extractor = FactExtractor(max_facts=2)
+        raw = '[{"fact": "a", "importance": 9}, {"fact": "b", "importance": 7}, {"fact": "c", "importance": 5}]'
+        facts = extractor._parse_extraction_response(raw)
+        assert len(facts) == 2
+
+
+class TestFactExtractorWithMockedLLM:
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_extract_calls_ollama(self, mock_ollama):
+        mock_ollama.generate.return_value = {
+            "response": '[{"fact": "APT28 shifted tactics", "importance": 8}]'
+        }
+        extractor = FactExtractor()
+        facts = extractor.extract("APT28 has shifted tactics to edge devices")
+        assert len(facts) == 1
+        assert facts[0].text == "APT28 shifted tactics"
+        mock_ollama.generate.assert_called_once()
+
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_extract_with_context(self, mock_ollama):
+        mock_ollama.generate.return_value = {
+            "response": '[{"fact": "new tactic", "importance": 7}]'
+        }
+        extractor = FactExtractor()
+        facts = extractor.extract(
+            "They now use compromised credentials",
+            context="Previous: APT28 used DROPBEAR malware"
+        )
+        assert len(facts) == 1
+        call_args = mock_ollama.generate.call_args
+        assert "Previous:" in call_args.kwargs.get("prompt", call_args[1].get("prompt", ""))
+
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_extract_handles_ollama_error(self, mock_ollama):
+        mock_ollama.generate.side_effect = Exception("ollama down")
+        extractor = FactExtractor()
+        facts = extractor.extract("some content")
+        assert len(facts) == 1
+        assert "some content" in facts[0].text
+        assert facts[0].importance == 5

--- a/tests/test_graph_retriever.py
+++ b/tests/test_graph_retriever.py
@@ -1,0 +1,78 @@
+"""Tests for GraphRetriever - graph-based note retrieval."""
+import pytest
+import tempfile
+from datetime import datetime
+
+from zettelforge.graph_retriever import GraphRetriever, ScoredResult
+from zettelforge.knowledge_graph import KnowledgeGraph
+
+
+NOW = datetime.now().isoformat()
+
+
+@pytest.fixture
+def kg_with_data():
+    """KG with a small graph: actor -> tool -> note, actor -> cve -> note."""
+    tmpdir = tempfile.mkdtemp()
+    kg = KnowledgeGraph(data_dir=tmpdir)
+    kg.add_edge("actor", "apt28", "tool", "cobalt-strike", "USES_TOOL")
+    kg.add_edge("actor", "apt28", "cve", "cve-2024-1111", "EXPLOITS_CVE")
+    kg.add_edge("tool", "cobalt-strike", "note", "note_001", "MENTIONED_IN")
+    kg.add_edge("cve", "cve-2024-1111", "note", "note_002", "MENTIONED_IN")
+    kg.add_edge("actor", "apt28", "note", "note_003", "MENTIONED_IN")
+    return kg
+
+
+class TestScoredResult:
+    def test_creation(self):
+        sr = ScoredResult(note_id="note_001", score=0.5, hops=2, path=["apt28", "cobalt-strike", "note_001"])
+        assert sr.note_id == "note_001"
+        assert sr.score == 0.5
+        assert sr.hops == 2
+
+
+class TestGraphRetrieverTraverse:
+    def test_finds_direct_notes(self, kg_with_data):
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={"actor": ["apt28"]}, max_depth=2)
+        note_ids = [r.note_id for r in results]
+        assert "note_003" in note_ids
+
+    def test_finds_multihop_notes(self, kg_with_data):
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={"actor": ["apt28"]}, max_depth=2)
+        note_ids = [r.note_id for r in results]
+        assert "note_001" in note_ids
+        assert "note_002" in note_ids
+
+    def test_direct_notes_score_higher(self, kg_with_data):
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={"actor": ["apt28"]}, max_depth=2)
+        scores = {r.note_id: r.score for r in results}
+        assert scores["note_003"] > scores["note_001"]
+
+    def test_empty_entities_returns_empty(self, kg_with_data):
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={}, max_depth=2)
+        assert results == []
+
+    def test_unknown_entity_returns_empty(self, kg_with_data):
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={"actor": ["nonexistent"]}, max_depth=2)
+        assert results == []
+
+    def test_max_depth_limits_hops(self, kg_with_data):
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={"actor": ["apt28"]}, max_depth=1)
+        note_ids = [r.note_id for r in results]
+        assert "note_003" in note_ids
+        assert "note_001" not in note_ids
+        assert "note_002" not in note_ids
+
+    def test_deduplicates_notes(self, kg_with_data):
+        kg_with_data.add_edge("tool", "cobalt-strike", "note", "note_003", "MENTIONED_IN")
+        retriever = GraphRetriever(kg_with_data)
+        results = retriever.retrieve_note_ids(query_entities={"actor": ["apt28"]}, max_depth=2)
+        note_003_results = [r for r in results if r.note_id == "note_003"]
+        assert len(note_003_results) == 1
+        assert note_003_results[0].hops == 1

--- a/tests/test_intent_classifier.py
+++ b/tests/test_intent_classifier.py
@@ -4,7 +4,7 @@ Test intent classifier in ZettelForge.
 Validates Task 3: Lightweight intent classifier for adaptive query routing.
 """
 import sys
-sys.path.insert(0, '/home/rolandpg/.openclaw/workspace/skills/zettelforge/src')
+# Package installed via pip - no sys.path manipulation needed
 
 from zettelforge.intent_classifier import IntentClassifier, get_intent_classifier, QueryIntent
 

--- a/tests/test_memory_updater.py
+++ b/tests/test_memory_updater.py
@@ -160,7 +160,7 @@ class TestMemoryUpdaterApply:
                 source_ref="extraction:2",
                 similar_notes=[old_note],
             )
-            assert status == "deleted"
+            assert status == "corrected"
             refreshed_old = mm.store.get_note_by_id(old_note.id)
             assert refreshed_old.links.superseded_by is not None
 

--- a/tests/test_memory_updater.py
+++ b/tests/test_memory_updater.py
@@ -1,0 +1,183 @@
+"""Tests for MemoryUpdater - Phase 2 of Mem0-style pipeline."""
+import pytest
+import tempfile
+from unittest.mock import patch, MagicMock
+from datetime import datetime
+
+from zettelforge.memory_updater import MemoryUpdater, UpdateOperation
+from zettelforge.memory_manager import MemoryManager
+from zettelforge.note_schema import MemoryNote, Content, Semantic, Embedding, Metadata
+
+NOW = datetime.now().isoformat()
+
+
+def _make_note(note_id: str, raw: str, importance: int = 5) -> MemoryNote:
+    return MemoryNote(
+        id=note_id,
+        created_at=NOW,
+        updated_at=NOW,
+        content=Content(raw=raw, source_type="test", source_ref=""),
+        semantic=Semantic(context=raw[:50], keywords=[], tags=[], entities=[]),
+        embedding=Embedding(vector=[0.1] * 768),
+        metadata=Metadata(importance=importance),
+    )
+
+
+class TestUpdateOperation:
+    def test_values(self):
+        assert UpdateOperation.ADD.value == "ADD"
+        assert UpdateOperation.UPDATE.value == "UPDATE"
+        assert UpdateOperation.DELETE.value == "DELETE"
+        assert UpdateOperation.NOOP.value == "NOOP"
+
+
+class TestMemoryUpdaterParsing:
+    def test_parse_add(self):
+        updater = MemoryUpdater.__new__(MemoryUpdater)
+        op = updater._parse_operation_response('{"operation": "ADD", "reason": "new fact"}')
+        assert op == UpdateOperation.ADD
+
+    def test_parse_update(self):
+        updater = MemoryUpdater.__new__(MemoryUpdater)
+        op = updater._parse_operation_response('{"operation": "UPDATE", "reason": "refines existing"}')
+        assert op == UpdateOperation.UPDATE
+
+    def test_parse_delete(self):
+        updater = MemoryUpdater.__new__(MemoryUpdater)
+        op = updater._parse_operation_response('{"operation": "DELETE", "reason": "contradicts"}')
+        assert op == UpdateOperation.DELETE
+
+    def test_parse_noop(self):
+        updater = MemoryUpdater.__new__(MemoryUpdater)
+        op = updater._parse_operation_response('{"operation": "NOOP", "reason": "already stored"}')
+        assert op == UpdateOperation.NOOP
+
+    def test_parse_garbage_defaults_to_add(self):
+        updater = MemoryUpdater.__new__(MemoryUpdater)
+        op = updater._parse_operation_response("not json")
+        assert op == UpdateOperation.ADD
+
+    def test_parse_markdown_wrapped(self):
+        updater = MemoryUpdater.__new__(MemoryUpdater)
+        op = updater._parse_operation_response('```json\n{"operation": "DELETE", "reason": "old"}\n```')
+        assert op == UpdateOperation.DELETE
+
+
+class TestMemoryUpdaterDecision:
+    def test_add_when_no_similar_notes(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            updater = MemoryUpdater(mm)
+            op = updater.decide("APT28 shifted to edge devices", similar_notes=[])
+            assert op == UpdateOperation.ADD
+
+    @patch("zettelforge.memory_updater.ollama")
+    def test_update_when_similar_exists(self, mock_ollama):
+        mock_ollama.generate.return_value = {
+            "response": '{"operation": "UPDATE", "reason": "refines existing"}'
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            updater = MemoryUpdater(mm)
+            existing = _make_note("old_001", "APT28 uses DROPBEAR malware")
+            op = updater.decide("APT28 no longer uses DROPBEAR", similar_notes=[existing])
+            assert op == UpdateOperation.UPDATE
+
+    @patch("zettelforge.memory_updater.ollama")
+    def test_delete_on_contradiction(self, mock_ollama):
+        mock_ollama.generate.return_value = {
+            "response": '{"operation": "DELETE", "reason": "contradicts existing"}'
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            updater = MemoryUpdater(mm)
+            existing = _make_note("old_002", "Server ALPHA is compromised")
+            op = updater.decide("Server ALPHA has been fully remediated", similar_notes=[existing])
+            assert op == UpdateOperation.DELETE
+
+
+class TestMemoryUpdaterApply:
+    def test_apply_add_creates_note(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            updater = MemoryUpdater(mm)
+            note, status = updater.apply(
+                UpdateOperation.ADD,
+                fact_text="New fact about APT28",
+                importance=8,
+                source_ref="extraction:0",
+                similar_notes=[],
+            )
+            assert status == "added"
+            assert note is not None
+            assert note.metadata.importance == 8
+            assert mm.store.count_notes() == 1
+
+    def test_apply_update_supersedes_old(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            old_note, _ = mm.remember("APT28 uses DROPBEAR", domain="cti")
+            updater = MemoryUpdater(mm)
+            new_note, status = updater.apply(
+                UpdateOperation.UPDATE,
+                fact_text="APT28 no longer uses DROPBEAR, shifted to edge exploitation",
+                importance=9,
+                source_ref="extraction:1",
+                similar_notes=[old_note],
+            )
+            assert status == "updated"
+            assert new_note is not None
+            refreshed_old = mm.store.get_note_by_id(old_note.id)
+            assert refreshed_old.links.superseded_by == new_note.id
+
+    def test_apply_delete_marks_superseded(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            old_note, _ = mm.remember("Server ALPHA is compromised", domain="incident")
+            updater = MemoryUpdater(mm)
+            new_note, status = updater.apply(
+                UpdateOperation.DELETE,
+                fact_text="Server ALPHA fully remediated",
+                importance=7,
+                source_ref="extraction:2",
+                similar_notes=[old_note],
+            )
+            assert status == "deleted"
+            refreshed_old = mm.store.get_note_by_id(old_note.id)
+            assert refreshed_old.links.superseded_by is not None
+
+    def test_apply_noop_creates_nothing(self):
+        with tempfile.TemporaryDirectory() as tmpdir:
+            mm = MemoryManager(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb",
+            )
+            updater = MemoryUpdater(mm)
+            note, status = updater.apply(
+                UpdateOperation.NOOP,
+                fact_text="Already known",
+                importance=5,
+                source_ref="extraction:3",
+                similar_notes=[],
+            )
+            assert status == "noop"
+            assert note is None
+            assert mm.store.count_notes() == 0

--- a/tests/test_recall_integration.py
+++ b/tests/test_recall_integration.py
@@ -1,0 +1,57 @@
+"""Integration tests for rewritten recall() with graph traversal."""
+import pytest
+import tempfile
+import time
+
+from zettelforge.memory_manager import MemoryManager
+
+
+@pytest.fixture
+def mm_with_graph():
+    tmpdir = tempfile.mkdtemp()
+    mm = MemoryManager(
+        jsonl_path=f"{tmpdir}/notes.jsonl",
+        lance_path=f"{tmpdir}/vectordb",
+    )
+    mm.remember("APT28 uses Cobalt Strike for lateral movement", domain="cti")
+    mm.remember("Cobalt Strike exploits CVE-2024-1111 in edge devices", domain="cti")
+    mm.remember("APT28 targets energy sector infrastructure", domain="cti")
+    return mm
+
+
+class TestRecallWithGraph:
+    def test_recall_returns_results(self, mm_with_graph):
+        results = mm_with_graph.recall("APT28", k=5)
+        assert len(results) >= 1
+
+    def test_relational_query_uses_graph(self, mm_with_graph):
+        results = mm_with_graph.recall("What tools does APT28 use?", k=5)
+        assert len(results) >= 1
+        texts = [n.content.raw for n in results]
+        assert any("Cobalt Strike" in t for t in texts)
+
+    def test_multihop_finds_indirect_notes(self, mm_with_graph):
+        results = mm_with_graph.recall("APT28 toolkit and vulnerabilities", k=10)
+        texts = [n.content.raw for n in results]
+        has_cve_note = any("CVE-2024-1111" in t for t in texts)
+        has_tool_note = any("Cobalt Strike" in t for t in texts)
+        assert has_cve_note or has_tool_note
+
+    def test_exploratory_query_blends_both(self, mm_with_graph):
+        results = mm_with_graph.recall("Tell me about threats to energy sector", k=5)
+        assert len(results) >= 1
+
+    def test_recall_excludes_superseded(self, mm_with_graph):
+        note_old, _ = mm_with_graph.remember("Server ALPHA compromised", domain="incident")
+        time.sleep(0.1)
+        note_new, _ = mm_with_graph.remember("Server ALPHA remediated and patched", domain="incident")
+        mm_with_graph.mark_note_superseded(note_old.id, note_new.id)
+        results = mm_with_graph.recall("Server ALPHA status", k=10, exclude_superseded=True)
+        result_ids = [r.id for r in results]
+        assert note_old.id not in result_ids
+
+    def test_recall_performance(self, mm_with_graph):
+        start = time.perf_counter()
+        mm_with_graph.recall("APT28 tools and techniques", k=10)
+        duration = time.perf_counter() - start
+        assert duration < 5.0, f"recall() took {duration:.2f}s (max 5s)"

--- a/tests/test_temporal_graph.py
+++ b/tests/test_temporal_graph.py
@@ -6,7 +6,7 @@ Validates Task 2: Temporal graph indexing and queries.
 import sys
 import tempfile
 import time
-sys.path.insert(0, '/home/rolandpg/.openclaw/workspace/skills/zettelforge/src')
+# Package installed via pip - no sys.path manipulation needed
 
 from zettelforge import MemoryManager
 from zettelforge.knowledge_graph import KnowledgeGraph, get_knowledge_graph

--- a/tests/test_two_phase_e2e.py
+++ b/tests/test_two_phase_e2e.py
@@ -1,0 +1,88 @@
+"""End-to-end tests for Mem0-style two-phase pipeline."""
+import pytest
+import tempfile
+from unittest.mock import patch
+
+from zettelforge import MemoryManager
+
+
+@pytest.fixture
+def fresh_mm():
+    tmpdir = tempfile.mkdtemp()
+    return MemoryManager(
+        jsonl_path=f"{tmpdir}/notes.jsonl",
+        lance_path=f"{tmpdir}/vectordb",
+    )
+
+
+class TestRememberWithExtraction:
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_extracts_and_stores_facts(self, mock_ollama, fresh_mm):
+        mock_ollama.generate.return_value = {
+            "response": '[{"fact": "APT28 shifted to edge devices", "importance": 8}, {"fact": "DROPBEAR no longer in use", "importance": 7}]'
+        }
+        results = fresh_mm.remember_with_extraction(
+            "APT28 has shifted tactics. They no longer use DROPBEAR and now exploit edge devices.",
+            domain="cti",
+        )
+        assert len(results) >= 1
+        for note, status in results:
+            assert status in ("added", "updated", "deleted", "noop")
+            if status != "noop":
+                assert note is not None
+
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_returns_empty_for_low_importance(self, mock_ollama, fresh_mm):
+        mock_ollama.generate.return_value = {
+            "response": '[{"fact": "greeting exchanged", "importance": 1}]'
+        }
+        results = fresh_mm.remember_with_extraction(
+            "Hi, how are you?",
+            domain="general",
+            min_importance=3,
+        )
+        assert len(results) == 0
+
+    @patch("zettelforge.memory_updater.ollama")
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_update_supersedes_old_note(self, mock_fact_ollama, mock_updater_ollama, fresh_mm):
+        old_note, _ = fresh_mm.remember("APT28 uses DROPBEAR malware", domain="cti")
+
+        mock_fact_ollama.generate.return_value = {
+            "response": '[{"fact": "APT28 no longer uses DROPBEAR", "importance": 9}]'
+        }
+        mock_updater_ollama.generate.return_value = {
+            "response": '{"operation": "UPDATE", "reason": "refines old intel"}'
+        }
+        results = fresh_mm.remember_with_extraction(
+            "APT28 has dropped DROPBEAR from their toolkit.",
+            domain="cti",
+        )
+        assert len(results) == 1
+        new_note, status = results[0]
+        assert status == "updated"
+        refreshed_old = fresh_mm.store.get_note_by_id(old_note.id)
+        assert refreshed_old.links.superseded_by == new_note.id
+
+    @patch("zettelforge.memory_updater.ollama")
+    @patch("zettelforge.fact_extractor.ollama")
+    def test_noop_stores_nothing_new(self, mock_fact_ollama, mock_updater_ollama, fresh_mm):
+        fresh_mm.remember("APT28 targets NATO", domain="cti")
+        initial_count = fresh_mm.store.count_notes()
+
+        mock_fact_ollama.generate.return_value = {
+            "response": '[{"fact": "APT28 targets NATO", "importance": 6}]'
+        }
+        mock_updater_ollama.generate.return_value = {
+            "response": '{"operation": "NOOP", "reason": "already stored"}'
+        }
+        results = fresh_mm.remember_with_extraction(
+            "APT28 targets NATO allies.",
+            domain="cti",
+        )
+        assert len(results) == 1
+        assert results[0][1] == "noop"
+        assert fresh_mm.store.count_notes() == initial_count
+
+    def test_method_exists(self, fresh_mm):
+        assert callable(getattr(fresh_mm, "remember_with_extraction", None))

--- a/tests/test_two_phase_e2e.py
+++ b/tests/test_two_phase_e2e.py
@@ -27,7 +27,7 @@ class TestRememberWithExtraction:
         )
         assert len(results) >= 1
         for note, status in results:
-            assert status in ("added", "updated", "deleted", "noop")
+            assert status in ("added", "updated", "corrected", "noop")
             if status != "noop":
                 assert note is not None
 


### PR DESCRIPTION
## Summary

- Add `GraphRetriever` that traverses the knowledge graph via BFS from query entities, collecting reachable notes scored by hop distance (`1 / (1 + hops)`)
- Add `BlendedRetriever` that merges vector similarity and graph traversal results using intent-based policy weights — notes found by both sources get combined scores
- Rewrite `MemoryManager.recall()` to use blended retrieval instead of ad-hoc routing with broken stubs
- Fix `self.resolver` initialization (remove lazy `getattr` pattern, initialize in `__init__`)
- Bumps version to v1.5.0

### Why

The knowledge graph was fully populated during `remember()` but never used during retrieval. Multi-hop queries (e.g., "what tools does APT28 use?") scored 0% on LOCOMO because `recall()` only used vector similarity. The graph traversal now enables:
- **Multi-hop discovery**: APT28 → Cobalt Strike → CVE-2024-1111 (2 hops)
- **Policy-weighted blending**: RELATIONAL queries weight graph 0.5, CAUSAL queries weight graph 0.6
- **Combined ranking**: Notes found by both vector and graph sources rank highest

### New files
- `src/zettelforge/graph_retriever.py` — BFS traversal, hop-distance scoring
- `src/zettelforge/blended_retriever.py` — Policy-weighted result merging
- `tests/test_graph_retriever.py` — 8 unit tests
- `tests/test_blended_retriever.py` — 6 unit tests  
- `tests/test_recall_integration.py` — 6 integration tests

### Note
This branch includes the two-phase pipeline commits (PR #2) as its base. Should be merged after PR #2.

## Test plan

- [x] 62/62 tests passing across all test files
- [x] GraphRetriever: direct notes, multi-hop, depth limiting, deduplication, empty entities
- [x] BlendedRetriever: vector-only, graph-only, merged dedup, shared-note boosting, k-limit, policy weights
- [x] Integration: relational queries find graph-connected notes, superseded filtering, <5s performance
- [ ] Re-run LOCOMO benchmark to measure multi-hop accuracy improvement

🤖 Generated with [Claude Code](https://claude.com/claude-code)