### PR TITLE
fix: LanceDB vector index only contains one row per table

### DIFF
--- a/scripts/rebuild_index.py
+++ b/scripts/rebuild_index.py
@@ -57,10 +57,23 @@ def rebuild_indexes(jsonl_path=None, lance_path=None):
         # Drop existing tables so we rebuild from scratch
         existing = store.lancedb.list_tables()
         tables = existing.tables if hasattr(existing, 'tables') else (existing if isinstance(existing, list) else [])
-        for t in tables:
-            if t.startswith('notes_'):
+        note_tables = [t for t in tables if t.startswith('notes_')]
+        dropped_tables = []
+        failed_drops = []
+        for t in note_tables:
+            try:
                 store.lancedb.drop_table(t)
-        print(f"  Dropped {len([t for t in tables if t.startswith('notes_')])} stale table(s)")
+                dropped_tables.append(t)
+            except Exception as e:
+                failed_drops.append((t, str(e)))
+        print(f"  Dropped {len(dropped_tables)} stale table(s)")
+        if failed_drops:
+            print("  Failed to drop the following stale table(s):")
+            for table_name, error in failed_drops:
+                print(f"    {table_name}: {error}")
+            raise RuntimeError(
+                "Could not drop all stale LanceDB tables; aborting reindex to avoid inconsistent state."
+            )
         
         # Count by domain
         domain_counts = {}

--- a/scripts/rebuild_index.py
+++ b/scripts/rebuild_index.py
@@ -53,15 +53,14 @@ def rebuild_indexes(jsonl_path=None, lance_path=None):
     
     # 2. Reindex LanceDB
     print("\n[2/2] Reindexing LanceDB...")
-    if store.lancedb:
-        # Clear existing tables and reindex
-        result = store.lancedb.list_tables()
-        if hasattr(result, 'tables'):
-            tables = result.tables
-        else:
-            tables = []
-        
-        print(f"  Existing tables: {tables}")
+    if store.lancedb is not None:
+        # Drop existing tables so we rebuild from scratch
+        existing = store.lancedb.list_tables()
+        tables = existing.tables if hasattr(existing, 'tables') else (existing if isinstance(existing, list) else [])
+        for t in tables:
+            if t.startswith('notes_'):
+                store.lancedb.drop_table(t)
+        print(f"  Dropped {len([t for t in tables if t.startswith('notes_')])} stale table(s)")
         
         # Count by domain
         domain_counts = {}
@@ -85,11 +84,8 @@ def rebuild_indexes(jsonl_path=None, lance_path=None):
         print(f"  Indexed: {indexed}/{len(notes)} notes")
         
         # Verify
-        result = store.lancedb.list_tables()
-        if hasattr(result, 'tables'):
-            tables = result.tables
-        else:
-            tables = []
+        final = store.lancedb.list_tables()
+        tables = final.tables if hasattr(final, 'tables') else (final if isinstance(final, list) else [])
         print(f"  Final tables: {tables}")
         
         for t in tables:
@@ -105,7 +101,7 @@ def rebuild_indexes(jsonl_path=None, lance_path=None):
     print("="*50)
     print(f"JSONL notes: {len(notes)}")
     print(f"Entity index: {result['stats']}")
-    if store.lancedb:
+    if store.lancedb is not None:
         print(f"LanceDB: Reindexed {indexed} notes")
 
 

--- a/src/zettelforge/memory_store.py
+++ b/src/zettelforge/memory_store.py
@@ -103,14 +103,27 @@ class MemoryStore:
             self._note_cache[note.id] = note
 
         # Index in LanceDB if available
-        if self.lancedb:
+        if self.lancedb is not None:
             self._index_in_lance(note)
     
     def _index_in_lance(self, note: MemoryNote) -> None:
         """Index note in LanceDB vector store"""
         try:
+            import pyarrow as pa
+
             table_name = f"notes_{note.metadata.domain}"
-            tables = self.lancedb.list_tables()
+            note_data = {
+                "id": note.id,
+                "vector": note.embedding.vector if note.embedding.vector else [0.0] * 768,
+                "content": note.content.raw[:500],
+                "context": note.semantic.context,
+                "keywords": ",".join(note.semantic.keywords),
+                "tags": ",".join(note.semantic.tags),
+                "created_at": note.created_at,
+            }
+
+            result = self.lancedb.list_tables()
+            tables = result.tables if hasattr(result, 'tables') else (result if isinstance(result, list) else [])
 
             if table_name not in tables:
                 schema = pa.schema([
@@ -122,22 +135,10 @@ class MemoryStore:
                     ("tags", pa.string()),
                     ("created_at", pa.string()),
                 ])
-                tbl = self.lancedb.create_table(table_name, schema=schema)
-            # Create optimized vector index per governance and performance requirements
-            # Only create index if table is new (not on every insert)
-            # Skip index creation on table create — index after enough data accumulates
-            # LanceDB IVF_FLAT needs at least num_partitions rows to build
-
-            table = self.lancedb.open_table(table_name)
-            table.add([{
-                "id": note.id,
-                "vector": note.embedding.vector if note.embedding.vector else [0.0] * 768,
-                "content": note.content.raw[:500],
-                "context": note.semantic.context,
-                "keywords": ",".join(note.semantic.keywords),
-                "tags": ",".join(note.semantic.tags),
-                "created_at": note.created_at,
-            }])
+                self.lancedb.create_table(table_name, data=[note_data], schema=schema)
+            else:
+                tbl = self.lancedb.open_table(table_name)
+                tbl.add([note_data])
         except Exception as e:
             print(f"LanceDB indexing failed: {e}")
     

--- a/src/zettelforge/vector_retriever.py
+++ b/src/zettelforge/vector_retriever.py
@@ -99,7 +99,7 @@ class VectorRetriever:
         Falls back to in-memory search if LanceDB unavailable.
         """
         # Try LanceDB first (IVF_FLAT index, no double-quantization)
-        if use_lancedb and self.store.lancedb:
+        if use_lancedb and self.store.lancedb is not None:
             try:
                 results = self._retrieve_via_lancedb(query, domain, k, include_links)
                 if results:

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -132,6 +132,59 @@ class TestMemoryStore:
             assert retrieved.content.raw == "Test content"
 
 
+class TestLanceDBIndexing:
+    """Test LanceDB vector index population (issue #26)"""
+
+    def test_multiple_notes_indexed(self):
+        """Multiple notes in the same domain should all appear in the LanceDB table."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = MemoryStore(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb"
+            )
+            # Write 5 notes to the same domain
+            for i in range(5):
+                note = MemoryNote(
+                    id=f"lance_{i}",
+                    created_at=NOW,
+                    updated_at=NOW,
+                    content=Content(raw=f"Content {i}", source_type="test", source_ref=""),
+                    semantic=Semantic(context="ctx", keywords=["k"], tags=[], entities=[]),
+                    embedding=Embedding(vector=[float(i)] * 768),
+                    metadata=Metadata(domain="cti"),
+                )
+                store.write_note(note)
+
+            tbl = store.lancedb.open_table("notes_cti")
+            assert len(tbl) == 5, f"Expected 5 rows, got {len(tbl)}"
+
+    def test_multiple_domains(self):
+        """Notes across different domains should create separate tables."""
+        with tempfile.TemporaryDirectory() as tmpdir:
+            store = MemoryStore(
+                jsonl_path=f"{tmpdir}/notes.jsonl",
+                lance_path=f"{tmpdir}/vectordb"
+            )
+            for domain in ("cti", "general", "cti", "general", "cti"):
+                note = MemoryNote(
+                    id=f"lance_{domain}_{id(domain)}",
+                    created_at=NOW,
+                    updated_at=NOW,
+                    content=Content(raw=f"Content for {domain}", source_type="test", source_ref=""),
+                    semantic=Semantic(context="ctx", keywords=[], tags=[], entities=[]),
+                    embedding=Embedding(vector=[1.0] * 768),
+                    metadata=Metadata(domain=domain),
+                )
+                store.write_note(note)
+
+            result = store.lancedb.list_tables()
+            tables = result.tables if hasattr(result, 'tables') else result
+            assert "notes_cti" in tables
+            assert "notes_general" in tables
+            assert len(store.lancedb.open_table("notes_cti")) == 3
+            assert len(store.lancedb.open_table("notes_general")) == 2
+
+
 class TestEntityExtractor:
     """Test entity extraction"""
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -3,6 +3,7 @@ Basic tests for ZettelForge
 """
 import pytest
 import tempfile
+import uuid
 from datetime import datetime
 from pathlib import Path
 
@@ -167,7 +168,7 @@ class TestLanceDBIndexing:
             )
             for domain in ("cti", "general", "cti", "general", "cti"):
                 note = MemoryNote(
-                    id=f"lance_{domain}_{id(domain)}",
+                    id=f"lance_{domain}_{uuid.uuid4().hex}",
                     created_at=NOW,
                     updated_at=NOW,
                     content=Content(raw=f"Content for {domain}", source_type="test", source_ref=""),


### PR DESCRIPTION
## Summary

Fixes #26 — LanceDB vector index tables each contained exactly 1 row despite thousands of notes.

**Three root causes discovered through systematic debugging:**

1. **`LanceDBConnection.__bool__` returns `False`** — The guard `if self.lancedb:` in `write_note()` always evaluated to `False`, so `_index_in_lance()` was never called. Changed all truthiness checks to `is not None`.

2. **Missing `import pyarrow as pa`** — `_index_in_lance()` used `pa.schema()` without importing pyarrow. The `NameError` was silently swallowed by the bare `except Exception`.

3. **`list_tables()` returns `ListTablesResponse`, not a list** — The table existence check `table_name not in tables` never matched because `in` doesn't work on `ListTablesResponse` objects. Normalized to extract `.tables` attribute.

**Additional fix:** `rebuild_index.py` now drops stale tables before re-indexing instead of appending to corrupted 1-row tables.

## Changes

- `src/zettelforge/memory_store.py` — import pyarrow, fix `is not None` check, normalize `list_tables()` return, restructure create-vs-add logic
- `src/zettelforge/vector_retriever.py` — fix `is not None` check
- `scripts/rebuild_index.py` — drop stale tables before rebuild, normalize `list_tables()` return
- `tests/test_basic.py` — add `TestLanceDBIndexing` with multi-note and multi-domain tests

## Test plan

- [x] `TestLanceDBIndexing::test_multiple_notes_indexed` — 5 notes in same domain → 5 rows in table
- [x] `TestLanceDBIndexing::test_multiple_domains` — notes across cti/general → separate tables with correct counts
- [x] Full test suite passes (33 tests)
- [ ] Run `rebuild_index.py` against production JSONL to verify full re-index

🤖 Generated with [Claude Code](https://claude.com/claude-code)