### PR TITLE
feat: add LangChain retriever wrapper (closes #37)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -52,12 +52,18 @@ web = [
     "uvicorn>=0.20.0",
 ]
 
+# LangChain integration
+langchain = [
+    "langchain-core>=0.2.0",
+]
+
 dev = [
     "pytest>=7.0.0",
     "pytest-asyncio>=0.21.0",
     "pytest-cov>=4.0.0",
     "mypy>=1.0.0",
     "ruff>=0.4.0",
+    "langchain-core>=0.2.0",
 ]
 
 [project.urls]

--- a/src/zettelforge/integrations/__init__.py
+++ b/src/zettelforge/integrations/__init__.py
@@ -1,0 +1,10 @@
+"""
+ZettelForge Integrations — Framework wrappers for popular AI/agent libraries.
+
+Available integrations:
+    - langchain: ZettelForgeRetriever (LangChain BaseRetriever)
+"""
+
+from zettelforge.integrations.langchain_retriever import ZettelForgeRetriever
+
+__all__ = ["ZettelForgeRetriever"]

--- a/src/zettelforge/integrations/langchain_retriever.py
+++ b/src/zettelforge/integrations/langchain_retriever.py
@@ -1,0 +1,101 @@
+"""
+ZettelForge × LangChain Integration
+
+Provides a LangChain-compatible retriever that wraps ZettelForge's
+MemoryManager.recall() method, allowing ZettelForge to be used as a
+retriever in any LangChain RAG pipeline.
+
+Usage:
+    >>> from langchain_core.runnables import RunnableConfig
+    >>> from zettelforge import MemoryManager
+    >>> from zettelforge.integrations.langchain_retriever import ZettelForgeRetriever
+    >>>
+    >>> mm = MemoryManager()
+    >>> mm.remember("APT28 uses spear-phishing with credential-harvesting links")
+    >>> retriever = ZettelForgeRetriever(memory_manager=mm, k=5)
+    >>> docs = retriever.invoke("What techniques does APT28 use?")
+"""
+
+from __future__ import annotations
+
+from typing import Any, Dict, List, Optional
+
+from langchain_core.callbacks import CallbackManagerForRetrieverRun
+from langchain_core.documents import Document
+from langchain_core.retrievers import BaseRetriever
+from pydantic import Field
+
+from zettelforge.memory_manager import MemoryManager
+
+
+class ZettelForgeRetriever(BaseRetriever):
+    """LangChain retriever wrapping ZettelForge's blended recall.
+
+    Converts ZettelForge MemoryNotes into LangChain Documents with
+    rich metadata (source, tier, confidence, keywords, tags, entities).
+
+    Args:
+        memory_manager: A ZettelForge MemoryManager instance.
+        k: Number of results to return (default 10).
+        domain: Optional domain filter (e.g. "security_ops").
+        include_links: Whether to include graph-linked notes (default True).
+        exclude_superseded: Whether to filter superseded notes (default True).
+    """
+
+    memory_manager: MemoryManager = Field(exclude=True)
+    k: int = 10
+    domain: Optional[str] = None
+    include_links: bool = True
+    exclude_superseded: bool = True
+
+    class Config:
+        """Pydantic config — allow arbitrary types for MemoryManager."""
+
+        arbitrary_types_allowed = True
+
+    def _get_relevant_documents(
+        self, query: str, *, run_manager: CallbackManagerForRetrieverRun
+    ) -> List[Document]:
+        """Retrieve documents from ZettelForge memory.
+
+        Calls MemoryManager.recall() and converts each MemoryNote
+        into a LangChain Document with page_content and metadata.
+        """
+        notes = self.memory_manager.recall(
+            query=query,
+            domain=self.domain,
+            k=self.k,
+            include_links=self.include_links,
+            exclude_superseded=self.exclude_superseded,
+        )
+
+        documents: List[Document] = []
+        for note in notes:
+            metadata: Dict[str, Any] = {
+                "note_id": note.id,
+                "source_type": note.content.source_type,
+                "source_ref": note.content.source_ref,
+                "context": note.semantic.context,
+                "keywords": note.semantic.keywords,
+                "tags": note.semantic.tags,
+                "entities": note.semantic.entities,
+                "domain": note.metadata.domain,
+                "tier": note.metadata.tier,
+                "confidence": note.metadata.confidence,
+                "importance": note.metadata.importance,
+                "created_at": note.created_at,
+                "updated_at": note.updated_at,
+            }
+            # Include CVE metadata if present
+            if note.metadata.vuln is not None:
+                metadata["cvss_v3_score"] = note.metadata.vuln.cvss_v3_score
+                metadata["cisa_kev"] = note.metadata.vuln.cisa_kev
+
+            documents.append(
+                Document(
+                    page_content=note.content.raw,
+                    metadata=metadata,
+                )
+            )
+
+        return documents

--- a/tests/test_langchain_retriever.py
+++ b/tests/test_langchain_retriever.py
@@ -1,0 +1,113 @@
+"""
+Tests for ZettelForge × LangChain retriever integration.
+"""
+
+import tempfile
+from pathlib import Path
+
+import pytest
+
+from zettelforge import MemoryManager
+from zettelforge.integrations.langchain_retriever import ZettelForgeRetriever
+
+
+@pytest.fixture
+def memory_manager(tmp_path):
+    """Create a MemoryManager with a temp directory for testing."""
+    mm = MemoryManager(persist_directory=str(tmp_path / "zf_test_db"))
+    # Seed with CTI-relevant memories
+    mm.remember(
+        "APT28 (Fancy Bear) uses spear-phishing emails with credential-harvesting links. "
+        "They have been observed using domains mimicking NATO and defense contractors.",
+        domain="security_ops",
+    )
+    mm.remember(
+        "CVE-2024-3094: XZ Utils backdoor in versions 5.6.0 and 5.6.1. "
+        "CVSS score 10.0. Supply chain attack affecting SSH authentication.",
+        domain="security_ops",
+    )
+    mm.remember(
+        "Project Alpha migration to Kubernetes completed on 2024-03-15. "
+        "All services running on EKS cluster us-east-1.",
+        domain="project",
+    )
+    return mm
+
+
+class TestZettelForgeRetriever:
+    """Test suite for ZettelForgeRetriever."""
+
+    def test_invoke_returns_documents(self, memory_manager):
+        """retriever.invoke() returns LangChain Documents."""
+        retriever = ZettelForgeRetriever(memory_manager=memory_manager, k=3)
+        docs = retriever.invoke("APT28 spear-phishing techniques")
+
+        assert isinstance(docs, list)
+        assert len(docs) > 0
+        # Each result should be a LangChain Document
+        doc = docs[0]
+        assert hasattr(doc, "page_content")
+        assert hasattr(doc, "metadata")
+        assert isinstance(doc.page_content, str)
+        assert len(doc.page_content) > 0
+
+    def test_metadata_fields(self, memory_manager):
+        """Documents carry ZettelForge metadata fields."""
+        retriever = ZettelForgeRetriever(memory_manager=memory_manager, k=5)
+        docs = retriever.invoke("XZ Utils CVE")
+
+        assert len(docs) > 0
+        doc = docs[0]
+        meta = doc.metadata
+        # Core metadata fields from MemoryNote
+        assert "note_id" in meta
+        assert "source_type" in meta
+        assert "domain" in meta
+        assert "tier" in meta
+        assert "confidence" in meta
+        assert "keywords" in meta
+        assert "tags" in meta
+        assert meta["domain"] == "security_ops"
+
+    def test_k_limits_results(self, memory_manager):
+        """k parameter limits the number of results."""
+        retriever_k1 = ZettelForgeRetriever(memory_manager=memory_manager, k=1)
+        retriever_k5 = ZettelForgeRetriever(memory_manager=memory_manager, k=5)
+
+        docs_k1 = retriever_k1.invoke("APT28")
+        docs_k5 = retriever_k5.invoke("APT28")
+
+        assert len(docs_k1) <= 1
+        assert len(docs_k5) <= 5
+
+    def test_domain_filter(self, memory_manager):
+        """domain parameter filters results by domain."""
+        retriever = ZettelForgeRetriever(
+            memory_manager=memory_manager, k=10, domain="project"
+        )
+        docs = retriever.invoke("migration Kubernetes")
+
+        # All results should be from the "project" domain
+        for doc in docs:
+            if doc.metadata.get("domain"):
+                assert doc.metadata["domain"] == "project"
+
+    def test_empty_query(self, memory_manager):
+        """Empty query returns results without crashing."""
+        retriever = ZettelForgeRetriever(memory_manager=memory_manager, k=3)
+        docs = retriever.invoke("")
+        assert isinstance(docs, list)
+
+    def test_serializable_config(self, memory_manager):
+        """Retriever can be instantiated with config fields."""
+        retriever = ZettelForgeRetriever(
+            memory_manager=memory_manager,
+            k=7,
+            domain="security_ops",
+            include_links=False,
+            exclude_superseded=True,
+        )
+        assert retriever.k == 7
+        assert retriever.domain == "security_ops"
+        assert retriever.include_links is False
+        assert retriever.exclude_superseded is True


### PR DESCRIPTION
## Summary

Implements a LangChain-compatible retriever that wraps ZettelForge's  method, as requested in #37.

### Changes

- **New  package** — 
- **** — extends 
  -  calls  and converts  → 
  - Metadata includes: , , , , , , , , , CVE fields
  - Configurable: , , , 
- **** — added  optional dependency group ()
- **Tests** —  with 6 test cases

### Usage

```python
from zettelforge import MemoryManager
from zettelforge.integrations.langchain_retriever import ZettelForgeRetriever

mm = MemoryManager()
mm.remember("APT28 uses spear-phishing with credential-harvesting links")
retriever = ZettelForgeRetriever(memory_manager=mm, k=5)
docs = retriever.invoke("What techniques does APT28 use?")
```

### Design Notes

- Uses  on  to prevent serialization issues
-  since  isn't a Pydantic model
- No new core dependencies —  is optional
- Follows the project's existing code style and structure