### PR TITLE
feat(analytics): Cloudflare Web Analytics beacon for docs.threatrecall.ai

### DIFF
--- a/docs/assets/cf-analytics.js
+++ b/docs/assets/cf-analytics.js
@@ -1,0 +1,9 @@
+// Cloudflare Web Analytics — docs.threatrecall.ai
+// Injected via mkdocs.yml extra_javascript.
+(function(){
+  var s = document.createElement('script');
+  s.defer = true;
+  s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
+  s.setAttribute('data-cf-beacon', '{"token": "REPLACE_WITH_DOCS_TOKEN"}');
+  document.head.appendChild(s);
+})();

--- a/docs/assets/cf-analytics.js
+++ b/docs/assets/cf-analytics.js
@@ -4,6 +4,6 @@
   var s = document.createElement('script');
   s.defer = true;
   s.src = 'https://static.cloudflareinsights.com/beacon.min.js';
-  s.setAttribute('data-cf-beacon', '{"token": "REPLACE_WITH_DOCS_TOKEN"}');
+  s.setAttribute('data-cf-beacon', '{"token": "7740fa0d6ecf41abb3c7bc06803e7ed3"}');
   document.head.appendChild(s);
 })();

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -43,6 +43,9 @@ extra_css:
   - stylesheets/brand-tokens.css
   - stylesheets/extra.css
 
+extra_javascript:
+  - assets/cf-analytics.js
+
 nav:
   - Home: index.md
   - Getting Started:


### PR DESCRIPTION
## Summary

- Adds `docs/assets/cf-analytics.js` — beacon loader script for Cloudflare Web Analytics
- Adds `extra_javascript: [assets/cf-analytics.js]` to `mkdocs.yml` after the `extra_css` block

## Growth Week 2 prerequisite #5

This is one half of GW2 prereq #5. The beacon token is currently the placeholder `REPLACE_WITH_DOCS_TOKEN`.

**Before merging:** Patrick replaces `REPLACE_WITH_DOCS_TOKEN` in `docs/assets/cf-analytics.js` with the actual 32-char hex token from the Cloudflare Web Analytics dashboard (GW2 prereq #4 — provision the `docs.threatrecall.ai` site at dash.cloudflare.com → Analytics & Logs → Web Analytics → Add a site).

The token is a public beacon identifier (visible in HTML source on every page load) — safe to commit per Cloudflare's own documentation.

## DO NOT MERGE until token is substituted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)