### PR TITLE
fix(enrichment): wire OllamaProvider timeout + consolidation shutdown guard (RFC-010)

### DIFF
--- a/src/zettelforge/consolidation.py
+++ b/src/zettelforge/consolidation.py
@@ -20,6 +20,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from zettelforge.log import get_logger
 from zettelforge.ocsf import STATUS_SUCCESS, log_api_activity
+from zettelforge.storage_backend import BackendClosedError
 
 logger = get_logger("zettelforge.consolidation")
 
@@ -217,6 +218,17 @@ class ConsolidationEngine:
             "errors": [],
         }
 
+        # [RFC-010] fast-path guard — skip when the backing MemoryManager has
+        # begun shutdown. Prevents the shutdown-race `BackendClosedError` that
+        # surfaced in production logs 2026-04-24T17:25:48Z from
+        # consolidation.py:224 (iterate_notes). RFC-009 Section 4.3 replaces
+        # this with explicit cursor tracking; until then, this guard + the
+        # catch in the iteration below form a two-layer defense.
+        if not getattr(self._mm, "_accepting", True):
+            report["status"] = "skipped"
+            report["reason"] = "backend not accepting (shutdown in progress)"
+            return report
+
         try:
             # Gather recent notes (EPG candidates)
             # Only notes created since the last consolidation window
@@ -296,6 +308,13 @@ class ConsolidationEngine:
             self._detector.reset()
             self._consolidation_count += 1
 
+        except BackendClosedError:
+            # [RFC-010] Narrow race: _accepting was true at the guard check
+            # above, but flipped to false before iterate_notes yielded its
+            # first row. Treat as a clean skip rather than a noisy error.
+            report["status"] = "skipped"
+            report["reason"] = "backend closed mid-iteration"
+            return report
         except Exception as e:
             self._logger.error("consolidation_failed", error=str(e), exc_info=True)
             report["errors"].append(str(e))

--- a/src/zettelforge/llm_providers/ollama_provider.py
+++ b/src/zettelforge/llm_providers/ollama_provider.py
@@ -19,14 +19,26 @@ class OllamaProvider:
     Args:
         model: Ollama model tag (e.g. ``"qwen2.5:3b"``).
         url: Base URL of the Ollama server.
+        timeout: HTTP timeout in seconds (applied to ``ollama.Client``). Before
+            RFC-010 this kwarg was silently dropped — requests inherited the
+            ollama-python client's effectively-unbounded default. Production
+            audit 2026-04-24 attributed `remember()` p95 of ~66s to hung
+            Ollama calls; fixing this caps the hang class.
         **_: Ignored — registry may pass other providers' kwargs.
     """
 
     name = "ollama"
 
-    def __init__(self, model: str = "", url: str = "", **_: Any) -> None:
+    def __init__(
+        self,
+        model: str = "",
+        url: str = "",
+        timeout: float = 60.0,
+        **_: Any,
+    ) -> None:
         self._model = model or _DEFAULT_MODEL
         self._url = url or _DEFAULT_URL
+        self._timeout = timeout
 
     def generate(
         self,
@@ -51,6 +63,7 @@ class OllamaProvider:
         # Route through a per-instance Client so ``self._url`` actually affects
         # where the call goes. The module-level ``ollama.generate`` always
         # targets the default localhost:11434, ignoring this provider's config.
-        client = ollama.Client(host=self._url)
+        # ``timeout`` is now threaded through per RFC-010.
+        client = ollama.Client(host=self._url, timeout=self._timeout)
         response = client.generate(**kwargs)
         return str(response.get("response", "")).strip()

--- a/tests/test_consolidation.py
+++ b/tests/test_consolidation.py
@@ -15,6 +15,7 @@ from zettelforge.consolidation import (
     ConsolidationMiddleware,
     SemanticShiftDetector,
 )
+from zettelforge.storage_backend import BackendClosedError
 
 # ── SemanticShiftDetector Tests ─────────────────────────────────────────────
 
@@ -178,6 +179,35 @@ class TestConsolidationEngine:
         stats = engine.get_stats()
         assert "consolidation_count" in stats
         assert "detector_state" in stats
+
+    def test_consolidate_skips_when_backend_not_accepting(self):
+        """[RFC-010] Shutdown-race fast-path: if `_accepting` is False, skip
+        without ever calling `iterate_notes()`. Fixes the race where the
+        v2.4.1 BackendClosedError fired from consolidation.py:224 at
+        2026-04-24T17:25:48Z during Vigil's process shutdown."""
+        mm = MagicMock()
+        mm._accepting = False
+        engine = ConsolidationEngine(mm)
+        report = engine.consolidate()
+        assert report["status"] == "skipped"
+        assert "not accepting" in report["reason"]
+        mm.store.iterate_notes.assert_not_called()
+
+    def test_consolidate_catches_backend_closed_error_mid_iteration(self):
+        """[RFC-010] Second-layer defense: `_accepting` check passes, but
+        shutdown fires between the guard and the iterator yielding rows.
+        The narrow `BackendClosedError` catch turns the race into a clean
+        skip instead of `consolidation_failed` noise in the logs."""
+        mm = MagicMock()
+        mm._accepting = True
+        mm.store.iterate_notes.side_effect = BackendClosedError("SQLiteBackend(...) is closed")
+        engine = ConsolidationEngine(mm)
+        report = engine.consolidate()
+        assert report["status"] == "skipped"
+        assert "mid-iteration" in report["reason"]
+        # The outer except Exception: handler must NOT have been reached
+        # (i.e. report["errors"] was not populated).
+        assert report["errors"] == []
 
 
 # ── ConsolidationMiddleware Tests ───────────────────────────────────────────

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -138,7 +138,7 @@ class TestOllamaProvider:
             )
 
             assert result == "ok"
-            mock_client_cls.assert_called_once_with(host="http://host:11434")
+            mock_client_cls.assert_called_once_with(host="http://host:11434", timeout=60.0)
             args, kwargs = mock_client.generate.call_args
             assert kwargs["model"] == "qwen2.5:3b"
             assert kwargs["prompt"] == "hello"
@@ -169,11 +169,26 @@ class TestOllamaProvider:
         with patch("ollama.Client") as mock_client_cls:
             mock_client_cls.return_value.generate.return_value = {"response": "ok"}
             provider.generate("hello")
-            mock_client_cls.assert_called_once_with(host="http://gpu-box:11434")
+            mock_client_cls.assert_called_once_with(host="http://gpu-box:11434", timeout=60.0)
+
+    def test_timeout_threads_through_to_client(self):
+        """[RFC-010] Configured timeout must reach ``ollama.Client``.
+
+        Before RFC-010, ``OllamaProvider.__init__`` dropped ``timeout`` into
+        ``**_`` and the client inherited an effectively-unbounded default,
+        causing the 66.5s `remember()` tail observed in the 2026-04-24
+        Vigil audit.
+        """
+        provider = OllamaProvider(model="qwen2.5:3b", timeout=7.5)
+        with patch("ollama.Client") as mock_client_cls:
+            mock_client_cls.return_value.generate.return_value = {"response": "ok"}
+            provider.generate("hello")
+            mock_client_cls.assert_called_once_with(host="http://localhost:11434", timeout=7.5)
 
     def test_unknown_kwargs_ignored_at_construction(self):
         # The registry forwards kwargs meant for other providers; they
-        # must be accepted silently.
+        # must be accepted silently. Note: ``timeout`` is now a first-class
+        # parameter (RFC-010) but ``**_`` still absorbs anything else.
         provider = OllamaProvider(
             model="qwen2.5:3b",
             api_key="ignored",


### PR DESCRIPTION
## Summary

Ships RFC-010, the ship-today hotfix spec, ahead of RFC-009's broader redesign. Two small correctness patches motivated by the 2026-04-24 Vigil telemetry audit:

1. **OllamaProvider timeout plumbing** — `ollama.Client` was being built with no \`timeout\`, so hung Ollama calls bounded only by the SDK's default (effectively unbounded). Caps the 66s \`remember()\` tail.
2. **Consolidation shutdown guard** — closes the third shutdown-race site that slipped past PR #84 (logged 2026-04-24T17:25:48Z as \`BackendClosedError\` from \`consolidation.py:224\`).

~15 lines of production code + 3 new tests. No behaviour change for healthy flows.

## What this does NOT fix

**Important operator expectation:** the 2,329 daily enrichment-job drops observed in the audit are driven by TWO independent failures:

- **Hangs** (workers stall waiting on Ollama) — this hotfix addresses.
- **Empty-body responses** (HTTP 200 with \`raw == ""\`) — this hotfix does NOT address.

Realistic post-hotfix state:
- \`remember()\` p95: 66s → ~60s (bounded by new timeout default).
- \`enrichment_worker_error\` count: likely *increases* (hangs become explicit timeouts, each logging).
- Drops per day: **stays ~2,000-2,300** until the outbox + circuit breaker land in RFC-009.

RFC-010's commit message and the in-repo spec at \`docs/rfcs/RFC-010-enrichment-hotfix.md\` both state this explicitly. This is a latency + shutdown-hygiene fix, not a recovery fix.

## Changes

### \`src/zettelforge/llm_providers/ollama_provider.py\`
- \`__init__\` gains \`timeout: float = 60.0\` as a first-class kwarg (previously swallowed by \`**_\`)
- \`generate()\` passes \`timeout=self._timeout\` to \`ollama.Client(...)\`

### \`src/zettelforge/consolidation.py\`
- Import \`BackendClosedError\` from \`storage_backend\`
- \`ConsolidationEngine.consolidate()\` gains two-layer defense:
  - Fast-path: \`if not self._mm._accepting: return {status: skipped, ...}\`
  - Narrow catch: \`except BackendClosedError: return {status: skipped, reason: \"...mid-iteration\"}\`

### \`tests/test_llm_providers.py\`
- New: \`test_timeout_threads_through_to_client\` — RFC-010-specific assertion.
- Updated: two existing \`Client(host=...)\` assertions now include \`timeout=60.0\` (the new default).

### \`tests/test_consolidation.py\`
- New: \`test_consolidate_skips_when_backend_not_accepting\` — fast-path guard.
- New: \`test_consolidate_catches_backend_closed_error_mid_iteration\` — narrow race.

## Test plan

- [x] 45/45 of the affected-area tests pass locally (\`test_llm_providers.py\` + \`test_consolidation.py\`)
- [x] \`ruff check\` clean
- [x] \`ruff format --check\` clean
- [ ] Full CI
- [ ] Post-merge observation: grep Vigil's \`zettelforge.log\` for \`ocsf_api_activity\` with \`activity_name=remember\` and \`duration_ms > 60000\` — pre-hotfix = 1/day, post-hotfix target = 0/day.

Note: pre-existing failures in \`TestLocalLLMIntegration\` are environment-dependent (they call real Ollama at localhost and hit the empty-body cascade — the exact symptom this PR's timeout fix does NOT resolve). Not regressions.

## Release

Ships as **v2.4.2** on merge. Version bump + tag + GitHub Release will follow the v2.4.1 pattern. RFC-009's broader redesign continues in parallel and targets v2.5.0.

## Related

- RFC-010 spec: \`docs/rfcs/RFC-010-enrichment-hotfix.md\` (not yet committed; separate docs PR)
- RFC-009 (Phase 0 references this work): \`docs/rfcs/RFC-009-enrichment-pipeline-v2.md\`
- Audit: \`tasks/vigil-telemetry-audit-2026-04-24.md\`
- Owner: claude-code (assigned 2026-04-24 by Patrick)

🤖 Generated with [Claude Code](https://claude.com/claude-code)