### PR TITLE
seo: P0 fixes from Phase 0 audit — README hook, CTA row, docs OG/JSON-LD

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,25 +2,21 @@
 
 **The only agentic memory system built for cyber threat intelligence.**
 
-Give your AI agents persistent memory with entity extraction, knowledge graphs, and STIX ontology -- no cloud, no API keys, works offline.
-
+Persistent memory for AI agents and Claude Code — with CTI entity extraction, STIX knowledge graphs, threat-actor alias resolution, and offline-first RAG. MCP server included. No cloud, no API keys.
 
 [![PyPI](https://img.shields.io/pypi/v/zettelforge)](https://pypi.org/project/zettelforge/)
-[![Downloads](https://static.pepy.tech/badge/zettelforge)](https://pepy.tech/projects/zettelforge)
-[![Stars](https://img.shields.io/github/stars/rolandpg/zettelforge)](https://github.com/rolandpg/zettelforge/stargazers)
-[![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
+[![Downloads/month](https://static.pepy.tech/personalized-badge/zettelforge?period=month&units=international_system&left_color=grey&right_color=blue&left_text=downloads%2Fmonth)](https://pepy.tech/projects/zettelforge)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
+[![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/rolandpg/zettelforge/actions/workflows/ci.yml/badge.svg)](https://github.com/rolandpg/zettelforge/actions)
-[![Contributors](https://img.shields.io/github/contributors/rolandpg/zettelforge)](https://github.com/rolandpg/zettelforge/graphs/contributors)
-[![Last Commit](https://img.shields.io/github/last-commit/rolandpg/zettelforge)](https://github.com/rolandpg/zettelforge/commits/master)
-[![SafeSkill](https://safeskill.dev/api/badge/rolandpg-zettelforge)](https://safeskill.dev/scan/rolandpg-zettelforge)
+
+**[⭐ Star](https://github.com/rolandpg/zettelforge) · [📦 `pip install zettelforge`](https://pypi.org/project/zettelforge/) · [📖 Docs](https://docs.threatrecall.ai/) · [🧪 Hosted](https://threatrecall.ai)**
 
 <p align="center">
-<a href="https://www.buymeacoffee.com/xypher22pr0" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-green.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>
+  <img src="https://raw.githubusercontent.com/rolandpg/zettelforge/master/docs/assets/demo.gif" width="720" alt="ZettelForge demo — CTI agentic memory in action">
 </p>
-<p align="center">
-  <img src="docs/assets/demo.gif" width="720" alt="ZettelForge demo — CTI agentic memory in action">
-</p>
+
+> If ZettelForge fits a CTI workflow you run, a star is the fastest signal that this category is worth continuing to invest in.
 
 ## Why ZettelForge?
 
@@ -44,7 +40,7 @@ ZettelForge was built from the ground up for analysts who think in threat graphs
 
 ## Data Pipeline
 <p align="center">
-  <img src="docs/assets/zettelforge_architecture.svg" width="720" alt="ZettelForge">
+  <img src="https://raw.githubusercontent.com/rolandpg/zettelforge/master/docs/assets/zettelforge_architecture.svg" width="720" alt="ZettelForge architecture — Extract, Graph, Embed, Recall pipeline">
 </p>
 
 
@@ -216,6 +212,12 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for development setup.
 MIT -- See [LICENSE](LICENSE).
 
 **Made by Patrick Roland**.
+
+## Support the Project
+
+ZettelForge is MIT-licensed. If it's useful in your workflow and you'd like to help keep it maintained:
+
+<a href="https://www.buymeacoffee.com/xypher22pr0" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-green.png" alt="Buy Me a Coffee" style="height: 40px !important;width: 145px !important;" ></a>
 
 ## Acknowledgments
 

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -1,0 +1,81 @@
+{% extends "base.html" %}
+
+{#
+  Custom theme overrides for SEO:
+  - Canonical URL per page
+  - OpenGraph + Twitter card metadata
+  - JSON-LD SoftwareApplication schema on the home page
+
+  Registered via `theme.custom_dir: docs/overrides` in mkdocs.yml.
+#}
+
+{% block extrahead %}
+  {{ super() }}
+
+  {# ---------- Canonical URL ---------- #}
+  {% if page and page.canonical_url %}
+  <link rel="canonical" href="{{ page.canonical_url }}">
+  {% endif %}
+
+  {# ---------- OpenGraph ---------- #}
+  {% set og_title = page.meta.title if page and page.meta and page.meta.title else (page.title ~ " — " ~ config.site_name if page and page.title else config.site_name) %}
+  {% set og_description = page.meta.description if page and page.meta and page.meta.description else config.site_description %}
+  {% set og_image = page.meta.image if page and page.meta and page.meta.image else (config.site_url ~ "assets/social-preview.png") %}
+  {% set og_url = page.canonical_url if page and page.canonical_url else config.site_url %}
+
+  <meta property="og:type" content="article">
+  <meta property="og:site_name" content="{{ config.site_name }}">
+  <meta property="og:title" content="{{ og_title }}">
+  <meta property="og:description" content="{{ og_description }}">
+  <meta property="og:url" content="{{ og_url }}">
+  <meta property="og:image" content="{{ og_image }}">
+  <meta property="og:image:width" content="1280">
+  <meta property="og:image:height" content="640">
+
+  {# ---------- Twitter card ---------- #}
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="{{ og_title }}">
+  <meta name="twitter:description" content="{{ og_description }}">
+  <meta name="twitter:image" content="{{ og_image }}">
+  <meta name="twitter:site" content="@Deuslogica">
+  <meta name="twitter:creator" content="@Deuslogica">
+
+  {# ---------- JSON-LD: SoftwareApplication on the home page ---------- #}
+  {% if page and page.is_homepage %}
+  <script type="application/ld+json">
+  {
+    "@context": "https://schema.org",
+    "@type": "SoftwareApplication",
+    "name": "ZettelForge",
+    "description": "Agentic memory system for cyber threat intelligence. STIX 2.1 knowledge graphs, threat-actor alias resolution, offline-first RAG, MCP server for Claude Code.",
+    "url": "{{ config.site_url }}",
+    "applicationCategory": "SecurityApplication",
+    "applicationSubCategory": "Cyber Threat Intelligence",
+    "operatingSystem": "Linux, macOS, Windows",
+    "softwareVersion": "2.2.0",
+    "license": "https://opensource.org/licenses/MIT",
+    "isAccessibleForFree": true,
+    "programmingLanguage": "Python",
+    "downloadUrl": "https://pypi.org/project/zettelforge/",
+    "codeRepository": "https://github.com/rolandpg/zettelforge",
+    "author": {
+      "@type": "Person",
+      "name": "Patrick Roland",
+      "url": "https://github.com/rolandpg"
+    },
+    "publisher": {
+      "@type": "Organization",
+      "name": "ThreatRecall",
+      "url": "https://threatrecall.ai"
+    },
+    "offers": {
+      "@type": "Offer",
+      "price": "0",
+      "priceCurrency": "USD",
+      "availability": "https://schema.org/InStock"
+    },
+    "keywords": "agentic memory, cyber threat intelligence, CTI, STIX, knowledge graph, MCP server, Claude Code, RAG, offline-first, LLM memory"
+  }
+  </script>
+  {% endif %}
+{% endblock %}

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -23,7 +23,8 @@
   {% set og_image = page.meta.image if page and page.meta and page.meta.image else (config.site_url ~ "assets/social-preview.png") %}
   {% set og_url = page.canonical_url if page and page.canonical_url else config.site_url %}
 
-  <meta property="og:type" content="article">
+  {% set og_type = "website" if page and page.is_homepage else "article" %}
+  <meta property="og:type" content="{{ og_type }}">
   <meta property="og:site_name" content="{{ config.site_name }}">
   <meta property="og:title" content="{{ og_title }}">
   <meta property="og:description" content="{{ og_description }}">
@@ -52,7 +53,7 @@
     "applicationCategory": "SecurityApplication",
     "applicationSubCategory": "Cyber Threat Intelligence",
     "operatingSystem": "Linux, macOS, Windows",
-    "softwareVersion": "2.2.0",
+    "softwareVersion": "{{ config.extra.version }}",
     "license": "https://opensource.org/licenses/MIT",
     "isAccessibleForFree": true,
     "programmingLanguage": "Python",

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -27,6 +27,11 @@ plugins:
   - search
   - meta
 
+extra:
+  # Sourced by docs/overrides/main.html for JSON-LD SoftwareApplication.
+  # Bump on each release so schema.org metadata stays in sync with PyPI.
+  version: "2.2.1"
+
 extra_css:
   - stylesheets/extra.css
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,11 +1,13 @@
 site_name: ZettelForge Documentation
-site_url: https://docs.threatrecall.ai
-site_description: "ZettelForge — agentic memory for cyber threat intelligence"
+site_url: https://docs.threatrecall.ai/
+site_description: "ZettelForge — agentic memory for Python agents with CTI entity extraction, STIX knowledge graphs, threat-actor alias resolution, and an MCP server. Offline-first, MIT-licensed."
+site_author: Patrick Roland
 repo_url: https://github.com/rolandpg/zettelforge
 repo_name: rolandpg/zettelforge
 
 theme:
   name: material
+  custom_dir: docs/overrides
   palette:
     scheme: slate
     primary: custom


### PR DESCRIPTION
Ships the file-level subset of the nine P0 SEO fixes identified in the NEXUS Phase 0 audit (`/home/rolandpg/projects/zf-visibility/phase-0/github-seo-audit.md`).

Repo-metadata fixes (description, topic tags, release-note rewrite, social-preview upload, About-panel verify) are **NOT** in this PR — they are documented in the Phase 3 report at `/home/rolandpg/projects/zf-visibility/phase-3/week-1/seo-p0-fixes-report.md` and run as one-shot `gh repo edit` / GitHub Settings commands.

## What's in this PR

### `docs(readme)`: P0 above-fold rewrite (commit d719812)
- Hook line rewritten to land CTI, STIX, MCP server, RAG, and Claude Code in the first ~40 words.
- Badges trimmed 9 → 5; Downloads switched to /month framing.
- Star / pip install / Docs / Hosted CTA row added directly under the badges.
- One explicit star CTA under the demo GIF, brand-voice §2.4 approved copy.
- Relative image paths (`docs/assets/*`) → absolute `raw.githubusercontent.com` URLs so demo.gif and architecture.svg render on PyPI.
- Buy-Me-a-Coffee demoted to a `## Support the Project` section near the License block (kept, not removed — just not the first ask).

### `feat(docs)`: OG / canonical / JSON-LD on docs.threatrecall.ai (commit 33afd94)
- `mkdocs.yml`: register `docs/overrides` as `theme.custom_dir`, tighten `site_description`, add `site_author`, trailing slash on `site_url`.
- `docs/overrides/main.html` (new): canonical link per page + full OpenGraph + Twitter card (summary_large_image, @Deuslogica) + `SoftwareApplication` JSON-LD scoped to the home page only.
- No new Python deps. The heavier `mkdocs-material[imaging]` + `social` plugin is not required (can be layered later for per-page auto-generated OG images).

## What this PR intentionally does NOT touch

- Comparison table (Brand Guardian territory)
- Demo GIF (recently added in #55)
- `docs/llms.txt` (rewritten in #55)
- `pyproject.toml` / `CHANGELOG.md` (separate PR #57 scope — v2.2.1 metadata fix)

## Coordination with PR #57

PR #57 and this PR both touch `README.md` with the same absolute-URL image fix. Whichever merges second sees the edits as no-ops (same strings). Zero true conflict.

## Verification

- README renders on GitHub with the new CTA row and demo GIF loading from the absolute URL.
- `curl -s https://docs.threatrecall.ai/ | grep -E 'og:|twitter:|canonical|application/ld\+json'` returns all four families after `mkdocs gh-deploy`.
- Google Rich Results Test detects `SoftwareApplication` with no errors.
- An interior page (e.g. `/tutorials/01-quickstart/`) renders OG + canonical but NO JSON-LD (the `is_homepage` guard).

## Patrick post-merge actions (NOT part of this PR)

Detailed in `/home/rolandpg/projects/zf-visibility/phase-3/week-1/seo-p0-fixes-report.md`:

- `gh repo edit rolandpg/zettelforge --description "Agentic memory for CTI in Python — STIX knowledge graphs, threat-actor alias resolution, offline-first RAG, MCP server for Claude Code and LangChain agents"`
- Remove 4 low-signal topics, add 4 missing high-signal topics (20-tag target set)
- Upload `docs/assets/social-preview.png` via GitHub Settings → Social preview
- `gh release edit v2.2.0 --notes-file …` with the pre-written SEO-friendly body

## Refs

- `/home/rolandpg/projects/zf-visibility/phase-0/github-seo-audit.md`
- `/home/rolandpg/projects/zf-visibility/phase-1/brand-voice.md`
- `/home/rolandpg/projects/zf-visibility/phase-3/week-1/seo-p0-fixes-report.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code) via NEXUS Protocol Phase 3