### PR TITLE
fix(registry): shorten server.json description to ≤100 chars

### DIFF
--- a/server.json
+++ b/server.json
@@ -2,7 +2,7 @@
   "$schema": "https://static.modelcontextprotocol.io/schemas/2025-12-11/server.schema.json",
   "name": "io.github.rolandpg/zettelforge",
   "title": "ZettelForge",
-  "description": "Agentic memory for cyber threat intelligence: STIX knowledge graphs, threat-actor alias resolution, offline-first RAG, Sigma/YARA support.",
+  "description": "Agentic memory for cyber threat intelligence. STIX graphs, actor aliasing, offline RAG, Sigma/YARA.",
   "repository": {
     "url": "https://github.com/rolandpg/zettelforge",
     "source": "github"


### PR DESCRIPTION
The MCP Registry enforces a 100-char cap on `server.description`. The originally-committed value (138 chars) failed validation; updating to match what was accepted and is now live at [registry.modelcontextprotocol.io](https://registry.modelcontextprotocol.io/v0.1/servers?search=io.github.rolandpg/zettelforge).