### PR TITLE
docs(readme): add Detection Rules as Memory section

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,6 +160,35 @@ Your Claude Code agent can now remember and recall threat intelligence across se
 
 Exposed tools: `remember`, `recall`, `synthesize`, `entity`, `graph`, `stats`.
 
+## Detection Rules as Memory (Sigma + YARA)
+
+Sigma and YARA rules are first-class memory primitives. Parse, validate, and ingest a rule and its tags become graph edges: MITRE ATT&CK techniques, CVEs, threat-actor aliases, tools, and malware families resolve against the same ontology as every other note. A shared `DetectionRule` supertype carries `SigmaRule` and `YaraRule` subtypes, so a single rule UUID is addressable across both formats.
+
+Sigma rules are validated against the vendored [SigmaHQ JSON schema](https://github.com/SigmaHQ/sigma-specification). YARA rules are parsed with plyara and validated against the [CCCS YARA metadata standard](https://github.com/CybercentreCanada/CCCS-Yara) (tiers: `strict`, `warn`, `non_cccs`). Ingest is idempotent -- re-ingesting an unchanged rule returns the original note via a content-hashed `source_ref`.
+
+```python
+from zettelforge import MemoryManager
+from zettelforge.sigma import ingest_rule as ingest_sigma
+from zettelforge.yara import ingest_rule as ingest_yara
+
+mm = MemoryManager()
+ingest_sigma("rules/proc_creation_win_office_macro.yml", mm)
+ingest_yara("rules/webshell_china_chopper.yar", mm, tier="warn")
+```
+
+```bash
+# Bulk ingest from SigmaHQ or a private rule repo
+python -m zettelforge.sigma.ingest /path/to/sigma/rules/
+python -m zettelforge.yara.ingest /path/to/yara/rules/ --tier warn
+
+# CI fixture check -- parse + validate, no writes
+python -m zettelforge.sigma.ingest rules/ --dry-run
+```
+
+An LLM rule explainer (`zettelforge.detection.explainer.explain`) produces a structured JSON summary -- intent, key fields, evasion notes, false-positive hypotheses -- for any `DetectionRule`. It runs synchronously on demand in v1; async enrichment-queue wiring is v1.1. Rate-limited via `ZETTELFORGE_EXPLAIN_RPM` (default 60 calls/minute).
+
+References: [Sigma spec](https://github.com/SigmaHQ/sigma-specification), [SigmaHQ rules](https://github.com/SigmaHQ/sigma), [CCCS YARA](https://github.com/CybercentreCanada/CCCS-Yara), [YARA docs](https://yara.readthedocs.io).
+
 ## Integrations
 
 ### ATHF (Agentic Threat Hunting Framework)


### PR DESCRIPTION
Follow-up to #70. Adds a README section documenting the Sigma + YARA first-class primitives for readers who don't click through to the blog post.

## What's included

- One-paragraph explainer + reference to the shared `DetectionRule` supertype
- Upstream-spec references (SigmaHQ JSON schema, CCCS YARA metadata, YARA docs)
- Python API snippet (ingest_sigma + ingest_yara)
- CLI usage (single-file, bulk-directory, `--dry-run`)
- Honest framing of the LLM rule explainer: synchronous on-demand in v1, async enrichment-queue wiring is v1.1 work (matches `detection/explainer.py:7-9` docstring)

## Voice + scope

- Brand-voice compliant: no emoji, no exclamation marks, no hype adjectives ("powerful", "blazing-fast")
- No comparative framing against Mem0 / Graphiti / LangMem
- No SOC Prime / DetectFlow endorsement claims
- Matches the existing `## Quick Start` / `## How It Works` / ATHF bridge voice
- Placement: between `## MCP Server (Claude Code)` and `## Integrations` (alongside the ATHF bridge row)

## Related

- #70 — source PR (merged `e6dcfa4`)
- #71 — follow-on: typed DetectionMeta extension
- #72 — follow-on: remember(sync=True) bulk-ingest bottleneck + plyara p95
- #73 — follow-on: CCCS YARA regex tightening