### PR TITLE
chore(release): v2.4.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,9 +6,30 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.4.0] - 2026-04-19
+
+Detection-rules-as-memory, MCP Registry publication, SQLite concurrency
+hardening, and a full test-suite hygiene pass.
+
+### Added
+
+- **Detection rules as first-class memory** (#70) — Sigma and YARA rules
+  are now ingested, indexed, and retrieved alongside CTI entities, with
+  an LLM rule explainer that surfaces what each rule detects and the
+  actors/techniques it's associated with. See the "Detection Rules as
+  Memory" section in the README (#74) for usage.
+- **MCP Registry publication** (#75) — `server.json` and the `mcp-name`
+  tag required to publish ZettelForge to the canonical MCP Registry
+  (registry.modelcontextprotocol.io), which feeds mcp.so and the
+  modelcontextprotocol.io community-servers list.
+- **Brand & docs polish** (#61) — neural-chain architecture diagram with
+  light/dark parity, updated GitHub social preview, canonical security
+  channels + RFC 9116 `security.txt`, real Code of Conduct contacts,
+  and a complete brand documentation set.
+
 ### Fixed
 
-- **SQLite backend concurrency** — 16 reader methods in
+- **SQLite backend concurrency** (#69) — 16 reader methods in
   `SQLiteBackend` (`get_note_by_id`, `get_note_by_source_ref`,
   `iterate_notes`, `get_notes_by_domain`, `get_recent_notes`,
   `count_notes`, `get_kg_node`, `get_kg_node_by_id`,
@@ -23,10 +44,12 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   Eliminates the `test_apply_delete_marks_superseded` flake and
   prevents the same race from surfacing in production
   `recall()`-during-write paths.
+- **CI regressions** (#67) — stabilized three tests exposed by the
+  test-suite audit sprint.
 
 ### Changed
 
-- **Test suite hygiene** — post-v2.3.0 audit (see
+- **Test suite hygiene** (#62, #63, #64, #65) — post-v2.3.0 audit (see
   `docs/superpowers/research/2026-04-17-test-suite-audit.md`)
   converted 10 CI-skipped LLM tests to the mock provider (RFC-002
   Phase 1), resolved both remaining `xfail` tests via prompt-routed

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -60,9 +60,9 @@ backported to the prior minor release.
 
 | Version | Supported |
 |---|---|
-| 2.3.x (current) | Yes — active security support |
-| 2.2.x | Critical fixes only, for 60 days after 2.3.0 release |
-| < 2.2 | No — upgrade required |
+| 2.4.x (current) | Yes — active security support |
+| 2.3.x | Critical fixes only, for 60 days after 2.4.0 release |
+| < 2.3 | No — upgrade required |
 
 ---
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -31,7 +31,7 @@ plugins:
 extra:
   # Sourced by docs/overrides/main.html for JSON-LD SoftwareApplication.
   # Bump on each release so schema.org metadata stays in sync with PyPI.
-  version: "2.3.0"
+  version: "2.4.0"
 
 extra_css:
   # Brand tokens first — defines --signal-*, --graphite-*, --fog-*, --font-*

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zettelforge"
-version = "2.3.0"
+version = "2.4.0"
 description = "ZettelForge: Agentic Memory System with vector search, knowledge graph, and synthesis"
 readme = "README.md"
 license = "MIT"

--- a/server.json
+++ b/server.json
@@ -7,12 +7,12 @@
     "url": "https://github.com/rolandpg/zettelforge",
     "source": "github"
   },
-  "version": "2.3.1",
+  "version": "2.4.0",
   "packages": [
     {
       "registryType": "pypi",
       "identifier": "zettelforge",
-      "version": "2.3.1",
+      "version": "2.4.0",
       "transport": {
         "type": "stdio"
       }

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -57,7 +57,7 @@ from zettelforge.vector_retriever import VectorRetriever
 # importable for advanced use but are not part of the advertised public API
 # and are therefore excluded from __all__ below.
 
-__version__ = "2.3.0"
+__version__ = "2.4.0"
 __all__ = [
     # Edition
     "Edition",


### PR DESCRIPTION
## Summary

Cuts v2.4.0 — detection-rules-as-memory, MCP Registry publication, SQLite concurrency hardening, test hygiene, and brand/docs polish.

## Version bumps

- \`pyproject.toml\`: 2.3.0 → 2.4.0
- \`src/zettelforge/__init__.py\`: 2.3.0 → 2.4.0
- \`mkdocs.yml\`: 2.3.0 → 2.4.0
- \`server.json\`: 2.3.1 → 2.4.0 (both server and package)
- \`SECURITY.md\`: support matrix rolled forward

## Release highlights (see CHANGELOG.md)

### Added
- **Sigma + YARA as first-class memory** (#70, #74)
- **MCP Registry publication infra** (#75)
- **Brand & docs polish** — neural-chain diagram, security.txt, social preview (#61)

### Fixed
- **SQLite reader concurrency** — 16 methods now hold \`_write_lock\`, closes a production read-during-write race (#68/#69)
- **3 CI test regressions** (#67)

### Changed
- **Test suite hygiene** — 280→305 passing, Pydantic V2 migration (#62, #63, #64, #65)

## Post-merge

1. Create GitHub release with tag \`v2.4.0\` → triggers \`publish.yml\` → PyPI publish.
2. Once \`zettelforge==2.4.0\` is on PyPI (with the new README containing the \`mcp-name\` tag), run:
   \`\`\`bash
   mcp-publisher login github
   mcp-publisher publish
   \`\`\`