### PR TITLE
docs: v2.4.2 live-test evidence log (2026-04-24)

### DIFF
--- a/docs/superpowers/research/2026-04-24-v2.4.2-live-test-observations.md
+++ b/docs/superpowers/research/2026-04-24-v2.4.2-live-test-observations.md
@@ -1,0 +1,206 @@
+---
+title: "v2.4.2 live-test evidence log — Vigil instance, 2026-04-24"
+status: active session (data cutoff 2026-04-24T23:51:30Z, still running)
+author: "claude-code"
+session_id: "f94f8d71-ef48-4109-a0fa-0a87f2e736c4"
+data_sources:
+  - "/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/logs/zettelforge.log (OCSF)"
+  - "/home/rolandpg/.amem/telemetry/telemetry_2026-04-24.jsonl (RFC-007)"
+install_under_test: "/home/rolandpg/.openclaw/workspace-nexus/skills/zettelforge/ (shared by Vigil + Nexus)"
+pinned_version: "2.4.2"
+review_audience: "Patrick / Nexus / future claude-code sessions"
+---
+
+# v2.4.2 live-test evidence log
+
+Durable snapshot of everything observed during the first post-release test of ZettelForge v2.4.2 running against Vigil's CTI memory workload. Intended to survive context loss and to be forwardable to Nexus for independent review.
+
+## Test timeline
+
+| Time (UTC) | Event |
+|---|---|
+| `2026-04-24T22:35:45Z` | v2.4.2 tagged and published to PyPI (GH run 24914949025) |
+| `~2026-04-24T23:10Z` | Qwen3.5:9b traffic stopped; traffic generator force-killed |
+| `2026-04-24T23:11:42Z` | **First `phase_timings_ms` event emitted** — v2.4.2 code confirmed live on Vigil |
+| `2026-04-24T23:22:06Z` | DEBUG logging activated (per Nexus); traffic resumed under Nemotron-3-nano |
+| `~2026-04-24T23:44Z` | DEBUG enrichment fields finally reaching TelemetryCollector (after explicit setLevel fix) |
+| `2026-04-24T23:51:30Z` | Evidence snapshot captured (this document's data cutoff) |
+
+## Config under test
+
+```yaml
+# /home/rolandpg/.openclaw/workspace-vigil/config.yaml (excerpt)
+embedding:
+  provider: ollama
+  model: nomic-embed-text-v2-moe.gguf
+llm:
+  provider: ollama
+  model: nemotron-3-nano:latest     # was qwen3.5:9b, swapped at ~23:10Z
+```
+
+```text
+# /home/rolandpg/.openclaw/workspace-nexus/skills/zettelforge/pyproject.toml
+version = "2.4.2"
+```
+
+## Deployment path (critical for repro)
+
+Openclaw agents (Vigil, Nexus) read ZettelForge from a **separate git clone** at `/home/rolandpg/.openclaw/workspace-nexus/skills/zettelforge/`, not from PyPI. `pip install --upgrade zettelforge==2.4.2` does **not** propagate to runtime. Deploy path is:
+
+```bash
+cd /home/rolandpg/.openclaw/workspace-nexus/skills/zettelforge
+git fetch origin && git checkout v2.4.2
+# then restart Vigil + Nexus
+```
+
+## Primary findings
+
+### ✅ v2.4.2 ship-critical fixes verified
+
+| Check | Evidence |
+|---|---|
+| Phase 0.5 instrumentation live | 83 remember() events carry `phase_timings_ms` since 23:11:42Z; phase-sum coverage ≈100% of duration |
+| RFC-010 consolidation-race guard | **0** `consolidation_failed` events since v2.4.2 start, versus 4 on v2.4.1 earlier the same day (03:53–17:25 UTC) |
+| RFC-010 OllamaProvider timeout | No new 66-second `remember` hangs; slow tails now clustered tightly at ~55s (write-path, not LLM-path) |
+
+### 🎯 Phase 0.5 attribution — conclusively confirmed
+
+Aggregate across 83 v2.4.2 remember() calls:
+
+| Phase | Total ms | Share |
+|---|---:|---:|
+| `lance_index` | 444,208 | **98.1%** |
+| `construct` | 7,407 | 1.6% |
+| `supersession` | 642 | 0.1% |
+| `kg_update` | 206 | 0.0% |
+| `write_note` | 168 | 0.0% |
+| `enrichment_dispatch` | 81 | 0.0% |
+| `entity_index` | 51 | 0.0% |
+| `consolidation_observe` | 8 | 0.0% |
+
+Preliminary attribution (98.4% from v2.4.1 log reconstruction) now reads 98.1% on first-party `phase_timings_ms` data. No surprise phase.
+
+#### All 8 tail events (>30s) with phase breakdown
+
+Tails cluster tightly around **55s ± 3s** and are **99.66–99.98% `lance_index`**:
+
+| Time | Duration (ms) | lance_index (ms) | lance share |
+|---|---:|---:|---:|
+| 23:13:03 | 53,820.67 | 53,674.55 | 99.73% |
+| 23:15:50 | 58,097.93 | 58,088.16 | 99.98% |
+| 23:18:40 | 55,395.78 | 55,210.13 | 99.66% |
+| 23:45:23 | 55,979.23 | 55,887.17 | 99.84% |
+| 23:46:39 | 54,405.10 | 54,348.29 | 99.90% |
+| 23:49:22 | 54,645.26 | 54,605.45 | 99.93% |
+| 23:50:25 | 56,254.70 | 56,198.86 | 99.90% |
+| 23:51:31 | 58,456.06 | (not yet sampled) | — |
+
+**The tight band itself is a signal** — this is not random GC noise; the LanceDB stall appears deterministic, consistent with manifest-rewrite scaling with fragment count.
+
+### 🔧 Root-cause evidence for the tail
+
+```
+/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/vectordb/
+  notes_cti.lance/data/     → 7,576 fragment files (snapshot 23:51Z)
+  notes_general.lance/data/ →   458 fragment files
+```
+
+Fragment count grew from 7,356 (earlier today, pre-v2.4.2) to 7,576 (+220) — consistent with the observed write rate. Linear growth with every insert because ZettelForge never calls `compact_files()`. Confirmed via `grep -rn 'compact_files\|optimize' src/zettelforge/` → zero matches.
+
+### ⚠️ Issues the release does NOT fix (documented, in backlog)
+
+- Empty-body Ollama cascade is alive and pulsing. Post-v2.4.2 window: 56 `evolution_parse_retry` + 56 `evolution_parse_failed` + 34 `parse_failed`. Covered by RFC-009 Phases 1–3 (v2.5.0).
+- LanceDB tail is observed but not yet fixed. Offline shot via `compact_files()` (task #37) is ready; periodic in-code trigger is task #38.
+
+## Read path
+
+### Recall telemetry aggregate
+
+```
+total recalls    : 150
+avg latency      : 658 ms
+zero-hit count   : 33
+zero-hit rate    : 22%
+
+DEBUG-enriched   : 19   (only from 23:44Z onward, after Nexus's setLevel fix)
+
+Intents seen     : factual (8), exploratory (10), relational (1)
+Graph nonzero    : 2 / 150 = 1.3%
+```
+
+### Zero-hit rate: LLM swap did NOT change it
+
+| Window | Zero-hit rate |
+|---|---|
+| Qwen3.5:9b (pre-switch, 23:04–23:13Z) | 28% |
+| Nemotron-3-nano (post-switch, 23:22Z+) | 22% |
+
+Difference is within sampling noise for n ≤ 150. The hypothesis that Qwen drove zero-hits is **not supported**. Zero-hits are likely retriever-side: thin entity coverage, tight similarity thresholds, or regex-extraction gaps. Task #40 needs refocusing from "is it the LLM?" to "what queries return zero?" with DEBUG-payload comparisons between hit and miss queries.
+
+### Graph retriever: 98.7% dark
+
+148 of 150 recalls report `kg=0ms`. The 2 exceptions prove the path isn't fully broken. Seen across all three observed intents, **including `relational` queries**, which should route through the graph. Task #42 has the open diagnostic list.
+
+### Synthesis
+
+3 synthesis events in telemetry (vs 0 I incorrectly claimed in an earlier summary — corrected by this snapshot). Volume is low but non-zero; traffic generator does exercise the synthesize path, just sparsely.
+
+## Tooling & instrumentation issues discovered
+
+| # | Issue | Impact | Task |
+|---|---|---|---|
+| 1 | `metadata.product.version` in OCSF events still reads "2.4.1" despite v2.4.2 code running — hardcoded somewhere in `ocsf.py` | cosmetic / observability accuracy | #35 |
+| 2 | `log.py:154-159` auto-configures logging at INFO and never re-reads config.yaml; `config.yaml log.level=DEBUG` is dead code | operator confusion, blocks DEBUG telemetry collection | #41 |
+| 3 | `TelemetryCollector.log_recall` gates on `logging.getLogger("zettelforge.telemetry").isEnabledFor(DEBUG)`, which requires explicit setLevel on that specific named logger (not just root DEBUG) | triggered the "DEBUG active but payload empty" loop we ran this session | subset of #41 |
+
+## Reproduction queries
+
+```bash
+LOG=/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/logs/zettelforge.log
+TEL=/home/rolandpg/.amem/telemetry/telemetry_$(date -u +%F).jsonl
+SINCE="2026-04-24T23:11:00"
+
+# Aggregate remember() distribution
+jq -s '[.[] | select(.phase_timings_ms != null and .time > "'$SINCE'")] as $r |
+  [$r[] | .duration_ms] as $d |
+  {count: ($r|length), avg: ($d|add/($d|length)|round),
+   p50: ($d|sort|.[($d|length)/2|floor]|round),
+   p95: ($d|sort|.[($d|length)*95/100|floor]|round),
+   max: ($d|max), tails_30s: ([$d[]|select(.>30000)]|length)}' "$LOG"
+
+# Phase share
+jq -s '[.[] | select(.phase_timings_ms != null and .time > "'$SINCE'") | .phase_timings_ms] |
+  reduce .[] as $p ({}; reduce ($p | to_entries[]) as $e (.; .[$e.key] = ((.[$e.key] // 0) + $e.value))) |
+  (to_entries | map(.value) | add) as $total |
+  to_entries | map({phase: .key, total_ms: (.value|round),
+                    pct: ((.value * 1000 / $total | round) / 10)}) | sort_by(-.total_ms)' "$LOG"
+
+# Tail events with full breakdown
+jq -s '[.[] | select(.activity_name=="remember" and .duration_ms > 30000 and .time > "'$SINCE'")] |
+  map({time, note_id, duration_ms, lance_ms: .phase_timings_ms.lance_index,
+       lance_pct: ((.phase_timings_ms.lance_index // 0) * 10000 / .duration_ms | round / 100)})' "$LOG"
+
+# LanceDB fragment count (the real root cause)
+find /home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/vectordb/notes_cti.lance/data -name '*.lance' | wc -l
+```
+
+## Backlog snapshot
+
+Open tasks as of this cutoff (all created during this session):
+
+| ID | Subject |
+|---|---|
+| #35 | Fix hardcoded OCSF version string |
+| #36 | Promote Phase 0.5 attribution doc PRELIMINARY → CONFIRMED |
+| #37 | Compact Vigil's notes_cti LanceDB shard (one-shot, offline) |
+| #38 | Add periodic LanceDB compaction to code (RFC-009 scope expansion) |
+| #39 | Preload fastembed model at MemoryManager init (cold-start) |
+| #40 | Refocus: "what queries return zero?" using DEBUG payload deltas |
+| #41 | Fix log.py ignoring config.yaml log.level |
+| #42 | Investigate graph retriever firing only 1.3% of recalls |
+
+## For the reviewer
+
+- **Am I over-claiming?** The 98.1% phase-share number is from first-party `phase_timings_ms` instrumentation shipped in v2.4.2 — not reconstruction. Tail-event lance share (99.66–99.98%) is even tighter. If you doubt a single number, re-run the jq queries above against the same log file.
+- **Am I under-claiming?** Graph retriever at 1.3% utilization is a bigger product issue than Phase 0.5 lists — if the graph is supposed to be a first-class retrieval signal, we're shipping a 2-signal system that mostly runs as 1.5-signal.
+- **What else should you spot-check?** The 0 consolidation_failed events post-v2.4.2 is the RFC-010 verification; easiest falsification is `jq -s '[.[] | select(.event=="consolidation_failed" and .time > "2026-04-24T23:11:00")] | length' "$LOG"` — any result >0 means RFC-010 regressed.


### PR DESCRIPTION
## Summary
Durable evidence doc capturing everything observed during the post-release v2.4.2 test session against Vigil's live CTI workload. Written so the data survives context loss and can be forwarded to Nexus (or any reviewer) to re-verify each claim against the same log files.

## Why this exists
Patrick asked for notes + proof in case the session is lost or Nexus needs to review. This commits the session's key findings to the repo with full reproduction queries.

## What's in it
- Test timeline (v2.4.2 release → Qwen stop → v2.4.2 first emission → DEBUG activation → Nemotron traffic → data cutoff)
- Config under test + deployment-path note (openclaw-clone, not PyPI)
- **Phase 0.5 attribution CONFIRMED** on first-party `phase_timings_ms` data: 98.1% aggregate, 99.66–99.98% on 8 tail events
- **RFC-010 verified**: 0 consolidation_failed events post-v2.4.2 vs 4 on v2.4.1 same day
- **Root cause for tails**: notes_cti has 7,576 uncompacted fragments (grew +220 in ~6h)
- Tooling issues found in-session: OCSF version hardcoded (#35), log.py config.yaml level ignored (#41), graph retriever firing on 1.3% of recalls (#42)
- Zero-hit rate unchanged by LLM swap — falsifies the "Qwen is the culprit" hypothesis and refocuses #40
- Reproduction `jq` queries for every number claimed

## Review hints (in the doc under "For the reviewer")
- Falsify Phase 0.5: rerun phase-share jq; anything wildly off 98% would falsify
- Falsify RFC-010: `jq '[.[] | select(.event=="consolidation_failed" and .time > "2026-04-24T23:11:00")] | length'` — any >0 means regression
- Hidden issue worth spot-checking: graph retriever at 1.3% utilization is likely a bigger product issue than any single Phase 0.5 number

## Test plan
- [x] Docs-only (no code change, no CI risk)
- [ ] Merge to preserve evidence in repo history

🤖 Generated with [Claude Code](https://claude.com/claude-code)