### PR TITLE
test: eliminate flakes (AI-5, AI-6) + deprecation warnings (AI-8, AI-9)

### DIFF
--- a/tests/test_causal_extraction.py
+++ b/tests/test_causal_extraction.py
@@ -83,7 +83,7 @@ def test_causal_extraction():
         print(f"  {path_str}")
 
     print("\n=== Test Complete ===")
-    return len(causal_edges) > 0
+    assert len(causal_edges) > 0
 
 
 if __name__ == "__main__":

--- a/tests/test_core.py
+++ b/tests/test_core.py
@@ -77,7 +77,7 @@ class TestEntityRecall:
     def test_recall_cve_returns_notes(self, temp_memory):
         """CVE recall returns matching notes."""
         mm = MemoryManager(jsonl_path=f"{temp_memory}/notes.jsonl")
-        mm.remember("CVE-2024-3094 is a backdoor in XZ Utils", domain="security_ops")
+        mm.remember("CVE-2024-3094 is a backdoor in XZ Utils", domain="security_ops", sync=True)
 
         results = mm.recall_cve("CVE-2024-3094", k=5)
 


### PR DESCRIPTION
## Summary

Executes Stream A of the 2026-04-17 test suite audit. Two of the four audit items are shipped; the other two are reported back per the "stop and report if non-trivial" constraint.

## Shipped

### AI-6 — test_recall_cve_returns_notes flake (commit 8ffdc99)
- File: `tests/test_core.py:80`
- Fix: add `sync=True` to the seed `mm.remember()` so the entity index and vector write complete before `recall_cve()` runs.
- Verification (before): `pytest --count=20` flaked 3/20.
- Verification (after): `pytest --count=20` = **20/20 pass**.

```
$ pytest tests/test_core.py::TestEntityRecall::test_recall_cve_returns_notes --count=20
20 passed, 1 warning in 1.32s
```

### AI-8 — test_causal_extraction pytest return warning (commit d9a46d2)
- File: `tests/test_causal_extraction.py:86`
- Fix: replace `return len(causal_edges) > 0` with `assert len(causal_edges) > 0`. Test preserves its original intent; the `__main__` block still exits non-zero on failure because a failed assert raises.
- Verification: `pytest -W error::pytest.PytestReturnNotNoneWarning` passes with **no warning** firing.

```
$ pytest tests/test_causal_extraction.py -v -W error::pytest.PytestReturnNotNoneWarning
1 passed, 1 warning in 4.50s
```

## Stopped and reporting back (per constraint)

### AI-5 — test_apply_delete_marks_superseded flake
The audit's advertised minimal fix (`sync=True` on the seed `mm.remember()`) is **not sufficient**: `pytest --count=20` still shows ~1-3 failures. Diagnostic tracing shows the race is **not** the seed's enrichment write — it's between `updater.apply()`'s own inner async `mm.remember()` call (line 89 of `src/zettelforge/memory_updater.py`) and the background enrichment worker thread, which sporadically reads a `notes` row mid-write and raises a pydantic `ValidationError` (NULL `version` / `updated_at` / etc. in the SELECT result). Concrete evidence:

```
enrichment_worker_error: ValidationError: 1 validation error for MemoryNote
  version  Input should be a valid integer [type=int_type, input_value=None]
  at sqlite_backend.py:175 _row_to_note
```

The fix requires either (a) making `updater.apply()` itself honor `sync=True`, or (b) serializing reads against `_write_lock` in `SQLiteBackend.get_note_by_id` — both are source-side changes beyond the audit's specified test-only scope, so I stopped per the "trivial change only" constraint.

### AI-9 — lancedb table_names() deprecation
- `grep -rn "\.table_names()" src/zettelforge/` returns **zero hits**; `vector_memory.py:192` and `vector_retriever.py:140` already call `.list_tables()`.
- The residual `DeprecationWarning` originates *inside* lancedb's own `db.py:825 __len__` and `db.py:828 __contains__`, which internally invoke their own deprecated `table_names()`. This is a library-side bug (reproducible with `lancedb==0.26.x` in the installed venv) and cannot be fixed by renaming anything in our source.

Both AI-5 and AI-9 should be re-scoped as separate follow-ups with the investigation above attached.

## Test plan

- [x] `pytest tests/test_core.py::TestEntityRecall::test_recall_cve_returns_notes --count=20` — 20/20 pass
- [x] `pytest tests/test_causal_extraction.py -W error::pytest.PytestReturnNotNoneWarning` — 1 pass, no warning
- [ ] Downstream: re-open AI-5 as a source-level fix in `memory_updater.py` or `sqlite_backend.py`
- [ ] Downstream: re-open AI-9 as a lancedb pin/upgrade task (library-side warning)