### PR TITLE
feat(registry): add mcp-name tag + server.json for MCP Registry publish

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ZettelForge
 
+<!-- mcp-name: io.github.rolandpg/zettelforge -->
+
 **The only agentic memory system built for cyber threat intelligence.**
 
 Persistent memory for AI agents and Claude Code — with CTI entity extraction, STIX knowledge graphs, threat-actor alias resolution, and offline-first RAG. MCP server included. No cloud, no API keys.

--- a/server.json
+++ b/server.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
+  "name": "io.github.rolandpg/zettelforge",
+  "title": "ZettelForge",
+  "description": "Agentic memory for cyber threat intelligence: STIX knowledge graphs, threat-actor alias resolution, offline-first RAG, Sigma/YARA support.",
+  "repository": {
+    "url": "https://github.com/rolandpg/zettelforge",
+    "source": "github"
+  },
+  "version": "2.3.1",
+  "packages": [
+    {
+      "registryType": "pypi",
+      "identifier": "zettelforge",
+      "version": "2.3.1",
+      "transport": {
+        "type": "stdio"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Prepares ZettelForge for publication to the [MCP Registry](https://registry.modelcontextprotocol.io), which feeds:
- mcp.so
- modelcontextprotocol.io community servers
- any other aggregators that pull from the canonical registry

## Changes

- **README.md**: adds `<!-- mcp-name: io.github.rolandpg/zettelforge -->` (hidden HTML comment). The registry verifies PyPI ownership by looking for this exact string in the package description on pypi.org.
- **server.json**: registry metadata (schema `2025-12-11`), PyPI package type, stdio transport.

## Publish workflow (post-merge, manual)

The registry requires that the PyPI-served description contains the `mcp-name` tag. Current PyPI release `2.3.0` predates this commit, so a new release is required before publishing.

\`\`\`bash
# 1. Cut a new PyPI release (the existing publish.yml workflow handles this on GitHub Release)
#    — bump version in pyproject.toml, src/zettelforge/__init__.py, mkdocs.yml, server.json
#    — tag v2.3.1, create GitHub release

# 2. Install mcp-publisher
curl -L "https://github.com/modelcontextprotocol/registry/releases/latest/download/mcp-publisher_\$(uname -s | tr '[:upper:]' '[:lower:]')_\$(uname -m | sed 's/x86_64/amd64/;s/aarch64/arm64/').tar.gz" | tar xz mcp-publisher
sudo mv mcp-publisher /usr/local/bin/

# 3. Authenticate + publish
mcp-publisher login github
mcp-publisher publish

# 4. Verify
curl "https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.rolandpg/zettelforge"
\`\`\`

## Notes

- Version numbers left at 2.3.0 intentionally — the CHANGELOG's [Unreleased] section has real changes (SQLite concurrency fixes, test hygiene) that belong in the next release bump. This PR is scoped to registry infra only.
- No code changes to zettelforge itself. Pure metadata.