### PR TITLE
feat(observability): Tier 0/1/2 telemetry patches

### DIFF
--- a/src/zettelforge/entity_indexer.py
+++ b/src/zettelforge/entity_indexer.py
@@ -299,7 +299,14 @@ class EntityExtractor:
         empty = {t: [] for t in expected_types}
 
         if parsed is None:
-            _logger.warning("parse_failed", schema="ner_output", raw=(output or "")[:200])
+            raw = output or ""
+            _logger.warning(
+                "parse_failed",
+                schema="ner_output",
+                reason="empty_completion" if not raw.strip() else "json_decode",
+                raw=raw[:240],
+                raw_chars=len(raw),
+            )
             return empty
 
         # Normalize values

--- a/src/zettelforge/fact_extractor.py
+++ b/src/zettelforge/fact_extractor.py
@@ -63,11 +63,25 @@ class FactExtractor:
 
     def _parse_extraction_response(self, raw: str) -> List[ExtractedFact]:
         if not raw:
+            # Was previously a silent return — empty completions vanished
+            # entirely from the audit trail, undercounting LLM failures.
+            _logger.warning(
+                "parse_failed",
+                schema="fact_extraction",
+                reason="empty_completion",
+                raw="",
+            )
             return []
 
         parsed = extract_json(raw, expect="array")
         if parsed is None:
-            _logger.warning("parse_failed", schema="fact_extraction", raw=raw[:200])
+            _logger.warning(
+                "parse_failed",
+                schema="fact_extraction",
+                reason="json_decode",
+                raw=raw[:240],
+                raw_chars=len(raw),
+            )
             return []
 
         facts = []

--- a/src/zettelforge/llm_providers/ollama_provider.py
+++ b/src/zettelforge/llm_providers/ollama_provider.py
@@ -108,21 +108,22 @@ class OllamaProvider:
         is_empty = not stripped
         log_event = "llm_call_empty_response" if is_empty else "llm_call_complete"
         log_level = _logger.warning if is_empty else _logger.debug
-        log_level(
-            log_event,
-            provider="ollama",
-            model=self._model,
-            duration_ms=round(duration_ms, 1),
-            prompt_chars=prompt_chars,
-            response_chars=response_chars,
-            system_chars=system_chars,
-            max_tokens=max_tokens,
-            temperature=temperature,
-            json_mode=json_mode,
-            eval_count=eval_count,
-            prompt_eval_count=prompt_eval_count,
-            done_reason=done_reason,
-            response_preview=raw_response[:_PREVIEW_CHARS] if is_empty else None,
-            prompt_preview=prompt[:_PREVIEW_CHARS] if is_empty else None,
-        )
+        log_kwargs: dict[str, Any] = {
+            "provider": "ollama",
+            "model": self._model,
+            "duration_ms": round(duration_ms, 1),
+            "prompt_chars": prompt_chars,
+            "response_chars": response_chars,
+            "system_chars": system_chars,
+            "max_tokens": max_tokens,
+            "temperature": temperature,
+            "json_mode": json_mode,
+            "eval_count": eval_count,
+            "prompt_eval_count": prompt_eval_count,
+            "done_reason": done_reason,
+        }
+        if is_empty:
+            log_kwargs["response_preview"] = raw_response[:_PREVIEW_CHARS]
+            log_kwargs["prompt_preview"] = prompt[:_PREVIEW_CHARS]
+        log_level(log_event, **log_kwargs)
         return stripped

--- a/src/zettelforge/llm_providers/ollama_provider.py
+++ b/src/zettelforge/llm_providers/ollama_provider.py
@@ -7,10 +7,16 @@ registry can build instances from :class:`~zettelforge.config.LLMConfig`.
 
 from __future__ import annotations
 
+import time
 from typing import Any, Optional
+
+from zettelforge.log import get_logger
 
 _DEFAULT_MODEL = "qwen2.5:3b"
 _DEFAULT_URL = "http://localhost:11434"
+_PREVIEW_CHARS = 240
+
+_logger = get_logger("zettelforge.llm.ollama")
 
 
 class OllamaProvider:
@@ -65,5 +71,58 @@ class OllamaProvider:
         # targets the default localhost:11434, ignoring this provider's config.
         # ``timeout`` is now threaded through per RFC-010.
         client = ollama.Client(host=self._url, timeout=self._timeout)
-        response = client.generate(**kwargs)
-        return str(response.get("response", "")).strip()
+
+        prompt_chars = len(prompt)
+        system_chars = len(system) if system else 0
+        start = time.perf_counter()
+        try:
+            response = client.generate(**kwargs)
+        except Exception as exc:
+            duration_ms = (time.perf_counter() - start) * 1000
+            _logger.warning(
+                "llm_call_exception",
+                provider="ollama",
+                model=self._model,
+                duration_ms=round(duration_ms, 1),
+                prompt_chars=prompt_chars,
+                system_chars=system_chars,
+                max_tokens=max_tokens,
+                temperature=temperature,
+                json_mode=json_mode,
+                error=type(exc).__name__,
+                error_msg=str(exc)[:200],
+            )
+            raise
+
+        duration_ms = (time.perf_counter() - start) * 1000
+        raw_response = str(response.get("response", ""))
+        stripped = raw_response.strip()
+        response_chars = len(raw_response)
+        eval_count = response.get("eval_count")
+        prompt_eval_count = response.get("prompt_eval_count")
+        done_reason = response.get("done_reason")
+
+        # Empty completion is a distinct failure class — surface it loudly.
+        # Without this, callers like fact_extractor silently no-op on "" and
+        # the failure vanishes from the audit trail entirely.
+        is_empty = not stripped
+        log_event = "llm_call_empty_response" if is_empty else "llm_call_complete"
+        log_level = _logger.warning if is_empty else _logger.debug
+        log_level(
+            log_event,
+            provider="ollama",
+            model=self._model,
+            duration_ms=round(duration_ms, 1),
+            prompt_chars=prompt_chars,
+            response_chars=response_chars,
+            system_chars=system_chars,
+            max_tokens=max_tokens,
+            temperature=temperature,
+            json_mode=json_mode,
+            eval_count=eval_count,
+            prompt_eval_count=prompt_eval_count,
+            done_reason=done_reason,
+            response_preview=raw_response[:_PREVIEW_CHARS] if is_empty else None,
+            prompt_preview=prompt[:_PREVIEW_CHARS] if is_empty else None,
+        )
+        return stripped

--- a/src/zettelforge/log.py
+++ b/src/zettelforge/log.py
@@ -173,6 +173,6 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
             log_level = cfg.logging.level if hasattr(cfg, 'logging') else "INFO"
         except Exception:
             log_level = "INFO"
-        
+
         configure_logging(level=log_level, log_file=log_file, audit_log_file=audit_log_file)
     return structlog.get_logger(name)

--- a/src/zettelforge/log.py
+++ b/src/zettelforge/log.py
@@ -169,8 +169,9 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
         # Load config to get logging level (RFC-007 telemetry support)
         try:
             from zettelforge.config import get_config
+
             cfg = get_config()
-            log_level = cfg.logging.level if hasattr(cfg, 'logging') else "INFO"
+            log_level = cfg.logging.level if hasattr(cfg, "logging") else "INFO"
         except Exception:
             log_level = "INFO"
 

--- a/src/zettelforge/log.py
+++ b/src/zettelforge/log.py
@@ -165,7 +165,7 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
         logs_dir = Path(data_dir) / "logs"
         log_file = str(logs_dir / "zettelforge.log")
         audit_log_file = str(logs_dir / "audit.log")
-        
+
         # Load config to get logging level (RFC-007 telemetry support)
         try:
             from zettelforge.config import get_config

--- a/src/zettelforge/log.py
+++ b/src/zettelforge/log.py
@@ -115,6 +115,15 @@ def configure_logging(
         force=True,
     )
 
+    # Suppress noisy DEBUG-level traffic loggers from HTTP transport stacks.
+    # Without this, when ZF runs at DEBUG (RFC-007 telemetry pilot), httpcore
+    # and httpx emit ~3 lines per LLM/embedding call (connect_tcp.started,
+    # send_request_headers, etc.), drowning the actual application events.
+    # In one 17-min test run these accounted for >1,600 log lines for zero
+    # diagnostic value.
+    for noisy in ("httpcore", "httpcore.http11", "httpcore.connection", "httpx"):
+        logging.getLogger(noisy).setLevel(logging.WARNING)
+
     # structlog: JSON to log file (not stdout/stderr)
     # Use stdlib integration so structlog events flow through the handlers above
     structlog.configure(
@@ -156,5 +165,14 @@ def get_logger(name: str) -> structlog.stdlib.BoundLogger:
         logs_dir = Path(data_dir) / "logs"
         log_file = str(logs_dir / "zettelforge.log")
         audit_log_file = str(logs_dir / "audit.log")
-        configure_logging(log_file=log_file, audit_log_file=audit_log_file)
+        
+        # Load config to get logging level (RFC-007 telemetry support)
+        try:
+            from zettelforge.config import get_config
+            cfg = get_config()
+            log_level = cfg.logging.level if hasattr(cfg, 'logging') else "INFO"
+        except Exception:
+            log_level = "INFO"
+        
+        configure_logging(level=log_level, log_file=log_file, audit_log_file=audit_log_file)
     return structlog.get_logger(name)

--- a/src/zettelforge/memory_evolver.py
+++ b/src/zettelforge/memory_evolver.py
@@ -96,14 +96,29 @@ class MemoryEvolver:
         output = generate(prompt, max_tokens=1024, temperature=0.2, json_mode=True)
         result = extract_json(output, expect="object")
 
-        # Single retry on parse failure (AD-2)
+        # Single retry on parse failure (AD-2). Capture what the model
+        # actually returned so we can diagnose schema/template mismatches
+        # without re-running the test.
         if result is None:
-            self._logger.warning("evolution_parse_retry", neighbor_id=neighbor.id)
+            self._logger.warning(
+                "evolution_parse_retry",
+                neighbor_id=neighbor.id,
+                new_note_id=new_note.id,
+                raw_preview=(output or "")[:240],
+                raw_chars=len(output or ""),
+                prompt_preview=prompt[:240],
+            )
             output = generate(prompt, max_tokens=1024, temperature=0.1, json_mode=True)
             result = extract_json(output, expect="object")
 
         if result is None:
-            self._logger.warning("evolution_parse_failed", neighbor_id=neighbor.id)
+            self._logger.warning(
+                "evolution_parse_failed",
+                neighbor_id=neighbor.id,
+                new_note_id=new_note.id,
+                raw_preview=(output or "")[:240],
+                raw_chars=len(output or ""),
+            )
             return None
 
         # Validate required fields

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -200,9 +200,7 @@ class MemoryManager:
                 start=start,
             )
         finally:
-            structlog.contextvars.unbind_contextvars(
-                "trace_id", "domain", "source_type"
-            )
+            structlog.contextvars.unbind_contextvars("trace_id", "domain", "source_type")
 
     def _remember_inner(
         self,

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -17,6 +17,8 @@ from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Dict, List, Optional, Tuple
 
+import structlog
+
 from zettelforge.alias_resolver import AliasResolver
 from zettelforge.backend_factory import get_storage_backend
 from zettelforge.config import get_config
@@ -176,6 +178,44 @@ class MemoryManager:
         request_id = uuid.uuid4().hex
         start = time.perf_counter()
 
+        # Bind request_id to structlog context so every downstream log line
+        # (fact extraction, entity indexing, evolution, LLM calls, KG writes)
+        # carries this trace_id automatically. Cleared at function exit so it
+        # doesn't leak across sequential remember() calls.
+        structlog.contextvars.bind_contextvars(
+            trace_id=request_id,
+            domain=domain,
+            source_type=source_type,
+        )
+
+        try:
+            return self._remember_inner(
+                content=content,
+                source_type=source_type,
+                source_ref=source_ref,
+                domain=domain,
+                evolve=evolve,
+                sync=sync,
+                request_id=request_id,
+                start=start,
+            )
+        finally:
+            structlog.contextvars.unbind_contextvars(
+                "trace_id", "domain", "source_type"
+            )
+
+    def _remember_inner(
+        self,
+        content: str,
+        source_type: str,
+        source_ref: str,
+        domain: str,
+        evolve: bool,
+        sync: bool,
+        request_id: str,
+        start: float,
+    ) -> Tuple[MemoryNote, str]:
+        """Inner body of remember(); split out so trace_id binding can wrap it."""
         # Governance validation
         try:
             self.governance.enforce("remember", content)


### PR DESCRIPTION
## Summary

Surfaces blind spots discovered during the 2026-04-24 Nemotron-3-nano debug session — 7,892 notes ingested, 651 `evolution_parse_failed` events, 306 empty completions, and we could not see what the model was actually returning.

After this PR, every LLM call logs full I/O telemetry, parse failures carry diagnostic context, and a propagating `trace_id` lets you reconstruct a single `remember()` call across the synchronous pipeline.

## Changes

| File | Change |
|---|---|
| `llm_providers/ollama_provider.py` | Every call logs duration, prompt/response chars, eval_count, prompt_eval_count, done_reason. Empty completions WARN with full preview. Exceptions classified before re-raise. |
| `memory_evolver.py` | `evolution_parse_retry`/`_failed` carry `raw_preview`, `raw_chars`, `prompt_preview`, `new_note_id`. |
| `fact_extractor.py` | Empty completions logged (was silent). Failures classified: `empty_completion` vs `json_decode`. |
| `entity_indexer.py` | NER `parse_failed` gets reason classification + `raw_chars`. |
| `memory_manager.py` | `trace_id` bound to `structlog.contextvars` at `remember()` entry, auto-propagates to all downstream synchronous log lines. Background workers do **not** yet rebind — tracked in RFC-008. |
| `log.py` | Suppress httpcore/httpx DEBUG (1,612 lines of noise per 17-min test run). |

## Verification

- AST parse: clean on all 6 files
- Import smoke test: clean (`OllamaProvider`, `MemoryEvolver`, `FactExtractor`, `EntityIndexer`, `MemoryManager`)
- Functional smoke test: synthetic empty-response call emits `llm_call_empty_response` with full payload including `trace_id`, `domain`, `provider`, `duration_ms`, `prompt_eval_count`, `done_reason`, `prompt_preview`, `response_preview` ✅

## Out of Scope

- Background-worker `trace_id` rebinding (sync path only)
- SQLite/LanceDB/embedding instrumentation
- Enrichment-queue heartbeat (910/878/836 saturation events seen in test, no metrics)
- Lifecycle events (start/stop config dump)

All deferred to **RFC-008** (in parent repo: `rfc/rfc-008-zettelforge-observability-tier3.md`).

## Test Plan

- [ ] Re-run Nemotron-3-nano short ingestion (~10 min) and verify the new event names appear in `zettelforge.log`
- [ ] Grep one `trace_id` and confirm it links the `remember()` entry to its child events (fact extraction, entity indexing, evolution)
- [ ] Confirm httpcore noise is gone (no `connect_tcp.started` lines)
- [ ] Spot-check that `llm_call_empty_response` events include actionable `prompt_preview` for the failing schemas (`causal_triples`, `ner_output`, evolution)

🤖 Generated with [Claude Code](https://claude.com/claude-code)