### PR TITLE
Potential fix for code scanning alert no. 3: Information exposure through an exception

### DIFF
--- a/web/app.py
+++ b/web/app.py
@@ -19,6 +19,7 @@ Endpoints:
 import os
 import sys
 import time
+import logging
 from pathlib import Path
 
 # Ensure zettelforge is importable
@@ -35,6 +36,8 @@ from typing import Optional, List
 from zettelforge import MemoryManager, __version__
 from zettelforge.edition import is_enterprise, edition_name, EditionError
 from web.auth import register_auth_routes, get_mm_for_request, get_current_user
+
+logger = logging.getLogger(__name__)
 
 app = FastAPI(
     title="ThreatRecall" if is_enterprise() else "ZettelForge",
@@ -208,8 +211,9 @@ async def sync(request: Request, req: SyncRequest):
             use_extraction=False,
         )
         return result
-    except Exception as e:
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        logger.exception("OpenCTI sync failed")
+        return JSONResponse(status_code=500, content={"error": "Internal server error"})
 
 
 # ── HTML Frontend ────────────────────────────────────────────────────────────


### PR DESCRIPTION
Potential fix for [https://github.com/rolandpg/zettelforge/security/code-scanning/3](https://github.com/rolandpg/zettelforge/security/code-scanning/3)

To fix this without changing endpoint behavior (still returns HTTP 500 on failures), keep exception details on the server and return a generic error body to clients.

Best fix in `web/app.py`:
1. Add a standard logger setup (`import logging` and `logger = logging.getLogger(__name__)`).
2. In `/api/sync` exception handler, replace `{"error": str(e)}` with a generic message like `{"error": "Internal server error"}`.
3. Log the exception server-side with stack trace using `logger.exception(...)`.

This preserves status codes and control flow while preventing sensitive internal exception content from being exposed externally.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
