### PR TITLE
fix(sqlite): wrap reader methods in _write_lock (closes #68)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,38 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Fixed
+
+- **SQLite backend concurrency** — 16 reader methods in
+  `SQLiteBackend` (`get_note_by_id`, `get_note_by_source_ref`,
+  `iterate_notes`, `get_notes_by_domain`, `get_recent_notes`,
+  `count_notes`, `get_kg_node`, `get_kg_node_by_id`,
+  `get_kg_neighbors`, `traverse_kg`, `get_entity_timeline`,
+  `get_changes_since`, `get_causal_edges`, `get_incoming_causal`,
+  `get_note_ids_for_entity`, `search_entities`) were executing
+  `SELECT` statements without holding `_write_lock`, while writers
+  acquired it. Under concurrent background enrichment, readers could
+  observe a partially-written row and raise `pydantic.ValidationError`
+  on NULL columns. Each reader now wraps its SQL execute+fetch block
+  in `with self._write_lock:` (RLock, reentrant-safe). Closes #68.
+  Eliminates the `test_apply_delete_marks_superseded` flake and
+  prevents the same race from surfacing in production
+  `recall()`-during-write paths.
+
+### Changed
+
+- **Test suite hygiene** — post-v2.3.0 audit (see
+  `docs/superpowers/research/2026-04-17-test-suite-audit.md`)
+  converted 10 CI-skipped LLM tests to the mock provider (RFC-002
+  Phase 1), resolved both remaining `xfail` tests via prompt-routed
+  mocks, eliminated two long-standing flakes
+  (`test_recall_cve_returns_notes`, `test_apply_delete_marks_superseded`),
+  prepped `langchain_retriever` for Pydantic V3 by migrating to
+  `ConfigDict`, and reinstated meaningful causal-edge validation via
+  mock-seeded triples + `SQLiteBackend.get_causal_edges` query. Net
+  test-suite delta: 280 passed / 17 skipped / 2 xfailed → 305 passed
+  / 10 skipped / 0 xfailed on test-3.12.
+
 ## [2.3.0] - 2026-04-17
 
 Pluggable LLM provider infrastructure (RFC-002 Phase 1), MCP server

--- a/docs/how-to/migrate-jsonl-to-sqlite.md
+++ b/docs/how-to/migrate-jsonl-to-sqlite.md
@@ -34,7 +34,9 @@ directory on first use.
 1. Copies `notes.jsonl`, `kg_nodes.jsonl`, `kg_edges.jsonl`, and
    `entity_index.json` into `<data_dir>/backup_pre_sqlite/`.
 2. Creates or re-uses `<data_dir>/zettelforge.db` via
-   `SQLiteBackend` (WAL mode, 33-method ABC).
+   `SQLiteBackend` (WAL mode, 33-method ABC). Reads and writes are
+   serialized through an internal `threading.RLock`, so concurrent
+   background enrichment does not expose mid-write rows to readers.
 3. Writes every note with `INSERT OR REPLACE`, every entity with
    `INSERT OR IGNORE`, and upserts knowledge-graph nodes and edges.
 4. Leaves the original JSONL files on disk so you can roll back.

--- a/docs/superpowers/research/2026-04-17-test-suite-audit.md
+++ b/docs/superpowers/research/2026-04-17-test-suite-audit.md
@@ -1,0 +1,178 @@
+---
+title: "Test Suite Audit — Skipped / XFailed / Flaky (Python 3.12)"
+date: 2026-04-17
+status: shipped
+owner: completed via NEXUS sprint
+---
+
+# Test Suite Audit — Python 3.12
+
+## Sprint outcome (added 2026-04-17 after NEXUS sprint)
+
+| Item | Status | Landed in |
+|------|--------|-----------|
+| AI-1 (conversational-entities unskip) | SHIPPED | PR #64 `7fdf013` |
+| AI-2 (llm_client split + contract) | SHIPPED | PR #64 `7fdf013` |
+| AI-3 (two_phase_e2e generate() audit) | SHIPPED | PR #63 `0136888` |
+| AI-4 (xfail fix via prompt-routed mock) | SHIPPED | PR #63 `0136888` |
+| AI-5 (get_note_by_id race) | SHIPPED | issue #68, PR #69 (wrap 16 readers in `_write_lock`) |
+| AI-6 (test_recall_cve flake) | SHIPPED | PR #65 `af080ec` |
+| AI-7 (Pydantic V3 ConfigDict) | SHIPPED | PR #62 `24ca6bd` |
+| AI-8 (return→assert in test_causal_extraction) | SHIPPED + REWRITTEN | PR #65 `af080ec`, then properly validated via mock-routed triples + SQLite query in PR #67 `ba558a3` |
+| AI-9 (lancedb table_names) | NO-OP | already migrated upstream; residual warning is lancedb-internal |
+| AI-10 (fastembed revision pin) | DEFERRED | awaiting decision on revision choice |
+
+Stabilization PR #67 also addressed 3 CI regressions exposed by the sprint merges (weakened causal_extraction assertion, vector_recall_latency race, metadata_fields fuzzy-query ranking miss).
+
+**Net test-suite delta:** `280 passed / 17 skipped / 2 xfailed` → `305 passed / 10 skipped / 0 xfailed / 0 failed` on test-3.12.
+
+---
+
+## Source of truth
+
+CI run `24586625581` (master, commit `3a378c6`), test-3.12 job `71897758930`:
+
+> `280 passed, 17 skipped, 2 xfailed, 7 warnings in 13.13s`
+
+Plus known-flaky tests from the PR #60 first-attempt failure (both passed on rerun, both pre-existing):
+
+- `tests/test_core.py::TestEntityRecall::test_recall_cve_returns_notes`
+- `tests/test_memory_updater.py::TestMemoryUpdaterApply::test_apply_delete_marks_superseded`
+
+## Total 16 non-pass outcomes grouped by root cause
+
+| Bucket | Count | Root cause | Fix effort |
+|---|---|---|---|
+| A. LLM native crash in CI | 5 | `llama-cpp-python` segfaults on GH runner | M — swap to mock provider in CI |
+| B. LLM integration needs model/server | 5 | No model or Ollama on CI runners | S — swap to mock provider |
+| C. Performance tests off on CI | 4 | Runner hardware variance | — keep skipped, verify locally on cadence |
+| D. Two-phase e2e mock drift (xfail) | 2 | Mock `side_effect` length mismatch after `generate()` call-site changes | M — retune mock or switch to recorded fixtures |
+| E. Flaky | 2 | Enrichment-queue race + retrieval timing | M — add synchronization point or use `sync=True` |
+
+---
+
+## Action items
+
+### P1 — Convert CI skips that can actually run
+
+Both buckets A and B skip *because* CI can't run a real LLM, but the `mock`
+provider from RFC-002 Phase 1 (now shipped in v2.3.0) makes them
+runnable. The skip markers were written before the mock provider
+existed; they are out of date.
+
+#### AI-1. Rewrite the 5 Category-A tests against the mock provider
+
+- **File:** `tests/test_conversational_entities.py`
+- **What:** Remove the `@pytest.mark.skipif(os.environ.get("CI") == "true", ...)` class decorators on `TestLLMExtraction` and `TestHybridExtraction`. Inject the mock provider via a fixture that calls `llm_client.reload()` after setting `ZETTELFORGE_LLM_PROVIDER=mock`, with seeded mock responses that match the assertions (e.g. a "person: Alice, Bob" JSON for the Alice/Bob input).
+- **Why:** These tests assert output shape / entity counts, not real model quality. The mock provider produces deterministic output suitable for shape checks.
+- **Risk:** Low. The assertions are `len(result.get("person", [])) >= 1` — easy to satisfy with seeded mock data.
+
+#### AI-2. Rewrite the 5 Category-B tests against the mock provider
+
+- **File:** `tests/test_llm_client.py`
+- **What:** `TestLocalLLM` class currently exercises `_get_local_llm()` and end-to-end `generate()`. Split it: keep the integration tests skipped in CI (rename class to `TestLocalLLMIntegration` so intent is explicit), and add a new `TestGenerateContract` class that exercises the public `generate()` surface through the mock provider (asserts return type, system-prompt handoff, JSON mode formatting — not real model output).
+- **Why:** The public `generate()` API contract should be covered in CI even when no model is present. We currently have zero CI coverage for any path through `llm_client.generate()`.
+- **Risk:** Low. The contract tests don't care about model quality.
+
+### P2 — Retire the 2 XFails
+
+Both `test_two_phase_e2e.py` xfails have a stale `xfail` reason:
+
+> "remember_with_extraction calls generate 4x; mock side_effect count and NOOP/UPDATE routing need rework"
+
+This marks broken tests that are being ignored. They were probably
+accurate when written but need re-evaluation now that RFC-002 changed the
+`generate()` call path.
+
+#### AI-3. Audit the current `remember_with_extraction` call sites for `generate()`
+
+- **File:** `src/zettelforge/memory_manager.py` — search for every call into `llm_client.generate` inside `remember_with_extraction`.
+- **What:** Count the actual invocations. Either fix the mock `side_effect` list length, or switch to a `mocker.patch` that returns a fixed value regardless of call count.
+- **Why:** XFails that sit for more than one release are waste — they look like test coverage but provide none.
+
+#### AI-4. Decide: fix, delete, or replace with a fixture-recording test
+
+- If the supersession / NOOP routing is still interesting behavior: fix AI-3 and remove the xfail.
+- If it's covered by other tests: delete these two and their fixtures.
+- If the mock-heavy approach keeps drifting: record real `generate()` outputs once (via the mock-provider harness from AI-2) and replay them. Lowest maintenance path.
+
+### P3 — Stabilize the 2 flaky tests
+
+Both flakes are in the enrichment-queue async write path that landed in
+v2.1.1's dual-stream architecture. They pass on rerun.
+
+#### AI-5. `test_apply_delete_marks_superseded` — force-sync the enrichment queue
+
+- **File:** `tests/test_memory_updater.py`
+- **Symptom:** `Links(related=[], superseded_by=None, ...)` — the superseded_by field isn't set yet when the assertion runs.
+- **Cause:** Enrichment-queue worker hasn't finished dispatching the supersession write before the test reads.
+- **Fix:** Add `mm.remember(..., sync=True)` to block until background enrichment completes (the `sync` param already exists per v2.1.1 CHANGELOG). Or call an explicit flush on the enrichment queue at the assertion boundary.
+
+#### AI-6. `test_recall_cve_returns_notes` — investigate the 0-hit variant
+
+- **File:** `tests/test_core.py`
+- **Symptom:** `assert 0 >= 1` — vector recall returns empty.
+- **Hypothesis 1:** The entity-index lookup hasn't flushed yet (same race as AI-5).
+- **Hypothesis 2:** Fastembed lazy-init on first `recall()` races with the concurrent `remember()` embedding.
+- **Fix candidates:** (a) force `sync=True` on the seed `remember()` calls in the fixture, (b) call `mm.rebuild_index()` before the first `recall()`, (c) add a tiny explicit wait on the embedding singleton.
+
+### P4 — Clean up warnings (7 during last run)
+
+Cheap hygiene fixes; none blocks CI but each one will become a hard
+failure on a future dep bump.
+
+#### AI-7. Pydantic V3 migration in `langchain_retriever.py`
+
+- **File:** `src/zettelforge/integrations/langchain_retriever.py:31`
+- **What:** `class ZettelForgeRetriever(BaseRetriever)` uses class-based `Config`; Pydantic V3 (already warning in V2.13) will remove it.
+- **Fix:** Replace `class Config:` with `model_config = ConfigDict(...)`.
+
+#### AI-8. `test_causal_extraction` returns bool instead of asserting
+
+- **File:** `tests/test_causal_extraction.py`
+- **What:** `PytestReturnNotNoneWarning: Test functions should return None, but ... returned <class 'bool'>.` Test function ends with `return <expr>` instead of `assert <expr>`.
+- **Fix:** One-line change — `return` → `assert`.
+
+#### AI-9. lancedb `table_names()` → `list_tables()`
+
+- **File:** `src/zettelforge/vector_memory.py` (the one that triggers via `tests/test_core.py::TestLanceDBIntegration::test_lancedb_tables_created`)
+- **What:** `DeprecationWarning: table_names() is deprecated, use list_tables() instead`.
+- **Fix:** Rename the call sites; API is a drop-in replacement per lancedb docs.
+
+#### AI-10. Fastembed "model updated on HuggingFace" warning
+
+- **File:** `src/zettelforge/vector_memory.py:76`
+- **What:** `UserWarning: The model 'nomic-ai/nomic-embed-text-v1.5-Q' has been updated on HuggingFace.`
+- **Decision needed:** Pin to a specific revision (stable), accept the warning (status quo), or upgrade to `v1.5` full-precision (bigger download, slightly better quality).
+- **Fix:** Add `revision="<commit-sha>"` to the `TextEmbedding(...)` call to pin to current behavior, and note the revision in `docs/reference/configuration.md` so future bumps are intentional.
+
+---
+
+## Priority recommendation
+
+Ship in one PR:
+
+1. **AI-5 + AI-6** (flake fixes) — eliminates the two known-flaky tests that have been failing PRs on first CI run this month.
+2. **AI-8 + AI-9** (one-line warning fixes) — zero risk, green the warnings list.
+
+Ship separately (each a small-to-medium PR):
+
+3. **AI-1 + AI-2** — move from 10 CI skips to 10 CI-run contract tests via the mock provider. Meaningful coverage gain.
+4. **AI-3 + AI-4** — xfail cleanup.
+5. **AI-7** — Pydantic migration (coordinate with any other pydantic-touching changes).
+6. **AI-10** — fastembed revision pin (requires a decision, not a typing sweep).
+
+Defer: **Category C** (performance tests) — skip-in-CI is the right call.
+Cadence: run `pytest tests/test_performance.py` on a dev box weekly and
+append results to `benchmarks/BENCHMARK_REPORT.md`.
+
+---
+
+## Scope boundary
+
+This audit covers **test-suite hygiene**. It does not cover:
+
+- Coverage gaps (currently 64% — separate concern, tracked in governance).
+- Test performance / runtime budget (13 s is healthy).
+- Test environment bootstrapping (the local hang on lancedb C-extension
+  calls is a platform quirk on NVIDIA-kernel hosts, not a CI issue).

--- a/src/zettelforge/sqlite_backend.py
+++ b/src/zettelforge/sqlite_backend.py
@@ -352,42 +352,53 @@ class SQLiteBackend(StorageBackend):
         )
 
     def get_note_by_id(self, note_id: str) -> Optional[MemoryNote]:
-        cur = self._conn.execute("SELECT * FROM notes WHERE id = ?", (note_id,))
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute("SELECT * FROM notes WHERE id = ?", (note_id,))
+            row = cur.fetchone()
         if row is None:
             return None
         return _row_to_note(row)
 
     def get_note_by_source_ref(self, source_ref: str) -> Optional[MemoryNote]:
-        cur = self._conn.execute(
-            "SELECT * FROM notes WHERE content_source_ref = ? LIMIT 1",
-            (source_ref,),
-        )
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT * FROM notes WHERE content_source_ref = ? LIMIT 1",
+                (source_ref,),
+            )
+            row = cur.fetchone()
         if row is None:
             return None
         return _row_to_note(row)
 
     def iterate_notes(self) -> Iterator[MemoryNote]:
-        cur = self._conn.execute("SELECT * FROM notes")
+        with self._write_lock:
+            cur = self._conn.execute("SELECT * FROM notes")
         while True:
-            rows = cur.fetchmany(100)
+            with self._write_lock:
+                rows = cur.fetchmany(100)
             if not rows:
                 break
             for row in rows:
                 yield _row_to_note(row)
 
     def get_notes_by_domain(self, domain: str) -> List[MemoryNote]:
-        cur = self._conn.execute("SELECT * FROM notes WHERE domain = ?", (domain,))
-        return [_row_to_note(r) for r in cur.fetchall()]
+        with self._write_lock:
+            cur = self._conn.execute("SELECT * FROM notes WHERE domain = ?", (domain,))
+            rows = cur.fetchall()
+        return [_row_to_note(r) for r in rows]
 
     def get_recent_notes(self, limit: int = 10) -> List[MemoryNote]:
-        cur = self._conn.execute("SELECT * FROM notes ORDER BY created_at DESC LIMIT ?", (limit,))
-        return [_row_to_note(r) for r in cur.fetchall()]
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT * FROM notes ORDER BY created_at DESC LIMIT ?", (limit,)
+            )
+            rows = cur.fetchall()
+        return [_row_to_note(r) for r in rows]
 
     def count_notes(self) -> int:
-        cur = self._conn.execute("SELECT COUNT(*) FROM notes")
-        return cur.fetchone()[0]
+        with self._write_lock:
+            cur = self._conn.execute("SELECT COUNT(*) FROM notes")
+            return cur.fetchone()[0]
 
     def delete_note(self, note_id: str) -> bool:
         with self._write_lock:
@@ -458,11 +469,12 @@ class SQLiteBackend(StorageBackend):
         return node_id
 
     def get_kg_node(self, entity_type: str, entity_value: str) -> Optional[Dict]:
-        cur = self._conn.execute(
-            "SELECT * FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
-            (entity_type, entity_value),
-        )
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT * FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
+                (entity_type, entity_value),
+            )
+            row = cur.fetchone()
         if row is None:
             return None
         return {
@@ -538,33 +550,35 @@ class SQLiteBackend(StorageBackend):
         entity_value: str,
         relationship: Optional[str] = None,
     ) -> List[Dict]:
-        # Resolve node_id
-        cur = self._conn.execute(
-            "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
-            (entity_type, entity_value),
-        )
-        row = cur.fetchone()
-        if row is None:
-            return []
-        node_id = row["node_id"]
+        with self._write_lock:
+            # Resolve node_id
+            cur = self._conn.execute(
+                "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
+                (entity_type, entity_value),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return []
+            node_id = row["node_id"]
 
-        if relationship:
-            edges_cur = self._conn.execute(
-                "SELECT e.*, n.entity_type AS to_type, n.entity_value AS to_value, n.properties AS to_props "
-                "FROM kg_edges e JOIN kg_nodes n ON e.to_node_id = n.node_id "
-                "WHERE e.from_node_id = ? AND e.relationship = ?",
-                (node_id, relationship),
-            )
-        else:
-            edges_cur = self._conn.execute(
-                "SELECT e.*, n.entity_type AS to_type, n.entity_value AS to_value, n.properties AS to_props "
-                "FROM kg_edges e JOIN kg_nodes n ON e.to_node_id = n.node_id "
-                "WHERE e.from_node_id = ?",
-                (node_id,),
-            )
+            if relationship:
+                edges_cur = self._conn.execute(
+                    "SELECT e.*, n.entity_type AS to_type, n.entity_value AS to_value, n.properties AS to_props "
+                    "FROM kg_edges e JOIN kg_nodes n ON e.to_node_id = n.node_id "
+                    "WHERE e.from_node_id = ? AND e.relationship = ?",
+                    (node_id, relationship),
+                )
+            else:
+                edges_cur = self._conn.execute(
+                    "SELECT e.*, n.entity_type AS to_type, n.entity_value AS to_value, n.properties AS to_props "
+                    "FROM kg_edges e JOIN kg_nodes n ON e.to_node_id = n.node_id "
+                    "WHERE e.from_node_id = ?",
+                    (node_id,),
+                )
+            erows = edges_cur.fetchall()
 
         neighbors = []
-        for erow in edges_cur.fetchall():
+        for erow in erows:
             neighbors.append(
                 {
                     "node": {
@@ -587,11 +601,12 @@ class SQLiteBackend(StorageBackend):
         max_depth: int = 2,
     ) -> List[List[Dict]]:
         """BFS/DFS traversal up to max_depth.  Returns list of paths."""
-        cur = self._conn.execute(
-            "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
-            (start_type, start_value),
-        )
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
+                (start_type, start_value),
+            )
+            row = cur.fetchone()
         if row is None:
             return []
 
@@ -604,17 +619,19 @@ class SQLiteBackend(StorageBackend):
                 return
             visited.add(current_id)
 
-            edges_cur = self._conn.execute(
-                "SELECT e.to_node_id, e.relationship, "
-                "nf.entity_type AS from_type, nf.entity_value AS from_value, "
-                "nt.entity_type AS to_type, nt.entity_value AS to_value "
-                "FROM kg_edges e "
-                "JOIN kg_nodes nf ON e.from_node_id = nf.node_id "
-                "JOIN kg_nodes nt ON e.to_node_id = nt.node_id "
-                "WHERE e.from_node_id = ?",
-                (current_id,),
-            )
-            for erow in edges_cur.fetchall():
+            with self._write_lock:
+                edges_cur = self._conn.execute(
+                    "SELECT e.to_node_id, e.relationship, "
+                    "nf.entity_type AS from_type, nf.entity_value AS from_value, "
+                    "nt.entity_type AS to_type, nt.entity_value AS to_value "
+                    "FROM kg_edges e "
+                    "JOIN kg_nodes nf ON e.from_node_id = nf.node_id "
+                    "JOIN kg_nodes nt ON e.to_node_id = nt.node_id "
+                    "WHERE e.from_node_id = ?",
+                    (current_id,),
+                )
+                erows = edges_cur.fetchall()
+            for erow in erows:
                 step = {
                     "from_type": erow["from_type"],
                     "from_value": erow["from_value"],
@@ -633,25 +650,27 @@ class SQLiteBackend(StorageBackend):
 
     def get_entity_timeline(self, entity_type: str, entity_value: str) -> List[Dict]:
         """Get temporal timeline of states for an entity via temporal edges."""
-        cur = self._conn.execute(
-            "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
-            (entity_type, entity_value),
-        )
-        row = cur.fetchone()
-        if row is None:
-            return []
-        node_id = row["node_id"]
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
+                (entity_type, entity_value),
+            )
+            row = cur.fetchone()
+            if row is None:
+                return []
+            node_id = row["node_id"]
 
-        edges_cur = self._conn.execute(
-            "SELECT e.*, nt.entity_type AS to_type, nt.entity_value AS to_value "
-            "FROM kg_edges e JOIN kg_nodes nt ON e.to_node_id = nt.node_id "
-            "WHERE e.from_node_id = ? AND "
-            "(e.relationship LIKE 'TEMPORAL_%' OR e.relationship = 'SUPERSEDES') "
-            "ORDER BY e.created_at",
-            (node_id,),
-        )
+            edges_cur = self._conn.execute(
+                "SELECT e.*, nt.entity_type AS to_type, nt.entity_value AS to_value "
+                "FROM kg_edges e JOIN kg_nodes nt ON e.to_node_id = nt.node_id "
+                "WHERE e.from_node_id = ? AND "
+                "(e.relationship LIKE 'TEMPORAL_%' OR e.relationship = 'SUPERSEDES') "
+                "ORDER BY e.created_at",
+                (node_id,),
+            )
+            erows = edges_cur.fetchall()
         timeline = []
-        for erow in edges_cur.fetchall():
+        for erow in erows:
             props = json.loads(erow["properties"] or "{}")
             ts = props.get("timestamp") or erow["created_at"] or ""
             timeline.append(
@@ -666,20 +685,22 @@ class SQLiteBackend(StorageBackend):
 
     def get_changes_since(self, timestamp: str) -> List[Dict]:
         """Get all temporal edge changes since a given ISO-8601 timestamp."""
-        edges_cur = self._conn.execute(
-            "SELECT e.*, "
-            "nf.entity_type AS from_type, nf.entity_value AS from_value, "
-            "nt.entity_type AS to_type, nt.entity_value AS to_value "
-            "FROM kg_edges e "
-            "JOIN kg_nodes nf ON e.from_node_id = nf.node_id "
-            "JOIN kg_nodes nt ON e.to_node_id = nt.node_id "
-            "WHERE (e.relationship LIKE 'TEMPORAL_%' OR e.relationship = 'SUPERSEDES') "
-            "AND e.created_at >= ? "
-            "ORDER BY e.created_at",
-            (timestamp,),
-        )
+        with self._write_lock:
+            edges_cur = self._conn.execute(
+                "SELECT e.*, "
+                "nf.entity_type AS from_type, nf.entity_value AS from_value, "
+                "nt.entity_type AS to_type, nt.entity_value AS to_value "
+                "FROM kg_edges e "
+                "JOIN kg_nodes nf ON e.from_node_id = nf.node_id "
+                "JOIN kg_nodes nt ON e.to_node_id = nt.node_id "
+                "WHERE (e.relationship LIKE 'TEMPORAL_%' OR e.relationship = 'SUPERSEDES') "
+                "AND e.created_at >= ? "
+                "ORDER BY e.created_at",
+                (timestamp,),
+            )
+            erows = edges_cur.fetchall()
         changes = []
-        for erow in edges_cur.fetchall():
+        for erow in erows:
             changes.append(
                 {
                     "timestamp": erow["created_at"],
@@ -692,8 +713,9 @@ class SQLiteBackend(StorageBackend):
 
     def get_kg_node_by_id(self, node_id: str) -> Optional[Dict]:
         """Lookup a KG node by its internal node_id."""
-        cur = self._conn.execute("SELECT * FROM kg_nodes WHERE node_id = ?", (node_id,))
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute("SELECT * FROM kg_nodes WHERE node_id = ?", (node_id,))
+            row = cur.fetchone()
         if row is None:
             return None
         return {
@@ -713,11 +735,12 @@ class SQLiteBackend(StorageBackend):
         max_visited: int = 50,
     ) -> List[Dict]:
         """BFS over outgoing causal edges — traces forward from cause to effects."""
-        cur = self._conn.execute(
-            "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
-            (entity_type, entity_value),
-        )
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
+                (entity_type, entity_value),
+            )
+            row = cur.fetchone()
         if row is None:
             return []
 
@@ -732,11 +755,13 @@ class SQLiteBackend(StorageBackend):
                 continue
             visited.add(current_id)
 
-            edges_cur = self._conn.execute(
-                "SELECT * FROM kg_edges WHERE from_node_id = ? AND edge_type = 'causal'",
-                (current_id,),
-            )
-            for erow in edges_cur.fetchall():
+            with self._write_lock:
+                edges_cur = self._conn.execute(
+                    "SELECT * FROM kg_edges WHERE from_node_id = ? AND edge_type = 'causal'",
+                    (current_id,),
+                )
+                erows = edges_cur.fetchall()
+            for erow in erows:
                 edge = dict(erow)
                 edge["properties"] = json.loads(edge.get("properties") or "{}")
                 causal_edges.append(edge)
@@ -754,11 +779,12 @@ class SQLiteBackend(StorageBackend):
         max_visited: int = 50,
     ) -> List[Dict]:
         """BFS over incoming causal edges — traces back to root causes."""
-        cur = self._conn.execute(
-            "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
-            (entity_type, entity_value),
-        )
-        row = cur.fetchone()
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT node_id FROM kg_nodes WHERE entity_type = ? AND entity_value = ?",
+                (entity_type, entity_value),
+            )
+            row = cur.fetchone()
         if row is None:
             return []
 
@@ -773,11 +799,13 @@ class SQLiteBackend(StorageBackend):
                 continue
             visited.add(current_id)
 
-            edges_cur = self._conn.execute(
-                "SELECT * FROM kg_edges WHERE to_node_id = ? AND edge_type = 'causal'",
-                (current_id,),
-            )
-            for erow in edges_cur.fetchall():
+            with self._write_lock:
+                edges_cur = self._conn.execute(
+                    "SELECT * FROM kg_edges WHERE to_node_id = ? AND edge_type = 'causal'",
+                    (current_id,),
+                )
+                erows = edges_cur.fetchall()
+            for erow in erows:
                 edge = dict(erow)
                 edge["properties"] = json.loads(edge.get("properties") or "{}")
                 causal_edges.append(edge)
@@ -804,21 +832,25 @@ class SQLiteBackend(StorageBackend):
             self._conn.commit()
 
     def get_note_ids_for_entity(self, entity_type: str, entity_value: str) -> List[str]:
-        cur = self._conn.execute(
-            "SELECT note_id FROM entity_index WHERE entity_type = ? AND entity_value = ?",
-            (entity_type, entity_value),
-        )
-        return [r["note_id"] for r in cur.fetchall()]
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT note_id FROM entity_index WHERE entity_type = ? AND entity_value = ?",
+                (entity_type, entity_value),
+            )
+            rows = cur.fetchall()
+        return [r["note_id"] for r in rows]
 
     def search_entities(self, query: str, limit: int = 10) -> Dict[str, List[str]]:
         """Prefix search across entity types."""
-        cur = self._conn.execute(
-            "SELECT DISTINCT entity_type, entity_value FROM entity_index "
-            "WHERE entity_value LIKE ? LIMIT ?",
-            (f"{query}%", limit),
-        )
+        with self._write_lock:
+            cur = self._conn.execute(
+                "SELECT DISTINCT entity_type, entity_value FROM entity_index "
+                "WHERE entity_value LIKE ? LIMIT ?",
+                (f"{query}%", limit),
+            )
+            rows = cur.fetchall()
         result: Dict[str, List[str]] = defaultdict(list)
-        for row in cur.fetchall():
+        for row in rows:
             result[row["entity_type"]].append(row["entity_value"])
         return dict(result)
 


### PR DESCRIPTION
## Root cause

`SQLiteBackend` readers executed `SELECT`s on `self._conn` without holding `self._write_lock`, while every writer (`write_note`, `rewrite_note`, `delete_note`, `mark_access_dirty`, `add_kg_node`, `add_kg_edge`, entity_index ops) already locks correctly. Under concurrent pressure from the `MemoryManager._enrichment_worker` daemon (causal triple extraction, LLM-NER, evolution), a reader thread could observe a row mid-`INSERT OR REPLACE` with NULL NOT-NULL columns and blow up pydantic validation in `_row_to_note`. The flaky `test_apply_delete_marks_superseded` reproduced this as a different-but-related symptom: `get_note_by_id` returned a stale snapshot of the old note missing the `superseded_by` link the writer had just set.

## Fix

Wrap the `execute + fetch` block of every reader in `with self._write_lock:`. Scope stays tight — only the SQL call is held, not Python-level post-processing. `_write_lock` is a `threading.RLock` (`sqlite_backend.py:290`), so existing reentrant call chains (`reindex_vector` → `get_note_by_id` → `rewrite_note`, `add_kg_edge` → `add_kg_node` → internal SELECT) remain safe.

## Methods wrapped (all in `src/zettelforge/sqlite_backend.py`)

1. `get_note_by_id`
2. `get_note_by_source_ref`
3. `iterate_notes` (wraps both `execute` and each `fetchmany`)
4. `get_notes_by_domain`
5. `get_recent_notes`
6. `count_notes`
7. `get_kg_node`
8. `get_kg_neighbors`
9. `traverse_kg` (each `_dfs` execute wrapped individually)
10. `get_entity_timeline`
11. `get_changes_since`
12. `get_kg_node_by_id`
13. `get_causal_edges` (each BFS-iteration execute wrapped individually)
14. `get_incoming_causal` (each BFS-iteration execute wrapped individually)
15. `get_note_ids_for_entity`
16. `search_entities`

## Deadlock audit

`_write_lock` is an `RLock`, so same-thread reentry via `reindex_vector` / `add_kg_edge` chains is safe. The only other thread-aware primitive in this code path is the enrichment worker's `queue.Queue`, which never interacts with `_write_lock`. No cross-lock ordering introduced.

## Verification

All runs: `CI=true ZETTELFORGE_LLM_PROVIDER=mock ZETTELFORGE_BACKEND=sqlite ZETTELFORGE_EMBEDDING_PROVIDER=fastembed`.

- **Targeted flake, 20 reps**: `test_apply_delete_marks_superseded` → **20/20 passed** (was 16/20 before fix).
- **Full `tests/test_memory_updater.py`**: **14/14 passed**.
- **Full suite**: **319 passed, 11 skipped, 0 failed** in 14.98s.

No test changes, no writer changes, no adjacent refactors.

Closes #68

🤖 Generated with [Claude Code](https://claude.com/claude-code)