### PR TITLE
chore(deps): migrate langchain_retriever to Pydantic V2 ConfigDict (AI-7)

### DIFF
--- a/src/zettelforge/integrations/langchain_retriever.py
+++ b/src/zettelforge/integrations/langchain_retriever.py
@@ -23,7 +23,7 @@ from typing import Any, Dict, List, Optional
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
 from langchain_core.retrievers import BaseRetriever
-from pydantic import Field
+from pydantic import ConfigDict, Field
 
 from zettelforge.memory_manager import MemoryManager
 
@@ -42,16 +42,13 @@ class ZettelForgeRetriever(BaseRetriever):
         exclude_superseded: Whether to filter superseded notes (default True).
     """
 
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     memory_manager: MemoryManager = Field(exclude=True)
     k: int = 10
     domain: Optional[str] = None
     include_links: bool = True
     exclude_superseded: bool = True
-
-    class Config:
-        """Pydantic config — allow arbitrary types for MemoryManager."""
-
-        arbitrary_types_allowed = True
 
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun


### PR DESCRIPTION
## Summary

Stream D of the test-suite remediation (audit: `docs/superpowers/research/2026-04-17-test-suite-audit.md`, action item **AI-7**).

CI `test-3.12` was emitting:

> `PydanticDeprecatedSince20: Support for class-based Config is deprecated, use ConfigDict instead. Deprecated in Pydantic V2.0 to be removed in V3.0.`

Source: `src/zettelforge/integrations/langchain_retriever.py:31` — `class ZettelForgeRetriever(BaseRetriever)` was using the V1-style `class Config:` block. When Pydantic V3 ships this becomes a hard failure.

This PR is a purely syntactic migration to the V2 canonical form. No behavior change.

## Before / after

```diff
-from pydantic import Field
+from pydantic import ConfigDict, Field
 ...
 class ZettelForgeRetriever(BaseRetriever):
     ...
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+
     memory_manager: MemoryManager = Field(exclude=True)
     k: int = 10
     domain: Optional[str] = None
     include_links: bool = True
     exclude_superseded: bool = True

-    class Config:
-        """Pydantic config — allow arbitrary types for MemoryManager."""
-
-        arbitrary_types_allowed = True
-
```

The only V1 flag in the original block was `arbitrary_types_allowed = True` (needed so Pydantic accepts the non-BaseModel `MemoryManager` as a field type). It is preserved as `ConfigDict(arbitrary_types_allowed=True)`. No other V1 patterns (`orm_mode`, `allow_mutation`, `validate_all`) were present in the file.

## Verification

Elevating the deprecation to an error proves the migration worked (the raw warning never fires on our migrated class):

```
VENV=/tmp/nexus-stream-d-venv
uv venv --python 3.12 --clear "$VENV"
uv pip install --python "$VENV/bin/python" -q -e .
uv pip install --python "$VENV/bin/python" -q pytest pytest-cov pytest-asyncio pytest-timeout ollama langchain-core
ZETTELFORGE_LLM_PROVIDER=mock ZETTELFORGE_BACKEND=sqlite ZETTELFORGE_EMBEDDING_PROVIDER=fastembed \
  "$VENV/bin/python" -m pytest tests/test_langchain_retriever.py -v \
  -W "error::pydantic.PydanticDeprecatedSince20" --timeout=30 --timeout-method=thread \
  --deselect tests/test_langchain_retriever.py::TestZettelForgeRetriever::test_metadata_fields
```

Output (tail):

```
tests/test_langchain_retriever.py::TestZettelForgeRetriever::test_invoke_returns_documents PASSED [ 20%]
tests/test_langchain_retriever.py::TestZettelForgeRetriever::test_k_limits_results       PASSED [ 40%]
tests/test_langchain_retriever.py::TestZettelForgeRetriever::test_domain_filter          PASSED [ 60%]
tests/test_langchain_retriever.py::TestZettelForgeRetriever::test_empty_query            PASSED [ 80%]
tests/test_langchain_retriever.py::TestZettelForgeRetriever::test_serializable_config    PASSED [100%]
================== 5 passed, 1 deselected, 1 warning in 7.72s ==================
```

5/5 applicable tests pass with the warning elevated to an error — no `PydanticDeprecatedSince20` is raised.

**Note on the deselected test:** `test_metadata_fields` fails on this branch, but I confirmed via `git stash` that it also fails on `origin/master` with the identical signature (`'NoneType' object has no attribute 'execute'` in `sqlite_backend.get_note_by_id`, recall returning 0 results). This is a pre-existing sqlite/LanceDB flake that belongs to a separate remediation stream and is explicitly out of scope for AI-7.

## Scope constraints honored

- Touches **only** `src/zettelforge/integrations/langchain_retriever.py` (3 insertions, 6 deletions).
- No behavior change: `arbitrary_types_allowed` preserved.
- No new dependencies (`langchain-core` was already an optional integration dep).
- Did not hunt for V1 patterns in other files — staying surgical per the audit.

## Test plan

- [x] `pytest tests/test_langchain_retriever.py -W error::pydantic.PydanticDeprecatedSince20` passes (5/5 applicable)
- [ ] CI `test-3.12` job runs green on this branch (awaiting CI)
- [ ] No new deprecation warnings introduced elsewhere (verified locally: only prior test-run warning is an unrelated HuggingFace `UserWarning` from fastembed)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>