### PR TITLE
test: resolve two_phase_e2e xfails (AI-3, AI-4)

### DIFF
--- a/tests/test_two_phase_e2e.py
+++ b/tests/test_two_phase_e2e.py
@@ -40,18 +40,20 @@ class TestRememberWithExtraction:
         )
         assert len(results) == 0
 
-    @pytest.mark.xfail(
-        reason="remember_with_extraction calls generate 4x; mock side_effect count and NOOP/UPDATE routing need rework"
-    )
     @patch("zettelforge.llm_client.generate")
     def test_update_supersedes_old_note(self, mock_generate, fresh_mm):
         old_note, _ = fresh_mm.remember("APT28 uses DROPBEAR malware", domain="cti")
 
-        # Mock returns: extraction → decision → any extra generate calls get empty
-        mock_generate.side_effect = [
-            '[{"fact": "APT28 no longer uses DROPBEAR", "importance": 9}]',
-            '{"operation": "UPDATE", "reason": "refines old intel"}',
-        ] + [""] * 10  # Extra calls (synthesis, causal, etc.) get empty string
+        # Prompt-aware mock: responds based on prompt content rather than call order.
+        # This is robust to call count drift (retries, background enrichment workers).
+        def _route(prompt, *args, **kwargs):
+            if "Extract the most important facts" in prompt:
+                return '[{"fact": "APT28 no longer uses DROPBEAR", "importance": 9}]'
+            if "Compare this new fact" in prompt:
+                return '{"operation": "UPDATE", "reason": "refines old intel"}'
+            return ""
+
+        mock_generate.side_effect = _route
         results = fresh_mm.remember_with_extraction(
             "APT28 has dropped DROPBEAR from their toolkit.",
             domain="cti",
@@ -62,18 +64,19 @@ class TestRememberWithExtraction:
         refreshed_old = fresh_mm.store.get_note_by_id(old_note.id)
         assert refreshed_old.links.superseded_by == new_note.id
 
-    @pytest.mark.xfail(
-        reason="remember_with_extraction calls generate 4x; mock side_effect count and NOOP routing need rework"
-    )
     @patch("zettelforge.llm_client.generate")
     def test_noop_stores_nothing_new(self, mock_generate, fresh_mm):
         fresh_mm.remember("APT28 targets NATO", domain="cti")
         initial_count = fresh_mm.store.count_notes()
 
-        mock_generate.side_effect = [
-            '[{"fact": "APT28 targets NATO", "importance": 6}]',
-            '{"operation": "NOOP", "reason": "already stored"}',
-        ] + [""] * 10  # Extra calls get empty string
+        def _route(prompt, *args, **kwargs):
+            if "Extract the most important facts" in prompt:
+                return '[{"fact": "APT28 targets NATO", "importance": 6}]'
+            if "Compare this new fact" in prompt:
+                return '{"operation": "NOOP", "reason": "already stored"}'
+            return ""
+
+        mock_generate.side_effect = _route
         results = fresh_mm.remember_with_extraction(
             "APT28 targets NATO allies.",
             domain="cti",


### PR DESCRIPTION
## AI-3 — generate() call count audit

Traced every synchronous call site reaching `zettelforge.llm_client.generate` from `MemoryManager.remember_with_extraction`:

| Caller | File | Calls per `remember_with_extraction` |
|---|---|---|
| `FactExtractor.extract` | `src/zettelforge/fact_extractor.py:46` | 1 |
| `MemoryUpdater.decide` (per fact) | `src/zettelforge/memory_updater.py:45` | 1 × N facts |
| `MemoryUpdater.decide` retry (on parse fail) | `src/zettelforge/memory_updater.py:51` | 0–1 × N facts |
| `MemoryUpdater.apply` → `self.mm.remember` | `src/zettelforge/memory_manager.py:136` | 0 (sync path defers all LLM work to background thread) |

**Synchronous total for a single-fact input: 2 calls** (1 extract + 1 decide).

The xfail reason ("calls generate 4x") was an undercount of the real problem: background daemon threads (`_enrichment_worker` in `memory_manager.py:127`) share the module-level `generate` patch and race the foreground test, consuming `side_effect` entries non-deterministically. Each `remember()` enqueues up to 3 jobs (`_run_enrichment` causal extraction, `_run_llm_ner`, `_run_evolution`), each of which calls `generate` if the daemon drains before the patch context ends.

No production bug — this is purely a test/mock-layer issue.

## AI-4 — Option chosen: Fix (prompt-aware side_effect)

**Why this option:** Smallest diff that restores real coverage and is robust to call-count drift.

- Option 2 (delete) rejected: `test_memory_updater.py` tests UPDATE/NOOP routing at the `MemoryUpdater` level with direct mocking, but does not cover the end-to-end path through `remember_with_extraction` (extraction → decide → apply → supersession). Deleting loses meaningful integration coverage.
- Option 3 (rewrite on mock provider) rejected: larger diff, couples Stream C to Stream B's provider-seeding API, and still has the same background-thread race.
- Option 1 (fix): replaced the brittle call-count-indexed `side_effect` list with a routing function that inspects the prompt text (`"Extract the most important facts"` vs `"Compare this new fact"`). Background-thread generate() calls fall through to `return ""` and no-op gracefully through the existing retry/exception handlers. Robust to retries and enrichment-worker races.

Diff: `tests/test_two_phase_e2e.py`, +18 / -15, single file. No `src/` changes.

## Verification

```
$ ZETTELFORGE_LLM_PROVIDER=mock ZETTELFORGE_BACKEND=sqlite ZETTELFORGE_EMBEDDING_PROVIDER=fastembed \
    /tmp/nexus-stream-c-venv/bin/python -m pytest tests/test_two_phase_e2e.py -v --timeout=30 --timeout-method=thread

tests/test_two_phase_e2e.py::TestRememberWithExtraction::test_extracts_and_stores_facts PASSED  [ 20%]
tests/test_two_phase_e2e.py::TestRememberWithExtraction::test_returns_empty_for_low_importance PASSED  [ 40%]
tests/test_two_phase_e2e.py::TestRememberWithExtraction::test_update_supersedes_old_note PASSED  [ 60%]
tests/test_two_phase_e2e.py::TestRememberWithExtraction::test_noop_stores_nothing_new PASSED  [ 80%]
tests/test_two_phase_e2e.py::TestRememberWithExtraction::test_method_exists PASSED  [100%]

========================= 5 passed, 1 warning in 3.73s =========================
```

Before: 3 passed, 2 xfailed. After: 5 passed, 0 xfailed. No tests re-marked xfail.