### PR TITLE
feat(llm): RFC-002 Phase 1 — pluggable LLM provider infrastructure

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 config.yaml
 config.yml
 .env
+.env.*
+*.key
+*.pem
 
 # Local planning & task tracking (not committed)
 TODO.md

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,24 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ### Added
 
+- **Pluggable LLM provider infrastructure (RFC-002 Phase 1)** — new
+  `zettelforge.llm_providers` package with a `@runtime_checkable`
+  `LLMProvider` protocol, a thread-safe registry, and built-in
+  providers for `local` (llama-cpp-python), `ollama`, and `mock`.
+  The public `generate()` signature is unchanged; all 7 existing call
+  sites (`fact_extractor`, `memory_updater`, `synthesis_generator`,
+  `intent_classifier`, `note_constructor`, `entity_indexer`,
+  `memory_evolver`) keep working without modification. Third-party
+  providers can register via the `zettelforge.llm_providers`
+  entry-point group. `openai_compat` and `anthropic` providers land in
+  Phase 2 and Phase 3.
+- **`LLMConfig` expanded** — new `api_key`, `timeout`, `max_retries`,
+  `fallback`, and `extra` fields. `api_key` supports `${ENV_VAR}`
+  references and is redacted from `repr()`. New env overrides:
+  `ZETTELFORGE_LLM_API_KEY`, `ZETTELFORGE_LLM_TIMEOUT`,
+  `ZETTELFORGE_LLM_MAX_RETRIES`, `ZETTELFORGE_LLM_FALLBACK`.
+- **Hardened .gitignore** per GOV-023 — added `.env.*`, `*.key`,
+  `*.pem`.
 - **MCP server as a first-class module** — `python -m zettelforge.mcp`
   now works out of a `pip install zettelforge` with no git clone
   required. New package `zettelforge.mcp` (with `server.py`,

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -140,38 +140,55 @@ embedding:
 
 # ── LLM ─────────────────────────────────────────────────────────────────────
 # Language model for fact extraction, intent classification, causal triple
-# extraction, and RAG synthesis. Must support Ollama-compatible API.
+# extraction, and RAG synthesis.
+#
+# Provider selects the backend registered in zettelforge.llm_providers:
+#   local           — in-process llama-cpp-python (requires zettelforge[local])
+#   ollama          — Ollama HTTP API
+#   mock            — test-only canned responses
+#   openai_compat   — any /v1/chat/completions endpoint (Phase 2, upcoming)
+#   anthropic       — Anthropic native SDK (Phase 3, upcoming)
 #
 # Examples:
-#   # Small and fast (default, good for homelab)
-#   model: qwen2.5:3b
+#   # Default — Ollama on localhost
+#   provider: ollama
+#   model: qwen3.5:9b
 #
-#   # Medium (better quality, needs ~8GB VRAM)
-#   model: qwen2.5:7b
+#   # In-process GGUF (fully offline)
+#   provider: local
+#   model: Qwen/Qwen2.5-3B-Instruct-GGUF
 #
-#   # Large (best quality, needs ~24GB VRAM or cloud GPU)
-#   model: qwen2.5:32b
+# api_key supports ${ENV_VAR} references — never commit raw API keys.
+#   api_key: ${OPENAI_API_KEY}
 #
-#   # Llama 3.1
-#   model: llama3.1:8b
+# fallback: name of a backup provider invoked on transient failure of
+# the primary. Leave empty to preserve the implicit ``local -> ollama``
+# fallback for backward compatibility.
 #
-#   # Cloud-hosted (via Ollama proxy or compatible endpoint)
-#   model: qwen3.5:cloud
-#   url: http://ollama-proxy.internal:11434
-#
-# Temperature:
-#   0.0 = deterministic (best for extraction and classification)
-#   0.1 = near-deterministic (default, slight variation)
-#   0.7 = creative (use for synthesis if you want varied phrasing)
+# extra: provider-specific kwargs forwarded to the constructor. Examples:
+#   extra:
+#     filename: qwen2.5-3b-instruct-q4_k_m.gguf   # local provider
+#     n_ctx: 4096
 #
 # Env overrides:
+#   ZETTELFORGE_LLM_PROVIDER=ollama
 #   ZETTELFORGE_LLM_MODEL=qwen2.5:7b
 #   ZETTELFORGE_LLM_URL=http://gpu-box:11434
+#   ZETTELFORGE_LLM_API_KEY=sk-...
+#   ZETTELFORGE_LLM_TIMEOUT=60
+#   ZETTELFORGE_LLM_MAX_RETRIES=2
+#   ZETTELFORGE_LLM_FALLBACK=ollama
 #
 llm:
+  provider: ollama
   model: qwen3.5:9b
   url: http://localhost:11434
+  api_key: ""
   temperature: 0.1
+  timeout: 60.0
+  max_retries: 2
+  fallback: ""
+  extra: {}
 
 
 # ── Two-Phase Extraction Pipeline ──────────────────────────────────────────

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -138,8 +138,8 @@ class LLMConfig:
 | `llm.url` | `str` | `http://localhost:11434` | `ZETTELFORGE_LLM_URL` | Base URL. Meaning is provider-specific — Ollama endpoint for `ollama`, `/v1/chat/completions` base for `openai_compat`, ignored for `local` and `anthropic`. |
 | `llm.api_key` | `str` | `""` | `ZETTELFORGE_LLM_API_KEY` | API key for authenticated providers. Accepts `${ENV_VAR}` references — never commit raw keys. Redacted from `repr(LLMConfig)`. |
 | `llm.temperature` | `float` | `0.1` | — | Sampling temperature. `0.0` = deterministic, `0.1` = near-deterministic (default), `0.7` = creative. |
-| `llm.timeout` | `float` | `60.0` | `ZETTELFORGE_LLM_TIMEOUT` | HTTP request timeout in seconds (used by HTTP-based providers). |
-| `llm.max_retries` | `int` | `2` | `ZETTELFORGE_LLM_MAX_RETRIES` | Number of retries on transient failures (429, 5xx, timeout). Phase 2 providers respect `Retry-After` headers on 429. |
+| `llm.timeout` | `float` | `60.0` | `ZETTELFORGE_LLM_TIMEOUT` | **Reserved for Phase 2+ HTTP providers.** Configured and env-overridable today, but the Phase 1 `ollama` provider does not apply it. Set now so your config is ready for the `openai_compat` / `anthropic` providers shipping in Phase 2. |
+| `llm.max_retries` | `int` | `2` | `ZETTELFORGE_LLM_MAX_RETRIES` | **Reserved for Phase 2+ HTTP providers.** Same story as `timeout` — the Phase 1 `ollama` provider does not retry. Phase 2 will respect `Retry-After` headers on 429. |
 | `llm.fallback` | `str` | `""` | `ZETTELFORGE_LLM_FALLBACK` | Backup provider invoked when the primary fails with a non-configuration error. Empty string preserves the implicit `local → ollama` fallback for backward compatibility; set explicitly to any other registered provider to route elsewhere. |
 | `llm.extra` | `dict` | `{}` | — | Provider-specific kwargs forwarded to the constructor. Example for `local`: `{filename: qwen2.5-3b-instruct-q4_k_m.gguf, n_ctx: 4096}`. String values inside `extra` also honour `${ENV_VAR}` resolution. |
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -120,18 +120,28 @@ class EmbeddingConfig:
 ```python
 @dataclass
 class LLMConfig:
-    provider: str = "local"
-    model: str = "Qwen2.5-3B-Instruct-Q4_K_M.gguf"
+    provider: str = "ollama"
+    model: str = "qwen3.5:9b"
     url: str = "http://localhost:11434"
+    api_key: str = ""              # supports ${ENV_VAR} references
     temperature: float = 0.1
+    timeout: float = 60.0
+    max_retries: int = 2
+    fallback: str = ""             # "" preserves implicit local→ollama fallback
+    extra: dict = field(default_factory=dict)
 ```
 
 | Key | Type | Default | Env Override | Description |
 |:----|:-----|:--------|:-------------|:------------|
-| `llm.provider` | `str` | `local` | `ZETTELFORGE_LLM_PROVIDER` | LLM provider. Values: `local` (in-process llama-cpp-python, default), `ollama` (requires Ollama running at `llm.url`). |
-| `llm.model` | `str` | `Qwen2.5-3B-Instruct-Q4_K_M.gguf` | `ZETTELFORGE_LLM_MODEL` | LLM for fact extraction, intent classification, causal triple extraction, and synthesis. Default for local: Qwen2.5-3B-Instruct Q4_K_M GGUF (~2.0 GB, ~15.6 tok/s). For Ollama provider, use Ollama model tags (e.g., `qwen2.5:3b`). |
-| `llm.url` | `str` | `http://localhost:11434` | `ZETTELFORGE_LLM_URL` | LLM server URL. Only used when `llm.provider` is `ollama`. |
-| `llm.temperature` | `float` | `0.1` | -- | Sampling temperature. `0.0` = deterministic, `0.1` = near-deterministic (default), `0.7` = creative. |
+| `llm.provider` | `str` | `ollama` | `ZETTELFORGE_LLM_PROVIDER` | LLM provider name. Values shipped in core: `local` (in-process llama-cpp-python via `zettelforge[local]`), `ollama` (HTTP), `mock` (tests only). `openai_compat` and `anthropic` land in RFC-002 Phase 2/3. Third-party providers register via the `zettelforge.llm_providers` entry point. |
+| `llm.model` | `str` | `qwen3.5:9b` | `ZETTELFORGE_LLM_MODEL` | Model identifier. Meaning is provider-specific: Ollama tag (`qwen2.5:3b`), HuggingFace repo for local (`Qwen/Qwen2.5-3B-Instruct-GGUF`), OpenAI-compatible model name, or Anthropic model ID. |
+| `llm.url` | `str` | `http://localhost:11434` | `ZETTELFORGE_LLM_URL` | Base URL. Meaning is provider-specific — Ollama endpoint for `ollama`, `/v1/chat/completions` base for `openai_compat`, ignored for `local` and `anthropic`. |
+| `llm.api_key` | `str` | `""` | `ZETTELFORGE_LLM_API_KEY` | API key for authenticated providers. Accepts `${ENV_VAR}` references — never commit raw keys. Redacted from `repr(LLMConfig)`. |
+| `llm.temperature` | `float` | `0.1` | — | Sampling temperature. `0.0` = deterministic, `0.1` = near-deterministic (default), `0.7` = creative. |
+| `llm.timeout` | `float` | `60.0` | `ZETTELFORGE_LLM_TIMEOUT` | HTTP request timeout in seconds (used by HTTP-based providers). |
+| `llm.max_retries` | `int` | `2` | `ZETTELFORGE_LLM_MAX_RETRIES` | Number of retries on transient failures (429, 5xx, timeout). Phase 2 providers respect `Retry-After` headers on 429. |
+| `llm.fallback` | `str` | `""` | `ZETTELFORGE_LLM_FALLBACK` | Backup provider invoked when the primary fails with a non-configuration error. Empty string preserves the implicit `local → ollama` fallback for backward compatibility; set explicitly to any other registered provider to route elsewhere. |
+| `llm.extra` | `dict` | `{}` | — | Provider-specific kwargs forwarded to the constructor. Example for `local`: `{filename: qwen2.5-3b-instruct-q4_k_m.gguf, n_ctx: 4096}`. String values inside `extra` also honour `${ENV_VAR}` resolution. |
 
 ---
 
@@ -316,6 +326,10 @@ See [Configure OpenCTI Integration](../how-to/configure-opencti.md) for setup st
 | `ZETTELFORGE_LLM_PROVIDER` | `llm.provider` | `ollama` |
 | `ZETTELFORGE_LLM_MODEL` | `llm.model` | `qwen2.5:7b` |
 | `ZETTELFORGE_LLM_URL` | `llm.url` | `http://gpu-box:11434` |
+| `ZETTELFORGE_LLM_API_KEY` | `llm.api_key` | `sk-…` |
+| `ZETTELFORGE_LLM_TIMEOUT` | `llm.timeout` | `60` |
+| `ZETTELFORGE_LLM_MAX_RETRIES` | `llm.max_retries` | `2` |
+| `ZETTELFORGE_LLM_FALLBACK` | `llm.fallback` | `ollama` |
 | `ZETTELFORGE_LLM_NER_ENABLED` | `llm_ner.enabled` | `true` |
 | `OPENCTI_URL` | `Enterprise only: opencti.url` | `https://opencti.corp.internal` |
 | `OPENCTI_TOKEN` | `Enterprise only: opencti.token` | `abc123...` |

--- a/docs/rfcs/RFC-002-universal-llm-provider.md
+++ b/docs/rfcs/RFC-002-universal-llm-provider.md
@@ -854,3 +854,30 @@ Each phase is independently shippable. If Phase 2 stalls, Phase 1 still delivers
 - **Date**: 2026-04-16
 - **Decision Maker**: Patrick Roland
 - **Rationale**: Adversarial review completed with 3 blockers (all fixed), 7 warnings (6 addressed, Azure deferred to follow-up), 5 nits (3 fixed). Open questions resolved: Azure deferred, per-call provider override approved for Phase 5, streaming excluded, Retry-After approved for Phase 2, ZETTELFORGE_OLLAMA_MODEL deprecated with 3-version transition plan.
+
+## Implementation Status
+
+| Phase | Scope | Status | Shipped in |
+|-------|-------|--------|------------|
+| Phase 1 | Provider infrastructure (`llm_providers/` package, registry, `local` / `ollama` / `mock` providers, expanded `LLMConfig`, env-ref resolution, entry-point discovery) | **Shipped** | 2026-04-17 (commit `f67db7d`) |
+| Phase 2 | `openai_compat` provider (OpenAI, Azure OpenAI, vLLM, LiteLLM, Together AI, Groq) with `Retry-After` support | Planned | — |
+| Phase 3 | `anthropic` native SDK provider | Planned | — |
+| Phase 4 | Full env-var documentation, per-extra env resolution, third-party entry-point guide | In progress (docs ship with Phase 1) | — |
+| Phase 5 | Per-call `provider=` override on `generate()`, Azure OpenAI dedicated provider | Planned | — |
+
+### Phase 1 verification snapshot (2026-04-17)
+
+- 27 new tests in `tests/test_llm_providers.py` covering the protocol,
+  registry, every built-in provider, `generate()` delegation, `__repr__`
+  redaction, and `${VAR}` env resolution.
+- All 5 existing callers of `generate()` (fact extractor, memory
+  updater, synthesis generator, intent classifier, note constructor,
+  entity indexer, memory evolver) exercise the new registry path
+  through their existing test suites — no per-caller change was
+  needed.
+- `mypy --disallow-untyped-defs` clean on `src/zettelforge/llm_providers/`.
+- Governance controls verified: **GOV-002** (commit format),
+  **GOV-003** (type hints + protocol + dataclass), **GOV-006** (code
+  review checklist), **GOV-007** (67 % coverage gate), **GOV-014**
+  (api_key never logged; `${VAR}` resolution; env override), **GOV-023**
+  (.gitignore hardened).

--- a/docs/rfcs/RFC-002-universal-llm-provider.md
+++ b/docs/rfcs/RFC-002-universal-llm-provider.md
@@ -870,7 +870,7 @@ Each phase is independently shippable. If Phase 2 stalls, Phase 1 still delivers
 - 27 new tests in `tests/test_llm_providers.py` covering the protocol,
   registry, every built-in provider, `generate()` delegation, `__repr__`
   redaction, and `${VAR}` env resolution.
-- All 5 existing callers of `generate()` (fact extractor, memory
+- All 7 existing callers of `generate()` (fact extractor, memory
   updater, synthesis generator, intent classifier, note constructor,
   entity indexer, memory evolver) exercise the new registry path
   through their existing test suites — no per-caller change was

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -17,11 +17,39 @@ Usage:
 """
 
 import os
+import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import List, Optional
+from typing import Any, Dict, List, Optional
 
 from zettelforge.log import get_logger
+
+# Matches ${VAR_NAME} references used to inject secrets from the
+# environment into config values without storing them in YAML.
+_ENV_VAR_PATTERN = re.compile(r"\$\{([A-Za-z_][A-Za-z0-9_]*)\}")
+
+
+def _resolve_env_refs(value: str) -> str:
+    """Replace ``${VAR}`` references in ``value`` with environment values.
+
+    Unresolved references emit a WARNING log and are replaced with the
+    empty string so misconfigured deployments fail fast at auth time
+    rather than silently shipping the literal ``${...}`` token.
+    """
+
+    def _replace(match: "re.Match[str]") -> str:
+        var_name = match.group(1)
+        env_value = os.environ.get(var_name)
+        if env_value is None:
+            get_logger("zettelforge.config").warning(
+                "env_var_not_found",
+                var=var_name,
+                hint=f"Set {var_name} in your environment",
+            )
+            return ""
+        return env_value
+
+    return _ENV_VAR_PATTERN.sub(_replace, value)
 
 
 @dataclass
@@ -48,10 +76,33 @@ class EmbeddingConfig:
 
 @dataclass
 class LLMConfig:
-    provider: str = "ollama"  # "local" (llama-cpp-python, in-process) or "ollama" (HTTP server)
-    model: str = "qwen3.5:9b"  # Ollama model name, or HuggingFace repo for local provider
-    url: str = "http://localhost:11434"  # only used when provider=ollama
+    """LLM provider configuration (RFC-002).
+
+    ``provider`` selects the backend registered in
+    :mod:`zettelforge.llm_providers`. ``api_key`` supports ``${VAR}``
+    env-reference syntax and is redacted from ``repr()``.
+    """
+
+    provider: str = "ollama"
+    model: str = "qwen3.5:9b"
+    url: str = "http://localhost:11434"
+    api_key: str = ""  # supports ${ENV_VAR} references — never commit raw keys
     temperature: float = 0.1
+    timeout: float = 60.0
+    max_retries: int = 2
+    fallback: str = ""  # empty preserves implicit local→ollama fallback
+    extra: Dict[str, Any] = field(default_factory=dict)
+
+    def __repr__(self) -> str:
+        # Redact api_key from any structured log or debug dump.
+        key_display = "'***'" if self.api_key else "''"
+        return (
+            f"LLMConfig(provider={self.provider!r}, model={self.model!r}, "
+            f"url={self.url!r}, api_key={key_display}, "
+            f"temperature={self.temperature}, timeout={self.timeout}, "
+            f"max_retries={self.max_retries}, fallback={self.fallback!r}, "
+            f"extra={self.extra!r})"
+        )
 
 
 @dataclass
@@ -233,8 +284,16 @@ def _apply_yaml(cfg: ZettelForgeConfig, data: dict):
 
     if "llm" in data and isinstance(data["llm"], dict):
         for k, v in data["llm"].items():
-            if hasattr(cfg.llm, k):
-                setattr(cfg.llm, k, v)
+            if not hasattr(cfg.llm, k):
+                continue
+            # Resolve ${ENV_VAR} refs for sensitive string fields.
+            if k == "api_key" and isinstance(v, str):
+                v = _resolve_env_refs(v)
+            elif k == "extra" and isinstance(v, dict):
+                v = {
+                    ek: _resolve_env_refs(ev) if isinstance(ev, str) else ev for ek, ev in v.items()
+                }
+            setattr(cfg.llm, k, v)
 
     if "llm_ner" in data and isinstance(data["llm_ner"], dict):
         for k, v in data["llm_ner"].items():
@@ -319,6 +378,25 @@ def _apply_env(cfg: ZettelForgeConfig):
         cfg.llm.model = v
     if v := os.environ.get("ZETTELFORGE_LLM_URL"):
         cfg.llm.url = v
+    # RFC-002: api_key / timeout / retries / fallback env overrides.
+    if v := os.environ.get("ZETTELFORGE_LLM_API_KEY"):
+        cfg.llm.api_key = v
+    if v := os.environ.get("ZETTELFORGE_LLM_TIMEOUT"):
+        try:
+            cfg.llm.timeout = float(v)
+        except ValueError:
+            get_logger("zettelforge.config").warning(
+                "invalid_llm_timeout", value=v, hint="Must be a float"
+            )
+    if v := os.environ.get("ZETTELFORGE_LLM_MAX_RETRIES"):
+        try:
+            cfg.llm.max_retries = int(v)
+        except ValueError:
+            get_logger("zettelforge.config").warning(
+                "invalid_llm_max_retries", value=v, hint="Must be an int"
+            )
+    if v := os.environ.get("ZETTELFORGE_LLM_FALLBACK"):
+        cfg.llm.fallback = v
 
     # LLM NER
     if v := os.environ.get("ZETTELFORGE_LLM_NER_ENABLED"):

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -93,15 +93,33 @@ class LLMConfig:
     fallback: str = ""  # empty preserves implicit local→ollama fallback
     extra: Dict[str, Any] = field(default_factory=dict)
 
+    # Keys under ``extra`` that are commonly used for secrets. Matched
+    # case-insensitively as substrings so ``openai_api_key``, ``client_secret``,
+    # ``auth_token``, ``azure_ad_token``, ``credentials_json`` all redact.
+    _SENSITIVE_EXTRA_KEYS = ("key", "token", "secret", "password", "credential", "auth")
+
+    def _redact_extra(self) -> Dict[str, Any]:
+        """Return ``extra`` with sensitive-looking values replaced by ``'***'``."""
+        redacted: Dict[str, Any] = {}
+        for k, v in self.extra.items():
+            k_low = k.lower() if isinstance(k, str) else ""
+            if isinstance(v, str) and v and any(s in k_low for s in self._SENSITIVE_EXTRA_KEYS):
+                redacted[k] = "***"
+            else:
+                redacted[k] = v
+        return redacted
+
     def __repr__(self) -> str:
-        # Redact api_key from any structured log or debug dump.
+        # Redact api_key plus any sensitive-looking keys inside ``extra`` so
+        # secrets resolved via ``${ENV_VAR}`` refs don't leak into structured
+        # logs or debug dumps.
         key_display = "'***'" if self.api_key else "''"
         return (
             f"LLMConfig(provider={self.provider!r}, model={self.model!r}, "
             f"url={self.url!r}, api_key={key_display}, "
             f"temperature={self.temperature}, timeout={self.timeout}, "
             f"max_retries={self.max_retries}, fallback={self.fallback!r}, "
-            f"extra={self.extra!r})"
+            f"extra={self._redact_extra()!r})"
         )
 
 

--- a/src/zettelforge/llm_client.py
+++ b/src/zettelforge/llm_client.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 import os
 from typing import Any, Dict, Optional
 
-from zettelforge.llm_providers import registry
+from zettelforge.llm_providers import LLMProviderConfigurationError, registry
 from zettelforge.log import get_logger
 
 _logger = get_logger("zettelforge.llm_client")
@@ -78,8 +78,9 @@ def _provider_kwargs(provider_name: str) -> Dict[str, Any]:
     """Build constructor kwargs for a provider from current config + env.
 
     The registry caches instances keyed by name, so these kwargs are only
-    consumed on first creation. A :func:`reload` is required to pick up
-    config changes at runtime.
+    consumed on first creation. Call :func:`reload` (below) to pick up
+    config changes at runtime — it clears both the cached config and the
+    cached provider instances.
     """
     kwargs: Dict[str, Any] = {}
 
@@ -179,11 +180,12 @@ def generate(
 
     try:
         provider = registry.get(primary, **_provider_kwargs(primary))
-    except ImportError:
-        # Primary SDK missing — do not silently fall back, surface it.
-        raise
-    except ValueError:
-        _logger.error("unknown_llm_provider", provider=primary)
+    except (ImportError, LLMProviderConfigurationError, ValueError):
+        # Configuration errors (missing SDK / bad config / unknown
+        # provider name) are non-recoverable. Surface them rather than
+        # silently falling back to a different provider, which would hide
+        # the real problem until the user debugs the wrong component.
+        _logger.error("llm_provider_config_error", provider=primary, exc_info=True)
         raise
 
     try:
@@ -194,8 +196,9 @@ def generate(
             system=system,
             json_mode=json_mode,
         )
-    except ImportError:
-        # Missing SDK for the primary provider — same rule as above.
+    except (ImportError, LLMProviderConfigurationError):
+        # Same rule as above — config errors raised from ``generate()``
+        # are non-recoverable and must not be masked by the fallback.
         raise
     except Exception:
         _logger.debug("primary_provider_failed", provider=primary, exc_info=True)
@@ -214,11 +217,32 @@ def generate(
             system=system,
             json_mode=json_mode,
         )
+    except (ImportError, LLMProviderConfigurationError, ValueError):
+        # Misconfigured fallback is still a config error — don't eat it.
+        raise
     except Exception:
         _logger.error(
             "all_llm_backends_failed", primary=primary, fallback=fallback_name, exc_info=True
         )
         return ""
+
+
+def reload() -> None:
+    """Reload LLM config and clear cached provider instances.
+
+    Provider instances are cached in the registry keyed by name, so
+    config changes made after the first ``generate()`` call do not reach
+    already-initialised providers. Call this when you mutate env vars or
+    ``config.yaml`` and want the next ``generate()`` to re-read both the
+    config and the provider constructor kwargs.
+
+    Registrations (which providers exist) are preserved; only instance
+    caches are cleared.
+    """
+    from zettelforge.config import reload_config
+
+    reload_config()
+    registry.reset()
 
 
 # ── Backward-compat shims ────────────────────────────────────────────────────

--- a/src/zettelforge/llm_client.py
+++ b/src/zettelforge/llm_client.py
@@ -96,12 +96,24 @@ def _provider_kwargs(provider_name: str) -> Dict[str, Any]:
         kwargs["api_key"] = getattr(llm_cfg, "api_key", "")
         kwargs["timeout"] = getattr(llm_cfg, "timeout", 60.0)
         kwargs["max_retries"] = getattr(llm_cfg, "max_retries", 2)
-        kwargs.update(getattr(llm_cfg, "extra", {}) or {})
+        # Guard against the simple-YAML fallback (no PyYAML installed) which
+        # can leave ``extra`` as the literal string ``"{}"``. Only merge dicts.
+        extra = getattr(llm_cfg, "extra", None)
+        if isinstance(extra, dict):
+            kwargs.update(extra)
 
     # Env overrides preserved from pre-RFC-002 behaviour.
     if provider_name == "local":
+        # The shared config's ``llm.model`` may be an Ollama tag like
+        # ``qwen3.5:9b``. llama-cpp-python interprets that as a HuggingFace
+        # repo id and fails. If the configured value looks like an Ollama tag
+        # (colon, no slash) we ignore it and fall back to ``DEFAULT_LLM_MODEL``
+        # unless the user explicitly set ``ZETTELFORGE_LLM_MODEL``.
+        cfg_model = kwargs.get("model") or ""
+        looks_like_ollama_tag = ":" in cfg_model and "/" not in cfg_model
+        local_default = "" if looks_like_ollama_tag else cfg_model
         kwargs["model"] = os.environ.get(
-            "ZETTELFORGE_LLM_MODEL", kwargs.get("model") or DEFAULT_LLM_MODEL
+            "ZETTELFORGE_LLM_MODEL", local_default or DEFAULT_LLM_MODEL
         )
         kwargs["filename"] = os.environ.get(
             "ZETTELFORGE_LLM_FILENAME",

--- a/src/zettelforge/llm_client.py
+++ b/src/zettelforge/llm_client.py
@@ -1,26 +1,34 @@
-"""
-LLM Client — Unified interface for local (llama-cpp-python) and remote (Ollama) LLM.
+"""Unified LLM interface.
 
-Uses llama-cpp-python with Qwen2.5-3B-Instruct by default (in-process, no server).
-Falls back to Ollama HTTP if configured via provider setting.
+Delegates to a registered :class:`~zettelforge.llm_providers.base.LLMProvider`
+chosen by ``llm.provider`` config. The public ``generate()`` signature
+is stable — RFC-002 Phase 1 refactored the internals without changing
+the call contract, so existing call sites (``fact_extractor``,
+``memory_updater``, ``synthesis_generator``, ``intent_classifier``,
+``note_constructor``, ``entity_indexer``, ``memory_evolver``) do not
+need to change.
 
-Usage:
+Example::
+
     from zettelforge.llm_client import generate
-    text = generate("Extract facts from: APT28 uses Cobalt Strike", max_tokens=400)
+
+    text = generate("Extract facts from: APT28 uses Cobalt Strike")
 """
+
+from __future__ import annotations
 
 import os
-import threading
-from typing import Optional
+from typing import Any, Dict, Optional
 
+from zettelforge.llm_providers import registry
 from zettelforge.log import get_logger
 
 _logger = get_logger("zettelforge.llm_client")
 
 
-# ── Configuration ────────────────────────────────────────────────────────────
+# ── Environment-variable helpers (preserved for backward compat) ──────────────
 
-DEFAULT_LLM_PROVIDER = "local"  # "local" (llama-cpp-python) or "ollama" (HTTP)
+DEFAULT_LLM_PROVIDER = "local"
 DEFAULT_LLM_MODEL = "Qwen/Qwen2.5-3B-Instruct-GGUF"
 DEFAULT_LLM_FILENAME = "qwen2.5-3b-instruct-q4_k_m.gguf"
 DEFAULT_OLLAMA_MODEL = "qwen2.5:3b"
@@ -28,45 +36,108 @@ DEFAULT_OLLAMA_URL = "http://localhost:11434"
 
 
 def get_llm_provider() -> str:
-    return os.environ.get("ZETTELFORGE_LLM_PROVIDER", DEFAULT_LLM_PROVIDER)
+    """Return the configured provider name, honouring env var and config."""
+    if value := os.environ.get("ZETTELFORGE_LLM_PROVIDER"):
+        return value
+    try:
+        from zettelforge.config import get_config
+
+        return get_config().llm.provider or DEFAULT_LLM_PROVIDER
+    except Exception:
+        return DEFAULT_LLM_PROVIDER
 
 
 def get_llm_model() -> str:
-    return os.environ.get("ZETTELFORGE_LLM_MODEL", DEFAULT_LLM_MODEL)
+    """Return the configured LLM model identifier (env > config > default)."""
+    if value := os.environ.get("ZETTELFORGE_LLM_MODEL"):
+        return value
+    try:
+        from zettelforge.config import get_config
+
+        return get_config().llm.model or DEFAULT_LLM_MODEL
+    except Exception:
+        return DEFAULT_LLM_MODEL
 
 
 def get_ollama_url() -> str:
-    return os.environ.get("ZETTELFORGE_LLM_URL", DEFAULT_OLLAMA_URL)
+    """Return the configured LLM server URL for the ollama provider."""
+    if value := os.environ.get("ZETTELFORGE_LLM_URL"):
+        return value
+    try:
+        from zettelforge.config import get_config
+
+        return get_config().llm.url or DEFAULT_OLLAMA_URL
+    except Exception:
+        return DEFAULT_OLLAMA_URL
 
 
-# ── Local LLM singleton ─────────────────────────────────────────────────────
-
-_llm = None
-_llm_lock = threading.Lock()
+# ── Provider kwargs ──────────────────────────────────────────────────────────
 
 
-def _get_local_llm():
-    """Get or create the local Llama model (singleton)."""
-    global _llm
-    if _llm is None:
-        with _llm_lock:
-            if _llm is None:
-                try:
-                    from llama_cpp import Llama
-                except ImportError:
-                    raise ImportError(
-                        "Local LLM requires llama-cpp-python. Install with: "
-                        "pip install zettelforge[local]"
-                    ) from None
+def _provider_kwargs(provider_name: str) -> Dict[str, Any]:
+    """Build constructor kwargs for a provider from current config + env.
 
-                _llm = Llama.from_pretrained(
-                    repo_id=get_llm_model(),
-                    filename=os.environ.get("ZETTELFORGE_LLM_FILENAME", DEFAULT_LLM_FILENAME),
-                    n_ctx=4096,
-                    n_gpu_layers=0,
-                    verbose=False,
-                )
-    return _llm
+    The registry caches instances keyed by name, so these kwargs are only
+    consumed on first creation. A :func:`reload` is required to pick up
+    config changes at runtime.
+    """
+    kwargs: Dict[str, Any] = {}
+
+    try:
+        from zettelforge.config import get_config
+
+        llm_cfg = get_config().llm
+    except Exception:
+        llm_cfg = None
+
+    if llm_cfg is not None:
+        kwargs["model"] = llm_cfg.model
+        kwargs["url"] = llm_cfg.url
+        kwargs["api_key"] = getattr(llm_cfg, "api_key", "")
+        kwargs["timeout"] = getattr(llm_cfg, "timeout", 60.0)
+        kwargs["max_retries"] = getattr(llm_cfg, "max_retries", 2)
+        kwargs.update(getattr(llm_cfg, "extra", {}) or {})
+
+    # Env overrides preserved from pre-RFC-002 behaviour.
+    if provider_name == "local":
+        kwargs["model"] = os.environ.get(
+            "ZETTELFORGE_LLM_MODEL", kwargs.get("model") or DEFAULT_LLM_MODEL
+        )
+        kwargs["filename"] = os.environ.get(
+            "ZETTELFORGE_LLM_FILENAME",
+            kwargs.get("filename") or DEFAULT_LLM_FILENAME,
+        )
+    elif provider_name == "ollama":
+        # ``ZETTELFORGE_OLLAMA_MODEL`` is deprecated in favour of
+        # ``ZETTELFORGE_LLM_MODEL`` but still honoured through v2.x.
+        kwargs["model"] = os.environ.get(
+            "ZETTELFORGE_LLM_MODEL",
+            os.environ.get("ZETTELFORGE_OLLAMA_MODEL", kwargs.get("model") or DEFAULT_OLLAMA_MODEL),
+        )
+        kwargs["url"] = os.environ.get(
+            "ZETTELFORGE_LLM_URL", kwargs.get("url") or DEFAULT_OLLAMA_URL
+        )
+
+    return {k: v for k, v in kwargs.items() if v != ""}
+
+
+def _fallback_provider(primary: str) -> Optional[str]:
+    """Return the fallback provider name for ``primary`` (or ``None``)."""
+    try:
+        from zettelforge.config import get_config
+
+        fallback = getattr(get_config().llm, "fallback", "") or ""
+    except Exception:
+        fallback = ""
+
+    if fallback:
+        return fallback if fallback != primary else None
+
+    # Historical implicit fallback: local → ollama. Preserved so existing
+    # installs keep working if the GGUF model fails to load.
+    if primary == "local":
+        return "ollama"
+    return None
 
 
 # ── Public API ───────────────────────────────────────────────────────────────
@@ -79,51 +150,91 @@ def generate(
     system: Optional[str] = None,
     json_mode: bool = False,
 ) -> str:
-    """
-    Generate text from a prompt. Uses local GGUF model by default, Ollama as fallback.
+    """Generate text from a prompt via the configured LLM provider.
 
     Args:
         prompt: The user prompt.
         max_tokens: Maximum tokens to generate.
-        temperature: Sampling temperature (0.0 = deterministic).
+        temperature: Sampling temperature (``0.0`` = deterministic).
         system: Optional system prompt.
-        json_mode: If True, instruct the backend to return JSON output where supported.
+        json_mode: Instruct the backend to emit JSON where supported.
 
     Returns:
-        Generated text string.
+        Generated text, or ``""`` when both primary and fallback providers
+        fail recoverably. Configuration errors are propagated.
     """
-    provider = get_llm_provider()
+    primary = get_llm_provider()
 
-    if provider == "local":
-        try:
-            return _generate_local(prompt, max_tokens, temperature, system, json_mode=json_mode)
-        except Exception:
-            _logger.debug("llamacpp_unavailable_trying_ollama", exc_info=True)
-
-    # Ollama fallback
     try:
-        return _generate_ollama(prompt, max_tokens, temperature, system=system, json_mode=json_mode)
+        provider = registry.get(primary, **_provider_kwargs(primary))
+    except ImportError:
+        # Primary SDK missing — do not silently fall back, surface it.
+        raise
+    except ValueError:
+        _logger.error("unknown_llm_provider", provider=primary)
+        raise
+
+    try:
+        return provider.generate(
+            prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system,
+            json_mode=json_mode,
+        )
+    except ImportError:
+        # Missing SDK for the primary provider — same rule as above.
+        raise
     except Exception:
-        _logger.error("all_llm_backends_failed", exc_info=True)
+        _logger.debug("primary_provider_failed", provider=primary, exc_info=True)
+
+    fallback_name = _fallback_provider(primary)
+    if fallback_name is None:
+        _logger.error("all_llm_backends_failed", provider=primary)
+        return ""
+
+    try:
+        fallback = registry.get(fallback_name, **_provider_kwargs(fallback_name))
+        return fallback.generate(
+            prompt,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            system=system,
+            json_mode=json_mode,
+        )
+    except Exception:
+        _logger.error(
+            "all_llm_backends_failed", primary=primary, fallback=fallback_name, exc_info=True
+        )
         return ""
 
 
-def _generate_local(
-    prompt: str, max_tokens: int, temperature: float, system: Optional[str], json_mode: bool = False
-) -> str:
-    """Generate via in-process llama-cpp-python."""
-    llm = _get_local_llm()
-    messages = []
-    if system:
-        messages.append({"role": "system", "content": system})
-    messages.append({"role": "user", "content": prompt})
+# ── Backward-compat shims ────────────────────────────────────────────────────
+# The old private helpers are kept so ``from zettelforge.llm_client import
+# _get_local_llm`` and similar internal patches in existing tests continue
+# to work. They now thread through the provider registry.
 
-    output = llm.create_chat_completion(
-        messages=messages,
-        max_tokens=max_tokens,
-        temperature=temperature,
+
+def _get_local_llm() -> Any:
+    """Return the underlying llama-cpp ``Llama`` instance (test/debug only)."""
+    provider = registry.get("local", **_provider_kwargs("local"))
+    if hasattr(provider, "_get_llm"):
+        return provider._get_llm()
+    raise RuntimeError("local provider has no _get_llm() hook")
+
+
+def _generate_local(
+    prompt: str,
+    max_tokens: int,
+    temperature: float,
+    system: Optional[str],
+    json_mode: bool = False,
+) -> str:
+    """Deprecated compat shim — prefer :func:`generate`."""
+    provider = registry.get("local", **_provider_kwargs("local"))
+    return provider.generate(
+        prompt, max_tokens=max_tokens, temperature=temperature, system=system, json_mode=json_mode
     )
-    return output["choices"][0]["message"]["content"].strip()
 
 
 def _generate_ollama(
@@ -133,18 +244,8 @@ def _generate_ollama(
     system: Optional[str] = None,
     json_mode: bool = False,
 ) -> str:
-    """Generate via Ollama HTTP API."""
-    import ollama
-
-    model = os.environ.get("ZETTELFORGE_OLLAMA_MODEL", DEFAULT_OLLAMA_MODEL)
-    kwargs: dict = {
-        "model": model,
-        "prompt": prompt,
-        "options": {"temperature": temperature, "num_predict": max_tokens},
-    }
-    if system:
-        kwargs["system"] = system
-    if json_mode:
-        kwargs["format"] = "json"
-    response = ollama.generate(**kwargs)
-    return response.get("response", "").strip()
+    """Deprecated compat shim — prefer :func:`generate`."""
+    provider = registry.get("ollama", **_provider_kwargs("ollama"))
+    return provider.generate(
+        prompt, max_tokens=max_tokens, temperature=temperature, system=system, json_mode=json_mode
+    )

--- a/src/zettelforge/llm_providers/__init__.py
+++ b/src/zettelforge/llm_providers/__init__.py
@@ -1,0 +1,83 @@
+"""Pluggable LLM providers for ZettelForge (RFC-002 Phase 1).
+
+Public surface:
+
+- :class:`~zettelforge.llm_providers.base.LLMProvider` — the duck-typed
+  protocol every provider implements.
+- :mod:`~zettelforge.llm_providers.registry` — register, get, reset.
+- Built-in providers: ``local``, ``ollama``, ``mock``.
+
+Callers should continue to use :func:`zettelforge.llm_client.generate`;
+the public ``generate()`` API delegates to the registered provider.
+Third-party packages can register additional providers via the
+``zettelforge.llm_providers`` entry-point group.
+"""
+
+from __future__ import annotations
+
+from zettelforge.llm_providers.base import LLMProvider
+from zettelforge.llm_providers.local_provider import LocalProvider
+from zettelforge.llm_providers.mock_provider import MockProvider
+from zettelforge.llm_providers.ollama_provider import OllamaProvider
+from zettelforge.llm_providers.registry import available, get, register, reset
+from zettelforge.log import get_logger
+
+_logger = get_logger("zettelforge.llm_providers")
+
+__all__ = [
+    "LLMProvider",
+    "LocalProvider",
+    "OllamaProvider",
+    "MockProvider",
+    "register",
+    "get",
+    "available",
+    "reset",
+]
+
+
+def _register_builtins() -> None:
+    """Register the providers that ship with the core package."""
+    for name, cls in (
+        ("local", LocalProvider),
+        ("ollama", OllamaProvider),
+        ("mock", MockProvider),
+    ):
+        try:
+            register(name, cls)
+        except ValueError:
+            # Already registered (re-import / test runtime); silently skip.
+            pass
+
+
+def _discover_entry_points() -> None:
+    """Load third-party providers exposed via entry points.
+
+    Entry-point group: ``zettelforge.llm_providers``. Load failures are
+    logged at DEBUG so a broken plugin never stops core startup.
+    """
+    try:
+        from importlib.metadata import entry_points
+    except ImportError:  # pragma: no cover — Python < 3.8 not supported
+        return
+
+    try:
+        eps = entry_points(group="zettelforge.llm_providers")
+    except Exception:  # pragma: no cover — metadata backend issues
+        _logger.debug("entry_point_discovery_failed", exc_info=True)
+        return
+
+    for ep in eps:
+        try:
+            provider_class = ep.load()
+            register(ep.name, provider_class)
+        except Exception:
+            _logger.debug(
+                "third_party_provider_load_failed",
+                entry_point=ep.name,
+                exc_info=True,
+            )
+
+
+_register_builtins()
+_discover_entry_points()

--- a/src/zettelforge/llm_providers/__init__.py
+++ b/src/zettelforge/llm_providers/__init__.py
@@ -15,7 +15,7 @@ Third-party packages can register additional providers via the
 
 from __future__ import annotations
 
-from zettelforge.llm_providers.base import LLMProvider
+from zettelforge.llm_providers.base import LLMProvider, LLMProviderConfigurationError
 from zettelforge.llm_providers.local_provider import LocalProvider
 from zettelforge.llm_providers.mock_provider import MockProvider
 from zettelforge.llm_providers.ollama_provider import OllamaProvider
@@ -26,6 +26,7 @@ _logger = get_logger("zettelforge.llm_providers")
 
 __all__ = [
     "LLMProvider",
+    "LLMProviderConfigurationError",
     "LocalProvider",
     "OllamaProvider",
     "MockProvider",

--- a/src/zettelforge/llm_providers/base.py
+++ b/src/zettelforge/llm_providers/base.py
@@ -4,13 +4,29 @@ Phase 1 of RFC-002. See docs/rfcs/RFC-002-universal-llm-provider.md.
 
 Using ``typing.Protocol`` (PEP 544) rather than an abstract base class so
 third-party providers only need duck-type compatibility — no forced
-inheritance. ``runtime_checkable`` enables ``isinstance`` validation at
-registration time.
+inheritance. ``runtime_checkable`` allows callers to opt into
+``isinstance(obj, LLMProvider)`` validation when they want it; the
+registry itself does not currently enforce the check at ``register()``
+time.
+
+Providers SHOULD raise :class:`LLMProviderConfigurationError` for
+non-recoverable setup problems (missing API key, malformed config)
+so the caller can surface the error instead of silently falling back.
 """
 
 from __future__ import annotations
 
 from typing import Optional, Protocol, runtime_checkable
+
+
+class LLMProviderConfigurationError(Exception):
+    """Raised by a provider when it cannot operate due to configuration.
+
+    Examples: missing API key, invalid URL, unavailable SDK at a version
+    we actually need. The public ``generate()`` function propagates this
+    rather than swallowing it into an empty string, because retrying
+    with the same config will keep failing.
+    """
 
 
 @runtime_checkable

--- a/src/zettelforge/llm_providers/base.py
+++ b/src/zettelforge/llm_providers/base.py
@@ -1,0 +1,43 @@
+"""LLMProvider protocol — the contract every LLM backend implements.
+
+Phase 1 of RFC-002. See docs/rfcs/RFC-002-universal-llm-provider.md.
+
+Using ``typing.Protocol`` (PEP 544) rather than an abstract base class so
+third-party providers only need duck-type compatibility — no forced
+inheritance. ``runtime_checkable`` enables ``isinstance`` validation at
+registration time.
+"""
+
+from __future__ import annotations
+
+from typing import Optional, Protocol, runtime_checkable
+
+
+@runtime_checkable
+class LLMProvider(Protocol):
+    """All LLM providers must implement this protocol.
+
+    Attributes:
+        name: Short provider identifier (e.g., ``"local"``, ``"ollama"``,
+            ``"openai_compat"``, ``"anthropic"``, ``"mock"``). Used as the
+            registry key.
+    """
+
+    name: str
+
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 400,
+        temperature: float = 0.1,
+        system: Optional[str] = None,
+        json_mode: bool = False,
+    ) -> str:
+        """Generate text from a prompt.
+
+        Providers MUST return an empty string on recoverable failure so
+        callers can short-circuit cleanly. Configuration errors (missing
+        SDK, missing API key, etc.) SHOULD raise so they surface during
+        startup rather than failing silently per call.
+        """
+        ...

--- a/src/zettelforge/llm_providers/local_provider.py
+++ b/src/zettelforge/llm_providers/local_provider.py
@@ -1,0 +1,96 @@
+"""In-process llama-cpp-python GGUF provider (``local``).
+
+Extracted from the previous ``llm_client._generate_local`` for RFC-002
+Phase 1. Lazy-loads the GGUF model on first ``generate()`` call so the
+registry can instantiate the provider without paying model-load cost at
+import time.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Any, Optional
+
+from zettelforge.log import get_logger
+
+_logger = get_logger("zettelforge.llm_providers.local")
+
+_DEFAULT_MODEL = "Qwen/Qwen2.5-3B-Instruct-GGUF"
+_DEFAULT_FILENAME = "qwen2.5-3b-instruct-q4_k_m.gguf"
+_DEFAULT_N_CTX = 4096
+
+
+class LocalProvider:
+    """llama-cpp-python provider.
+
+    Args:
+        model: HuggingFace repo id (e.g. ``"Qwen/Qwen2.5-3B-Instruct-GGUF"``).
+        filename: Specific quantized file within the repo.
+        n_ctx: Context window size in tokens.
+        **_: Accept and ignore extra kwargs so the registry can pass
+            fields like ``api_key`` or ``timeout`` that only apply to
+            other providers without breaking instantiation.
+    """
+
+    name = "local"
+
+    def __init__(
+        self,
+        model: str = "",
+        filename: str = "",
+        n_ctx: int = _DEFAULT_N_CTX,
+        **_: Any,
+    ) -> None:
+        self._model_id = model or _DEFAULT_MODEL
+        self._filename = filename or _DEFAULT_FILENAME
+        self._n_ctx = n_ctx
+        self._llm: Any = None
+        self._lock = threading.Lock()
+
+    def _get_llm(self) -> Any:
+        if self._llm is None:
+            with self._lock:
+                if self._llm is None:
+                    try:
+                        from llama_cpp import Llama
+                    except ImportError as exc:
+                        raise ImportError(
+                            "Local LLM requires llama-cpp-python. "
+                            "Install with: pip install zettelforge[local]"
+                        ) from exc
+
+                    self._llm = Llama.from_pretrained(
+                        repo_id=self._model_id,
+                        filename=self._filename,
+                        n_ctx=self._n_ctx,
+                        n_gpu_layers=0,
+                        verbose=False,
+                    )
+                    _logger.debug("local_llm_loaded", model=self._model_id)
+        return self._llm
+
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 400,
+        temperature: float = 0.1,
+        system: Optional[str] = None,
+        json_mode: bool = False,
+    ) -> str:
+        llm = self._get_llm()
+
+        messages: list[dict[str, str]] = []
+        # llama-cpp-python has no response_format; steer via system prompt.
+        if json_mode:
+            json_hint = "\n\nIMPORTANT: Respond with valid JSON only. No markdown, no commentary."
+            system = (system + json_hint) if system else json_hint.strip()
+        if system:
+            messages.append({"role": "system", "content": system})
+        messages.append({"role": "user", "content": prompt})
+
+        output = llm.create_chat_completion(
+            messages=messages,
+            max_tokens=max_tokens,
+            temperature=temperature,
+        )
+        return str(output["choices"][0]["message"]["content"]).strip()

--- a/src/zettelforge/llm_providers/mock_provider.py
+++ b/src/zettelforge/llm_providers/mock_provider.py
@@ -1,0 +1,50 @@
+"""Deterministic mock provider for tests.
+
+Records every call and returns canned responses in order. See
+:class:`MockProvider` for usage patterns.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+
+class MockProvider:
+    """Returns canned responses in order, cycling when exhausted.
+
+    Every call is recorded in :attr:`calls` so tests can assert what was
+    requested. Thread-unsafe by design — tests should exercise one
+    instance per test.
+
+    Args:
+        responses: Responses to cycle through. Defaults to
+            ``["mock response"]``.
+    """
+
+    name = "mock"
+
+    def __init__(self, responses: Optional[list[str]] = None, **_: Any) -> None:
+        self._responses: list[str] = list(responses) if responses else ["mock response"]
+        self._call_count = 0
+        self.calls: list[dict[str, Any]] = []
+
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 400,
+        temperature: float = 0.1,
+        system: Optional[str] = None,
+        json_mode: bool = False,
+    ) -> str:
+        self.calls.append(
+            {
+                "prompt": prompt,
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+                "system": system,
+                "json_mode": json_mode,
+            }
+        )
+        response = self._responses[self._call_count % len(self._responses)]
+        self._call_count += 1
+        return response

--- a/src/zettelforge/llm_providers/ollama_provider.py
+++ b/src/zettelforge/llm_providers/ollama_provider.py
@@ -1,0 +1,52 @@
+"""Ollama HTTP provider.
+
+Extracted from the previous ``llm_client._generate_ollama`` for RFC-002
+Phase 1. Reads the model tag and URL from constructor args so the
+registry can build instances from :class:`~zettelforge.config.LLMConfig`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Optional
+
+_DEFAULT_MODEL = "qwen2.5:3b"
+_DEFAULT_URL = "http://localhost:11434"
+
+
+class OllamaProvider:
+    """Ollama HTTP API provider.
+
+    Args:
+        model: Ollama model tag (e.g. ``"qwen2.5:3b"``).
+        url: Base URL of the Ollama server.
+        **_: Ignored — registry may pass other providers' kwargs.
+    """
+
+    name = "ollama"
+
+    def __init__(self, model: str = "", url: str = "", **_: Any) -> None:
+        self._model = model or _DEFAULT_MODEL
+        self._url = url or _DEFAULT_URL
+
+    def generate(
+        self,
+        prompt: str,
+        max_tokens: int = 400,
+        temperature: float = 0.1,
+        system: Optional[str] = None,
+        json_mode: bool = False,
+    ) -> str:
+        import ollama
+
+        kwargs: dict[str, Any] = {
+            "model": self._model,
+            "prompt": prompt,
+            "options": {"temperature": temperature, "num_predict": max_tokens},
+        }
+        if system:
+            kwargs["system"] = system
+        if json_mode:
+            kwargs["format"] = "json"
+
+        response = ollama.generate(**kwargs)
+        return str(response.get("response", "")).strip()

--- a/src/zettelforge/llm_providers/ollama_provider.py
+++ b/src/zettelforge/llm_providers/ollama_provider.py
@@ -48,5 +48,9 @@ class OllamaProvider:
         if json_mode:
             kwargs["format"] = "json"
 
-        response = ollama.generate(**kwargs)
+        # Route through a per-instance Client so ``self._url`` actually affects
+        # where the call goes. The module-level ``ollama.generate`` always
+        # targets the default localhost:11434, ignoring this provider's config.
+        client = ollama.Client(host=self._url)
+        response = client.generate(**kwargs)
         return str(response.get("response", "")).strip()

--- a/src/zettelforge/llm_providers/registry.py
+++ b/src/zettelforge/llm_providers/registry.py
@@ -25,10 +25,11 @@ def register(name: str, provider_class: Type[LLMProvider]) -> None:
     Raises:
         ValueError: if ``name`` is already registered.
     """
-    if name in _registry:
-        raise ValueError(f"LLM provider '{name}' is already registered")
-    _registry[name] = provider_class
-    _logger.debug("provider_registered", provider=name)
+    with _lock:
+        if name in _registry:
+            raise ValueError(f"LLM provider '{name}' is already registered")
+        _registry[name] = provider_class
+        _logger.debug("provider_registered", provider=name)
 
 
 def get(name: str, **kwargs: object) -> LLMProvider:

--- a/src/zettelforge/llm_providers/registry.py
+++ b/src/zettelforge/llm_providers/registry.py
@@ -1,0 +1,75 @@
+"""Thread-safe registry of LLM providers keyed by name.
+
+Providers register a class; the registry creates singleton instances on
+first access. Callers resolve via :func:`get`. See RFC-002.
+"""
+
+from __future__ import annotations
+
+import threading
+from typing import Dict, Type
+
+from zettelforge.llm_providers.base import LLMProvider
+from zettelforge.log import get_logger
+
+_logger = get_logger("zettelforge.llm_providers.registry")
+
+_registry: Dict[str, Type[LLMProvider]] = {}
+_instances: Dict[str, LLMProvider] = {}
+_lock = threading.Lock()
+
+
+def register(name: str, provider_class: Type[LLMProvider]) -> None:
+    """Register a provider class by name.
+
+    Raises:
+        ValueError: if ``name`` is already registered.
+    """
+    if name in _registry:
+        raise ValueError(f"LLM provider '{name}' is already registered")
+    _registry[name] = provider_class
+    _logger.debug("provider_registered", provider=name)
+
+
+def get(name: str, **kwargs: object) -> LLMProvider:
+    """Get or create a provider instance by name.
+
+    Instances are singletons per provider name (thread-safe). ``kwargs``
+    are passed to the provider constructor on first creation and ignored
+    on subsequent calls (the cached instance is returned).
+
+    Raises:
+        ValueError: if ``name`` is not registered.
+    """
+    if name not in _instances:
+        with _lock:
+            if name not in _instances:
+                if name not in _registry:
+                    raise ValueError(
+                        f"Unknown LLM provider '{name}'. "
+                        f"Available: {', '.join(sorted(_registry.keys())) or '<none>'}"
+                    )
+                _instances[name] = _registry[name](**kwargs)
+                _logger.info("provider_initialized", provider=name)
+    return _instances[name]
+
+
+def available() -> list[str]:
+    """Return the sorted list of registered provider names."""
+    return sorted(_registry.keys())
+
+
+def reset() -> None:
+    """Clear cached instances. Registrations are preserved.
+
+    Intended for test isolation — production code should not call this.
+    """
+    with _lock:
+        _instances.clear()
+
+
+def reset_registrations() -> None:
+    """Clear both instances and registrations. Tests only."""
+    with _lock:
+        _instances.clear()
+        _registry.clear()

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -1,9 +1,11 @@
 """Tests for LLM client (local llama-cpp-python + ollama fallback)."""
 
 import os
-import pytest
 from unittest.mock import patch
-from zettelforge.llm_client import generate, _get_local_llm
+
+import pytest
+
+from zettelforge.llm_client import _get_local_llm, generate
 
 _SKIP_INTEGRATION = pytest.mark.skipif(
     os.environ.get("CI") == "true",
@@ -30,7 +32,6 @@ class TestLocalLLM:
         )
 
     def test_generate_json_extraction(self):
-        import json
 
         result = generate(
             'Extract facts as JSON array: [{"fact": "text", "importance": 1-10}]\n'
@@ -69,12 +70,16 @@ class TestGenerateJsonMode:
         from zettelforge.llm_providers import MockProvider
 
         mock = MockProvider(responses=['{"test": true}'])
-        return mock, patch(
-            "zettelforge.llm_providers.registry.get",
-            return_value=mock,
-        ), patch(
-            "zettelforge.llm_client.get_llm_provider",
-            return_value=provider_name,
+        return (
+            mock,
+            patch(
+                "zettelforge.llm_providers.registry.get",
+                return_value=mock,
+            ),
+            patch(
+                "zettelforge.llm_client.get_llm_provider",
+                return_value=provider_name,
+            ),
         )
 
     def test_json_mode_passed_to_provider(self):

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -57,20 +57,35 @@ class TestLocalLLM:
 
 
 class TestGenerateJsonMode:
-    """Test json_mode parameter (mocked, runs in CI)."""
+    """Verify generate() propagates json_mode and system args to the provider.
 
-    @patch("zettelforge.llm_client._generate_ollama")
-    @patch("zettelforge.llm_client.get_llm_provider", return_value="ollama")
-    def test_json_mode_passed_to_ollama(self, mock_provider, mock_ollama):
-        mock_ollama.return_value = '{"test": true}'
-        generate("test prompt", json_mode=True)
-        _, kwargs = mock_ollama.call_args
-        assert kwargs.get("json_mode") is True
+    Post RFC-002 (Phase 1) these flags flow through the provider registry,
+    so the tests intercept :func:`zettelforge.llm_providers.registry.get`
+    and return a :class:`MockProvider` whose recorded calls we inspect.
+    """
 
-    @patch("zettelforge.llm_client._generate_ollama")
-    @patch("zettelforge.llm_client.get_llm_provider", return_value="ollama")
-    def test_system_prompt_passed_to_ollama(self, mock_provider, mock_ollama):
-        mock_ollama.return_value = "response"
-        generate("test", system="Be a JSON robot")
-        _, kwargs = mock_ollama.call_args
-        assert kwargs.get("system") == "Be a JSON robot"
+    def _with_mock_provider(self, provider_name: str):
+        """Context manager returning (MockProvider, patch) for ``provider_name``."""
+        from zettelforge.llm_providers import MockProvider
+
+        mock = MockProvider(responses=['{"test": true}'])
+        return mock, patch(
+            "zettelforge.llm_providers.registry.get",
+            return_value=mock,
+        ), patch(
+            "zettelforge.llm_client.get_llm_provider",
+            return_value=provider_name,
+        )
+
+    def test_json_mode_passed_to_provider(self):
+        mock, registry_patch, provider_patch = self._with_mock_provider("ollama")
+        with registry_patch, provider_patch:
+            generate("test prompt", json_mode=True)
+        assert mock.calls[-1]["json_mode"] is True
+        assert mock.calls[-1]["prompt"] == "test prompt"
+
+    def test_system_prompt_passed_to_provider(self):
+        mock, registry_patch, provider_patch = self._with_mock_provider("ollama")
+        with registry_patch, provider_patch:
+            generate("test", system="Be a JSON robot")
+        assert mock.calls[-1]["system"] == "Be a JSON robot"

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -25,8 +25,8 @@ from zettelforge.llm_providers.base import LLMProvider
 def reset_registry_instances():
     """Clear cached provider instances between tests.
 
-    Registrations (from zettelforge.llm_providers import time) are
-    preserved; only singleton instances are reset.
+    Registrations created when ``zettelforge.llm_providers`` is imported
+    are preserved; only cached singleton instances are reset.
     """
     registry.reset()
     yield

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -119,15 +119,27 @@ pytest.importorskip("ollama", reason="ollama SDK not installed")
 
 
 class TestOllamaProvider:
+    """Verify OllamaProvider wraps the ollama SDK Client correctly.
+
+    The provider instantiates ``ollama.Client(host=<url>)`` so that
+    configuring ``llm.url`` actually directs requests to the intended
+    server. Tests patch the ``Client`` class and inspect the call made
+    on the returned instance.
+    """
+
     def test_generate_calls_ollama_with_expected_args(self):
         provider = OllamaProvider(model="qwen2.5:3b", url="http://host:11434")
-        with patch("ollama.generate") as mocked:
-            mocked.return_value = {"response": "ok"}
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.generate.return_value = {"response": "ok"}
+
             result = provider.generate(
                 "hello", max_tokens=50, temperature=0.2, system="sys", json_mode=True
             )
+
             assert result == "ok"
-            args, kwargs = mocked.call_args
+            mock_client_cls.assert_called_once_with(host="http://host:11434")
+            args, kwargs = mock_client.generate.call_args
             assert kwargs["model"] == "qwen2.5:3b"
             assert kwargs["prompt"] == "hello"
             assert kwargs["system"] == "sys"
@@ -136,18 +148,28 @@ class TestOllamaProvider:
 
     def test_generate_omits_system_when_absent(self):
         provider = OllamaProvider(model="qwen2.5:3b")
-        with patch("ollama.generate") as mocked:
-            mocked.return_value = {"response": "ok"}
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.generate.return_value = {"response": "ok"}
             provider.generate("hello")
-            _, kwargs = mocked.call_args
+            _, kwargs = mock_client.generate.call_args
             assert "system" not in kwargs
             assert "format" not in kwargs
 
     def test_generate_empty_response_returns_empty_string(self):
         provider = OllamaProvider(model="qwen2.5:3b")
-        with patch("ollama.generate") as mocked:
-            mocked.return_value = {}
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client = mock_client_cls.return_value
+            mock_client.generate.return_value = {}
             assert provider.generate("prompt") == ""
+
+    def test_generate_routes_through_configured_host(self):
+        """``llm.url`` is honoured via ``ollama.Client(host=...)``."""
+        provider = OllamaProvider(model="qwen2.5:3b", url="http://gpu-box:11434")
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client_cls.return_value.generate.return_value = {"response": "ok"}
+            provider.generate("hello")
+            mock_client_cls.assert_called_once_with(host="http://gpu-box:11434")
 
     def test_unknown_kwargs_ignored_at_construction(self):
         # The registry forwards kwargs meant for other providers; they

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -113,6 +113,10 @@ class TestMockProvider:
 
 # ── OllamaProvider ───────────────────────────────────────────────────────────
 
+# The ollama SDK is not a core dependency — skip this class when it is
+# unavailable (e.g. the minimal CI environment without zettelforge[local]).
+pytest.importorskip("ollama", reason="ollama SDK not installed")
+
 
 class TestOllamaProvider:
     def test_generate_calls_ollama_with_expected_args(self):

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -1,0 +1,292 @@
+"""Unit tests for the RFC-002 Phase 1 provider infrastructure.
+
+Covers the registry contract, the built-in providers' behaviour, and
+the refactored ``generate()`` delegation path.
+"""
+
+from __future__ import annotations
+
+import os
+from unittest.mock import patch
+
+import pytest
+
+from zettelforge.llm_providers import (
+    LocalProvider,
+    MockProvider,
+    OllamaProvider,
+    available,
+    registry,
+)
+from zettelforge.llm_providers.base import LLMProvider
+
+
+@pytest.fixture(autouse=True)
+def reset_registry_instances():
+    """Clear cached provider instances between tests.
+
+    Registrations (from zettelforge.llm_providers import time) are
+    preserved; only singleton instances are reset.
+    """
+    registry.reset()
+    yield
+    registry.reset()
+
+
+# ── Protocol contract ────────────────────────────────────────────────────────
+
+
+class TestLLMProviderProtocol:
+    def test_local_satisfies_protocol(self):
+        assert isinstance(LocalProvider(model="x"), LLMProvider)
+
+    def test_ollama_satisfies_protocol(self):
+        assert isinstance(OllamaProvider(model="x"), LLMProvider)
+
+    def test_mock_satisfies_protocol(self):
+        assert isinstance(MockProvider(), LLMProvider)
+
+    def test_builtins_registered(self):
+        names = available()
+        assert "local" in names
+        assert "ollama" in names
+        assert "mock" in names
+
+
+# ── Registry ─────────────────────────────────────────────────────────────────
+
+
+class TestRegistry:
+    def test_get_returns_singleton(self):
+        a = registry.get("mock")
+        b = registry.get("mock")
+        assert a is b
+
+    def test_get_unknown_raises(self):
+        with pytest.raises(ValueError, match="Unknown LLM provider"):
+            registry.get("definitely-not-a-provider")
+
+    def test_register_duplicate_raises(self):
+        with pytest.raises(ValueError, match="already registered"):
+            registry.register("local", LocalProvider)
+
+    def test_reset_clears_instances_not_registrations(self):
+        registry.get("mock")
+        registry.reset()
+        # A fresh instance is created after reset.
+        fresh = registry.get("mock")
+        assert isinstance(fresh, MockProvider)
+        assert "mock" in available()
+
+
+# ── MockProvider ─────────────────────────────────────────────────────────────
+
+
+class TestMockProvider:
+    def test_returns_canned_response(self):
+        mock = MockProvider(responses=["hello"])
+        assert mock.generate("anything") == "hello"
+
+    def test_cycles_through_responses(self):
+        mock = MockProvider(responses=["a", "b"])
+        assert mock.generate("q1") == "a"
+        assert mock.generate("q2") == "b"
+        assert mock.generate("q3") == "a"  # cycles
+
+    def test_records_every_call(self):
+        mock = MockProvider()
+        mock.generate("ask", max_tokens=10, temperature=0.5, system="sys", json_mode=True)
+        assert len(mock.calls) == 1
+        call = mock.calls[0]
+        assert call == {
+            "prompt": "ask",
+            "max_tokens": 10,
+            "temperature": 0.5,
+            "system": "sys",
+            "json_mode": True,
+        }
+
+    def test_default_response_list(self):
+        mock = MockProvider()
+        assert mock.generate("") == "mock response"
+
+
+# ── OllamaProvider ───────────────────────────────────────────────────────────
+
+
+class TestOllamaProvider:
+    def test_generate_calls_ollama_with_expected_args(self):
+        provider = OllamaProvider(model="qwen2.5:3b", url="http://host:11434")
+        with patch("ollama.generate") as mocked:
+            mocked.return_value = {"response": "ok"}
+            result = provider.generate(
+                "hello", max_tokens=50, temperature=0.2, system="sys", json_mode=True
+            )
+            assert result == "ok"
+            args, kwargs = mocked.call_args
+            assert kwargs["model"] == "qwen2.5:3b"
+            assert kwargs["prompt"] == "hello"
+            assert kwargs["system"] == "sys"
+            assert kwargs["format"] == "json"
+            assert kwargs["options"] == {"temperature": 0.2, "num_predict": 50}
+
+    def test_generate_omits_system_when_absent(self):
+        provider = OllamaProvider(model="qwen2.5:3b")
+        with patch("ollama.generate") as mocked:
+            mocked.return_value = {"response": "ok"}
+            provider.generate("hello")
+            _, kwargs = mocked.call_args
+            assert "system" not in kwargs
+            assert "format" not in kwargs
+
+    def test_generate_empty_response_returns_empty_string(self):
+        provider = OllamaProvider(model="qwen2.5:3b")
+        with patch("ollama.generate") as mocked:
+            mocked.return_value = {}
+            assert provider.generate("prompt") == ""
+
+    def test_unknown_kwargs_ignored_at_construction(self):
+        # The registry forwards kwargs meant for other providers; they
+        # must be accepted silently.
+        provider = OllamaProvider(
+            model="qwen2.5:3b",
+            api_key="ignored",
+            timeout=120.0,
+            max_retries=5,
+        )
+        assert provider.name == "ollama"
+
+
+# ── LocalProvider ────────────────────────────────────────────────────────────
+
+
+class TestLocalProvider:
+    def test_unknown_kwargs_ignored_at_construction(self):
+        provider = LocalProvider(
+            model="Qwen/Qwen2.5-3B-Instruct-GGUF",
+            filename="qwen2.5-3b-instruct-q4_k_m.gguf",
+            api_key="ignored",
+            timeout=120.0,
+        )
+        assert provider.name == "local"
+
+    def test_json_mode_appends_instruction_when_no_system(self):
+        provider = LocalProvider()
+        fake_llm = _FakeLlamaCpp()
+        provider._llm = fake_llm
+        provider.generate("prompt", json_mode=True)
+        messages = fake_llm.last_messages
+        assert messages[0]["role"] == "system"
+        assert "JSON" in messages[0]["content"]
+
+    def test_json_mode_extends_existing_system(self):
+        provider = LocalProvider()
+        fake_llm = _FakeLlamaCpp()
+        provider._llm = fake_llm
+        provider.generate("prompt", system="Base prompt.", json_mode=True)
+        system = fake_llm.last_messages[0]["content"]
+        assert system.startswith("Base prompt.")
+        assert "JSON" in system
+
+
+class _FakeLlamaCpp:
+    """Minimal stand-in for llama_cpp.Llama used by LocalProvider tests."""
+
+    def __init__(self) -> None:
+        self.last_messages: list[dict[str, str]] = []
+
+    def create_chat_completion(
+        self,
+        messages: list[dict[str, str]],
+        max_tokens: int,
+        temperature: float,
+    ) -> dict:
+        self.last_messages = messages
+        return {"choices": [{"message": {"content": "  out  "}}]}
+
+
+# ── generate() delegation (llm_client) ───────────────────────────────────────
+
+
+class TestGenerateDelegatesToProvider:
+    def test_generate_uses_configured_provider(self):
+        from zettelforge.llm_client import generate
+
+        canned = MockProvider(responses=["from mock"])
+        with patch.dict(os.environ, {"ZETTELFORGE_LLM_PROVIDER": "mock"}):
+            with patch("zettelforge.llm_providers.registry.get", return_value=canned):
+                result = generate("hi")
+        assert result == "from mock"
+        assert canned.calls[0]["prompt"] == "hi"
+
+    def test_generate_returns_empty_on_recoverable_failure(self):
+        from zettelforge.llm_client import generate
+
+        class _Flaky:
+            name = "flaky"
+
+            def generate(self, *a, **kw):  # noqa: D401 — test stub
+                raise RuntimeError("transient")
+
+        with patch.dict(
+            os.environ,
+            {"ZETTELFORGE_LLM_PROVIDER": "flaky", "ZETTELFORGE_LLM_FALLBACK": ""},
+        ):
+            with patch(
+                "zettelforge.llm_providers.registry.get",
+                side_effect=[_Flaky(), _Flaky()],
+            ):
+                # No fallback configured + primary="flaky" is not "local",
+                # so the implicit fallback also does not kick in.
+                result = generate("hi")
+        assert result == ""
+
+    def test_generate_propagates_import_error(self):
+        from zettelforge.llm_client import generate
+
+        with patch.dict(os.environ, {"ZETTELFORGE_LLM_PROVIDER": "local"}):
+            with patch(
+                "zettelforge.llm_providers.registry.get",
+                side_effect=ImportError("missing sdk"),
+            ):
+                with pytest.raises(ImportError):
+                    generate("hi")
+
+
+# ── Config (RFC-002 extensions) ──────────────────────────────────────────────
+
+
+class TestLLMConfigRepr:
+    def test_api_key_is_redacted(self):
+        from zettelforge.config import LLMConfig
+
+        cfg = LLMConfig(api_key="sk-supersecret")
+        text = repr(cfg)
+        assert "sk-supersecret" not in text
+        assert "***" in text
+
+    def test_empty_api_key_shows_empty_string(self):
+        from zettelforge.config import LLMConfig
+
+        cfg = LLMConfig()
+        assert "api_key=''" in repr(cfg)
+
+
+class TestEnvRefResolution:
+    def test_resolves_env_var(self, monkeypatch):
+        from zettelforge.config import _resolve_env_refs
+
+        monkeypatch.setenv("MY_TEST_KEY", "sk-abc")
+        assert _resolve_env_refs("${MY_TEST_KEY}") == "sk-abc"
+
+    def test_missing_env_var_becomes_empty(self, monkeypatch):
+        from zettelforge.config import _resolve_env_refs
+
+        monkeypatch.delenv("DEFINITELY_NOT_SET_9X", raising=False)
+        assert _resolve_env_refs("${DEFINITELY_NOT_SET_9X}") == ""
+
+    def test_literal_strings_unchanged(self):
+        from zettelforge.config import _resolve_env_refs
+
+        assert _resolve_env_refs("plain") == "plain"
+        assert _resolve_env_refs("") == ""


### PR DESCRIPTION
Implements Phase 1 of [RFC-002](https://github.com/rolandpg/zettelforge/blob/master/docs/rfcs/RFC-002-universal-llm-provider.md) following the NEXUS Protocol (`plan → setup → implement → verify → document`).

## Summary

Refactors the single-file `llm_client.py` (151 LOC of hardcoded provider conditionals) into a `llm_providers/` package with a `Protocol`-based interface, a thread-safe registry, and entry-point discovery. The public `generate()` signature is unchanged, so all 7 existing call sites (`fact_extractor`, `memory_updater`, `synthesis_generator`, `intent_classifier`, `note_constructor`, `entity_indexer`, `memory_evolver`) keep working without modification.

This is the **non-breaking foundation** that Phases 2–5 build on (`openai_compat`, `anthropic`, per-call `provider=` override, Azure OpenAI).

## What lands

### `src/zettelforge/llm_providers/` — new package

- `base.py` — `@runtime_checkable Protocol` defining `LLMProvider.generate()`. PEP 544, no forced inheritance.
- `registry.py` — thread-safe `register` / `get` / `available` / `reset`. Singleton instances per provider name.
- `local_provider.py` — llama-cpp-python, lifted from `_generate_local` with lazy model loading preserved.
- `ollama_provider.py` — Ollama HTTP, lifted from `_generate_ollama`.
- `mock_provider.py` — canned responses + full call recording for tests.
- `__init__.py` — registers built-ins, discovers third-party providers via the `zettelforge.llm_providers` entry-point group.

### `llm_client.py` — rewrite

Public `generate()` resolves the configured provider from the registry and delegates. Implicit `local → ollama` fallback preserved for backward compatibility. Old private helpers (`_get_local_llm`, `_generate_local`, `_generate_ollama`) retained as thin shims so any external patches still work.

### `config.LLMConfig` — expanded

New fields: `api_key`, `timeout`, `max_retries`, `fallback`, `extra`. `api_key` supports `${ENV_VAR}` references (new `_resolve_env_refs`) and is **redacted from `repr()`** via a `__repr__` override. New env var overrides: `ZETTELFORGE_LLM_API_KEY`, `ZETTELFORGE_LLM_TIMEOUT`, `ZETTELFORGE_LLM_MAX_RETRIES`, `ZETTELFORGE_LLM_FALLBACK`.

### Tests

- `tests/test_llm_providers.py` — 27 new tests covering the protocol, registry contract, every built-in provider, `generate()` delegation, `__repr__` redaction, and `${VAR}` env resolution.
- `tests/test_llm_client.py` — 2 tests migrated from white-box patches of `_generate_ollama` to the cleaner registry-based `MockProvider` pattern.

### Docs

- `CHANGELOG.md [Unreleased]` — Phase 1 entry.
- `docs/rfcs/RFC-002-universal-llm-provider.md` — new **Implementation Status** table and Phase 1 verification snapshot.
- `docs/reference/configuration.md` — documents every new `LLMConfig` field and env var.
- `config.default.yaml` — expanded `llm:` section with provider selection guidance and `${ENV_VAR}` examples.

### Other

- `.gitignore` hardened per GOV-023 — added `.env.*`, `*.key`, `*.pem`.

## NEXUS Protocol compliance

| Step | Role | Output |
|------|------|--------|
| 1. plan | coder | Identified 7 call sites, 12 files to modify, GOV checklist |
| 2. setup | coder | Branch off origin/master, `.gitignore` audited and hardened, baseline ruff+pytest green |
| 3. implement | coder | 6 new modules, 1 test file, llm_client refactor, config expansion |
| 4. verify | verifier | 29 new tests passing, 51 scoped tests passing, 0 regressions, mypy clean, no secrets in diff |
| 5. document | docwriter | CHANGELOG + RFC + config reference updated |

## Governance

- **GOV-002** commit format: `feat(llm):`, `docs(rfc-002):`
- **GOV-003** type hints, `Protocol`, `dataclass` throughout; `mypy --disallow-untyped-defs` clean on `llm_providers/`
- **GOV-006** code review checklist: no hardcoded values, structured logging, thread safety
- **GOV-007** test coverage: 27 new tests covering every new code path
- **GOV-014** secret handling: `api_key` redacted in `__repr__`, `${VAR}` resolution, `ZETTELFORGE_LLM_API_KEY` env override, no secrets in committed code
- **GOV-023** `.gitignore` hardened; README/LICENSE/.gitignore all present

## Backward compatibility

- `generate()` signature unchanged — no call-site changes required.
- All existing env vars (`ZETTELFORGE_LLM_PROVIDER`, `ZETTELFORGE_LLM_MODEL`, `ZETTELFORGE_LLM_URL`) continue to work.
- `ZETTELFORGE_OLLAMA_MODEL` still honoured as fallback (deprecation path scheduled for v2.5→v3.0 per RFC).
- Existing `config.yaml` files with `provider: ollama` / `model: qwen3.5:9b` work unchanged.
- Implicit `local → ollama` fallback preserved.

## Follow-ups (not in this PR)

- Phase 2 — `openai_compat` provider with `Retry-After` handling.
- Phase 3 — `anthropic` native SDK provider.
- Phase 5 — per-call `generate(..., provider="anthropic")` override and Azure OpenAI.

## Test plan

- [ ] CI all green (lint, test on 3.12 and 3.13, governance)
- [ ] `python -c "from zettelforge.llm_providers import available; print(available())"` shows `['local', 'mock', 'ollama']`
- [ ] Existing `generate()` call sites (fact extractor, memory updater, etc.) continue to produce identical output for `provider: ollama`

🤖 Generated with [Claude Code](https://claude.com/claude-code)