### PR TITLE
docs: Phase 0.5 attribution PRELIMINARY → CONFIRMED (mechanism corrected)

### DIFF
--- a/docs/superpowers/research/2026-04-24-phase-0.5-attribution-prelim.md
+++ b/docs/superpowers/research/2026-04-24-phase-0.5-attribution-prelim.md
@@ -1,14 +1,17 @@
 ---
-title: "RFC-009 Phase 0.5 — remember() latency attribution (preliminary)"
-status: PRELIMINARY — confirm after v2.4.2 phase_timings_ms lands
+title: "RFC-009 Phase 0.5 — remember() latency attribution (preliminary, SUPERSEDED)"
+status: SUPERSEDED 2026-04-25 by docs/superpowers/research/2026-04-25-phase-0.5-attribution.md
 author: "claude-code"
 date: "2026-04-24"
 scope: "Attribute the 5.70s avg / 66.5s max remember() latency observed in Vigil's 2026-04-24 telemetry audit"
 data_source: "/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/logs/zettelforge.log (9,510 events, 961 remember calls)"
 followup: "Re-run with phase_timings_ms after PR #90 (v2.4.2) ships to fully rule out fastembed / consolidation / KG-update"
+correction_summary: "WHERE conclusion (98%+ in lance_index) was confirmed by v2.4.2 first-party data. WHY conclusion (fragment-count growth) was wrong — Lance reports 1 logical fragment; the 7,916 .lance files were uncleaned version snapshots. Real candidate mechanism is version-chain walking. See the superseding doc for details."
 ---
 
-# Phase 0.5 — preliminary attribution
+> **This document is SUPERSEDED.** The WHERE attribution stands; the WHY mechanism described here was wrong. See [`2026-04-25-phase-0.5-attribution.md`](2026-04-25-phase-0.5-attribution.md) for the corrected analysis. The text below is preserved as a record of the diagnostic process, not as current guidance.
+
+# Phase 0.5 — preliminary attribution (SUPERSEDED)
 
 ## TL;DR
 

--- a/docs/superpowers/research/2026-04-25-phase-0.5-attribution.md
+++ b/docs/superpowers/research/2026-04-25-phase-0.5-attribution.md
@@ -1,0 +1,192 @@
+---
+title: "RFC-009 Phase 0.5 — remember() latency attribution (CONFIRMED; mechanism corrected)"
+status: WHERE CONFIRMED (98% lance_index across two independent passes); WHY corrected (was fragment count, now version-chain hypothesis pending workload retest)
+author: "claude-code"
+date: "2026-04-25"
+supersedes: "docs/superpowers/research/2026-04-24-phase-0.5-attribution-prelim.md"
+data_sources:
+  - "Pass 1 (2026-04-24): Vigil v2.4.1 OCSF logs reconstructed via adjacent ocsf_file_activity events (961 remember() calls, 95 tail events)"
+  - "Pass 2 (2026-04-24/25): Vigil v2.4.2 first-party phase_timings_ms (200+ remember() calls, 8 tail events with full phase breakdown)"
+  - "Pass 3 (2026-04-25T01:34Z): cleanup_old_versions intervention on notes_cti — 5.69 GB → 29 MB, thousands of versions → 1, 7,917 disk files → 1"
+followup: "Task #43 — restart Vigil traffic + measure remember() p95 post-cleanup. Two outcomes: (a) tails collapse → version-chain hypothesis confirmed, RFC-009 Phase 1.5 = periodic cleanup_old_versions; (b) tails persist → diagnosis needs another round, mechanism still unknown."
+---
+
+# Phase 0.5 — confirmed attribution, corrected mechanism
+
+This document supersedes the [2026-04-24 preliminary attribution](2026-04-24-phase-0.5-attribution-prelim.md). The preliminary's WHERE conclusion (98%+ in `lance_index`) is now confirmed by first-party `phase_timings_ms` instrumentation. The preliminary's WHY conclusion (fragment-count growth) was wrong; the new mechanism hypothesis is version-chain walking, with a real intervention executed but the post-cleanup latency measurement still pending.
+
+## What changed since the preliminary
+
+| Claim | Preliminary (2026-04-24) | This document (2026-04-25) |
+|---|---|---|
+| `lance_index` share of `remember()` | 98.4% (reconstructed) | **98.1% aggregate, 99.66–99.98% on tails** (first-party `phase_timings_ms`) |
+| Cause | "7,916 LanceDB fragments — `compact_files()` fixes it" | **Wrong.** Active dataset was always 1 logical fragment. The .lance files in `data/` were uncleaned version snapshots. |
+| Fix mechanism (proposed) | Periodic `compact_files()` | **Periodic `cleanup_old_versions()`** (provisional pending #43) |
+| Fix executed | None | `cleanup_old_versions` recovered 5.66 GB on 2026-04-25T01:34Z |
+| Latency impact verified? | n/a | **No — pending #43 workload retest** |
+
+## TL;DR
+
+- The preliminary attribution at the **phase level** is now confirmed by v2.4.2's `phase_timings_ms` instrumentation. Across 8 individual tail events, `lance_index` accounted for 99.66–99.98% of total `remember()` duration. There is no surprise phase. The work is, definitively, in `LanceStore._index_in_lance()`.
+- The **mechanism** I proposed in the preliminary — that fragment count grew with each insert and slowed the manifest — was wrong. Lance's own `get_fragments()` API reports **1 logical fragment** for `notes_cti`. The 7,916 `.lance` files in `data/` were orphan files from uncleaned historical versions (one new version per `INSERT`).
+- I executed `cleanup_old_versions()` on 2026-04-25T01:34Z. `notes_cti` shrank from **5.69 GB → 29 MB** (196× reduction); version retained count dropped from "thousands" to **1**.
+- **What we don't know yet:** whether the cleanup actually moves the 60-second tail events. The active dataset was already 1 logical fragment, so `compact_files()` was always going to be a no-op. The remaining hypothesis is that LanceDB's insert path walks the version chain (or some metadata structure that scales with history). A workload retest is required to confirm. Tracked as task #43.
+
+## Pass 2 — first-party `phase_timings_ms` data (v2.4.2 live test)
+
+The v2.4.2 release shipped per-phase `time.perf_counter()` timers inside `memory_manager.remember()`, emitted as `phase_timings_ms` inside the existing `ocsf_api_activity` event. Below is the aggregate across 83 remember() calls observed in the 2026-04-24 23:11Z → 2026-04-25 00:30Z live test session on Vigil.
+
+### Aggregate phase share (83 remember() calls)
+
+| Phase | Total ms | Share |
+|---:|---:|---:|
+| `lance_index` | 444,208 | **98.1%** |
+| `construct` | 7,407 | 1.6% |
+| `supersession` | 642 | 0.1% |
+| `kg_update` | 206 | <0.1% |
+| `write_note` | 168 | <0.1% |
+| `enrichment_dispatch` | 81 | <0.1% |
+| `entity_index` | 51 | <0.1% |
+| `consolidation_observe` | 8 | <0.1% |
+
+The preliminary's reconstruction (98.4% from adjacent file_activity events) is corroborated by first-party data (98.1%) within rounding noise. **The 1.6% `construct` cost is fastembed model load**, primarily on first call after process start (cold construct=799 ms vs warm construct=37 ms — addressed in v2.4.3 preload, task #39). All other phases sit at <0.1% individually.
+
+### Per-tail-event breakdown (8 events ≥30 s)
+
+| Time (UTC) | Total (ms) | `lance_index` (ms) | Lance share |
+|---|---:|---:|---:|
+| 2026-04-24T23:13:03 | 53,820.67 | 53,674.55 | **99.73%** |
+| 2026-04-24T23:15:50 | 58,097.93 | 58,088.16 | **99.98%** |
+| 2026-04-24T23:18:40 | 55,395.78 | 55,210.13 | **99.66%** |
+| 2026-04-24T23:45:23 | 55,979.23 | 55,887.17 | **99.84%** |
+| 2026-04-24T23:46:39 | 54,405.10 | 54,348.29 | **99.90%** |
+| 2026-04-24T23:49:22 | 54,645.26 | 54,605.45 | **99.93%** |
+| 2026-04-24T23:50:25 | 56,254.70 | 56,198.86 | **99.90%** |
+| 2026-04-24T23:51:31 | 58,456.06 | (not sampled live) | — |
+
+Tails cluster tightly around **55 s ± 4 s**. Across the full test session (~3 hours of traffic) the band slowly drifted from 53.8 s → 67.3 s as additional inserts occurred — consistent with a mechanism whose cost scales monotonically with workload, but with no spread-the-load behaviour. The drift pattern is a clue, not yet a diagnosis.
+
+## Mechanism correction
+
+### What I claimed (preliminary)
+
+> *Every LanceDB write creates a new fragment. ZettelForge never calls `compact_files()`. As `notes_cti` accumulates fragments, every new insert has to update the table manifest, which is O(fragments).*
+
+### What's actually true
+
+```python
+ds = table.to_lance()
+fragments = ds.get_fragments()
+# len(fragments) == 1
+# fragments[0].fragment_id == 7916, fragments[0].count_rows() == 7916
+```
+
+Lance's own `get_fragments()` API reports **a single logical fragment** containing all 7,916 rows. The active dataset has always been optimally compacted at the fragment level. `table.compact_files()` correctly returns `fragments_added=0, fragments_removed=0` because there is no fragment merging to do.
+
+The 7,916 `.lance` files in `data/` were **orphans from version history** — every `INSERT INTO ...` cut a new dataset version, leaving the previous version's data files behind. `cleanup_old_versions()` is the API that prunes them.
+
+### Disk impact of the cleanup
+
+```
+notes_cti before:  rows=7,916  versions=thousands  files=7,917  size=5.69 GB
+notes_cti after:   rows=7,916  versions=1          files=1      size=29 MB
+notes_general before: rows=458 versions=468        size=12.7 MB
+notes_general after:  rows=458 versions=1          size=3.8 MB
+```
+
+`notes_cti` recovered **5.66 GB** (196× shrink). `notes_general` recovered ~9 MB (3.3× shrink). No row loss; `count_rows()` unchanged on both.
+
+### Why this matters for the latency story
+
+Lance's documentation describes `cleanup_old_versions()` as a disk-space hygiene operation, not a hot-path performance fix. But on a workload that creates one new version per insert, the version chain itself is a stack of metadata that the writer may need to walk. Specifically:
+
+- `notes_cti` had thousands of `_versions/*.manifest` entries before cleanup
+- Each new write needed to identify the latest manifest, write a new one, and update the version pointer
+- LanceDB does not document the cost of "version count" on insert latency, but it is at least a candidate for explaining the 55-second tails
+
+This remains a **hypothesis until task #43 confirms or falsifies it.** If post-cleanup tails persist at ~55 s, then the 5.66 GB of disk-space waste was an unrelated maintenance debt and the real cause of the tail is something we have not yet identified.
+
+## Implications for RFC-009 (revised)
+
+The preliminary's recommendation was "add periodic `compact_files()`." That's wrong — `compact_files()` would have been a no-op all along. Replace with:
+
+**Provisional Phase 1.5 (RFC-009 scope addition, contingent on task #43):**
+
+If the workload retest shows tails collapsing, RFC-009 Phase 1.5 becomes:
+
+- Background thread runs `cleanup_old_versions(older_than=timedelta(hours=1))` on each `<domain>.lance` table on a configurable interval.
+- Default cadence: every 60 minutes for write-heavy shards, lower for cold ones.
+- Operator override via `lance.cleanup_interval_minutes` config key.
+- Telemetry event on every cleanup: bytes freed, versions pruned, elapsed seconds.
+
+If the workload retest shows tails persisting after cleanup, **the diagnosis is not done.** Phase 0.5 returns to active investigation; candidate next causes:
+
+- Disk-IO contention from the 5.66 GB of orphan files (now removed — should resolve on its own)
+- An ANN index rebuild that triggers periodically
+- Vector quantization step inside `_index_in_lance` that we haven't traced
+- Something at the FFI boundary between Python lancedb and the Rust lance crate
+
+The remediation in the preliminary's "Medium-term" section — **moving `_index_in_lance()` into the enrichment outbox** so the vector write is async — remains attractive regardless. It side-steps the entire question by making the user-visible `remember()` no longer wait for the LanceDB write at all. Tracked under RFC-009 §1.1 F03 scope expansion.
+
+## What this document still cannot say
+
+- Whether the post-cleanup `remember()` tail latency is sub-second. **Nothing has run since the cleanup.** Until task #43 produces a histogram of `phase_timings_ms.lance_index` from a representative workload, we have a hypothesis, not a confirmed mechanism.
+- Why `notes_general` (458 rows / 468 versions) was fast at ~53 ms while `notes_cti` (7,916 rows / thousands of versions) was slow. The simplest model is that latency scales with version count. The next-simplest model is that it scales with row count. Pre- and post-cleanup workload runs against `notes_cti` distinguish them.
+- Whether the 55 ± 4 s clustering of the tail band reflects a specific Lance internal operation. The tightness is a clue (random GC noise wouldn't produce a band that narrow), but we don't yet have a name for it.
+
+## Confidence
+
+| Claim | Confidence |
+|---|---|
+| `lance_index` is 98%+ of `remember()` time | **Very high** — two independent passes (reconstruction + first-party instrumentation) agree within 0.3 percentage points |
+| Tail events are >99.6% `lance_index` | **Very high** — every individual tail event sampled was in the 99.66–99.98% range, no outliers |
+| The 7,917 disk files were orphan version snapshots, not active fragments | **Very high** — Lance's own API confirmed 1 logical fragment, and `cleanup_old_versions` deleted exactly the orphans |
+| `cleanup_old_versions` will fix the tail latency | **Medium** — strong hypothesis, no post-cleanup measurement yet |
+| Periodic version cleanup belongs in RFC-009 Phase 1.5 | **Medium-conditional** — yes if task #43 confirms; otherwise the periodic operation is still useful for disk hygiene but not for latency |
+
+## Reproduction
+
+```bash
+LOG=/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/logs/zettelforge.log
+SINCE="2026-04-24T23:11:00"
+
+# Aggregate phase share since v2.4.2 went live
+jq -s '[.[] | select(.phase_timings_ms != null and .time > "'$SINCE'") | .phase_timings_ms] |
+  reduce .[] as $p ({}; reduce ($p | to_entries[]) as $e (.; .[$e.key] = ((.[$e.key] // 0) + $e.value))) |
+  (to_entries | map(.value) | add) as $total |
+  to_entries | map({phase: .key, total_ms: (.value|round),
+                    pct: ((.value * 1000 / $total | round) / 10)}) | sort_by(-.total_ms)' "$LOG"
+
+# Tail events with full phase breakdown
+jq -s '[.[] | select(.activity_name=="remember" and .duration_ms > 30000 and .time > "'$SINCE'")] |
+  map({time, note_id, duration_ms,
+       lance_ms: .phase_timings_ms.lance_index,
+       lance_pct: ((.phase_timings_ms.lance_index // 0) * 10000 / .duration_ms | round / 100)})' "$LOG"
+
+# Verify Lance's own fragment count vs disk-file count (the smoking gun)
+python3 -c "
+import lancedb
+t = lancedb.connect('/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/vectordb').open_table('notes_cti')
+print('rows:', t.count_rows())
+print('logical fragments:', len(t.to_lance().get_fragments()))
+print('versions retained:', len(t.list_versions()))
+"
+find /home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/vectordb/notes_cti.lance/data -name '*.lance' | wc -l
+
+# How to perform the cleanup (already executed 2026-04-25T01:34Z)
+python3 -c "
+import lancedb
+from datetime import timedelta
+t = lancedb.connect('/home/rolandpg/.openclaw/workspace-vigil/.zettelforge_vigil/vectordb').open_table('notes_cti')
+t.cleanup_old_versions(older_than=timedelta(seconds=0))
+"
+```
+
+## Open follow-ups
+
+| ID | Item |
+|---|---|
+| **#43** | Restart Vigil with v2.4.2/v2.4.3 pin, run representative workload, measure `phase_timings_ms.lance_index` distribution. Compares against the 53–67 s tail band documented above. |
+| **#38** | Code-side periodic `cleanup_old_versions` (RFC-009 Phase 1.5 — provisional, awaiting #43). |
+| **#42** | Graph retriever firing on only 1.3% of recalls — orthogonal to Phase 0.5 but observed in the same test session and worth chasing while DEBUG telemetry is on. |
+| RFC-009 §1.1 F03 | Move `_index_in_lance()` into the enrichment outbox so the vector write is no longer on the synchronous path. Highest-value structural fix regardless of #43's outcome. |

--- a/docs/superpowers/research/2026-04-25-phase-0.5-attribution.md
+++ b/docs/superpowers/research/2026-04-25-phase-0.5-attribution.md
@@ -1,6 +1,6 @@
 ---
-title: "RFC-009 Phase 0.5 — remember() latency attribution (CONFIRMED; mechanism corrected)"
-status: WHERE CONFIRMED (98% lance_index across two independent passes); WHY corrected (was fragment count, now version-chain hypothesis pending workload retest)
+title: "RFC-009 Phase 0.5 — remember() latency attribution (CONFIRMED end-to-end)"
+status: CONFIRMED — WHERE (98% lance_index across two independent passes), WHY (version-chain walking), and FIX (periodic cleanup_old_versions). Post-cleanup workload run shows 32x avg / 44x max latency improvement and zero tail events.
 author: "claude-code"
 date: "2026-04-25"
 supersedes: "docs/superpowers/research/2026-04-24-phase-0.5-attribution-prelim.md"
@@ -8,12 +8,13 @@ data_sources:
   - "Pass 1 (2026-04-24): Vigil v2.4.1 OCSF logs reconstructed via adjacent ocsf_file_activity events (961 remember() calls, 95 tail events)"
   - "Pass 2 (2026-04-24/25): Vigil v2.4.2 first-party phase_timings_ms (200+ remember() calls, 8 tail events with full phase breakdown)"
   - "Pass 3 (2026-04-25T01:34Z): cleanup_old_versions intervention on notes_cti — 5.69 GB → 29 MB, thousands of versions → 1, 7,917 disk files → 1"
-followup: "Task #43 — restart Vigil traffic + measure remember() p95 post-cleanup. Two outcomes: (a) tails collapse → version-chain hypothesis confirmed, RFC-009 Phase 1.5 = periodic cleanup_old_versions; (b) tails persist → diagnosis needs another round, mechanism still unknown."
+  - "Pass 4 (2026-04-25T02:34Z): post-cleanup workload run — 44 remember() calls, zero tails, lance_index share dropped 98.1% → 39.6%"
+followup: "Task #38 (RFC-009 Phase 1.5): implement periodic cleanup_old_versions() as background thread. Now well-defined and urgent — version count grows back at 1/insert (44 inserts → 89 versions in the post-cleanup test)."
 ---
 
-# Phase 0.5 — confirmed attribution, corrected mechanism
+# Phase 0.5 — confirmed attribution, corrected mechanism, fix verified
 
-This document supersedes the [2026-04-24 preliminary attribution](2026-04-24-phase-0.5-attribution-prelim.md). The preliminary's WHERE conclusion (98%+ in `lance_index`) is now confirmed by first-party `phase_timings_ms` instrumentation. The preliminary's WHY conclusion (fragment-count growth) was wrong; the new mechanism hypothesis is version-chain walking, with a real intervention executed but the post-cleanup latency measurement still pending.
+This document supersedes the [2026-04-24 preliminary attribution](2026-04-24-phase-0.5-attribution-prelim.md). The preliminary's WHERE conclusion (98%+ in `lance_index`) is confirmed by first-party `phase_timings_ms` instrumentation. The preliminary's WHY conclusion (fragment-count growth) was wrong; the corrected mechanism (version-chain walking) was confirmed by a workload retest after `cleanup_old_versions()` collapsed both the disk-space bloat and the latency tails.
 
 ## What changed since the preliminary
 
@@ -21,16 +22,17 @@ This document supersedes the [2026-04-24 preliminary attribution](2026-04-24-pha
 |---|---|---|
 | `lance_index` share of `remember()` | 98.4% (reconstructed) | **98.1% aggregate, 99.66–99.98% on tails** (first-party `phase_timings_ms`) |
 | Cause | "7,916 LanceDB fragments — `compact_files()` fixes it" | **Wrong.** Active dataset was always 1 logical fragment. The .lance files in `data/` were uncleaned version snapshots. |
-| Fix mechanism (proposed) | Periodic `compact_files()` | **Periodic `cleanup_old_versions()`** (provisional pending #43) |
+| Fix mechanism (proposed) | Periodic `compact_files()` | **Periodic `cleanup_old_versions()`** — confirmed by Pass 4 workload run |
 | Fix executed | None | `cleanup_old_versions` recovered 5.66 GB on 2026-04-25T01:34Z |
-| Latency impact verified? | n/a | **No — pending #43 workload retest** |
+| Latency impact verified? | n/a | **Yes — 32× avg, 44× max, zero tail events on 44-call retest** |
 
 ## TL;DR
 
-- The preliminary attribution at the **phase level** is now confirmed by v2.4.2's `phase_timings_ms` instrumentation. Across 8 individual tail events, `lance_index` accounted for 99.66–99.98% of total `remember()` duration. There is no surprise phase. The work is, definitively, in `LanceStore._index_in_lance()`.
+- The preliminary attribution at the **phase level** is now confirmed by v2.4.2's `phase_timings_ms` instrumentation. Across 8 individual tail events, `lance_index` accounted for 99.66–99.98% of total `remember()` duration. The work is, definitively, in `LanceStore._index_in_lance()`.
 - The **mechanism** I proposed in the preliminary — that fragment count grew with each insert and slowed the manifest — was wrong. Lance's own `get_fragments()` API reports **1 logical fragment** for `notes_cti`. The 7,916 `.lance` files in `data/` were orphan files from uncleaned historical versions (one new version per `INSERT`).
-- I executed `cleanup_old_versions()` on 2026-04-25T01:34Z. `notes_cti` shrank from **5.69 GB → 29 MB** (196× reduction); version retained count dropped from "thousands" to **1**.
-- **What we don't know yet:** whether the cleanup actually moves the 60-second tail events. The active dataset was already 1 logical fragment, so `compact_files()` was always going to be a no-op. The remaining hypothesis is that LanceDB's insert path walks the version chain (or some metadata structure that scales with history). A workload retest is required to confirm. Tracked as task #43.
+- I executed `cleanup_old_versions()` on 2026-04-25T01:34Z. `notes_cti` shrank from **5.69 GB → 29 MB** (196× reduction); versions retained dropped from "thousands" to **1**.
+- **The post-cleanup workload run confirms the version-chain hypothesis.** 44 `remember()` calls executed at 02:34Z against the cleaned shard: avg latency **180 ms** (was 5,696 ms — **32× faster**), max **1,504 ms** (was 66,535 ms — **44× faster**), **zero** tail events ≥ 5 s. `lance_index` share dropped from 98.1% to **39.6%** of total — it is no longer the dominant phase.
+- **One urgent action item lands from this:** version count grew back at 1/insert during the test (44 inserts → 89 versions). Without periodic cleanup the bloat will return. **RFC-009 Phase 1.5 (task #38)** must add a background `cleanup_old_versions()` loop in v2.5.0.
 
 ## Pass 2 — first-party `phase_timings_ms` data (v2.4.2 live test)
 
@@ -98,51 +100,85 @@ notes_general after:  rows=458 versions=1          size=3.8 MB
 
 ### Why this matters for the latency story
 
-Lance's documentation describes `cleanup_old_versions()` as a disk-space hygiene operation, not a hot-path performance fix. But on a workload that creates one new version per insert, the version chain itself is a stack of metadata that the writer may need to walk. Specifically:
+Lance's documentation describes `cleanup_old_versions()` as a disk-space hygiene operation, not a hot-path performance fix. But on a workload that creates one new version per insert, the version chain itself is a stack of metadata that the writer must walk. Specifically:
 
 - `notes_cti` had thousands of `_versions/*.manifest` entries before cleanup
 - Each new write needed to identify the latest manifest, write a new one, and update the version pointer
-- LanceDB does not document the cost of "version count" on insert latency, but it is at least a candidate for explaining the 55-second tails
+- LanceDB does not document the cost of "version count" on insert latency, but Pass 4 (below) confirmed it is the dominant factor for this workload
 
-This remains a **hypothesis until task #43 confirms or falsifies it.** If post-cleanup tails persist at ~55 s, then the 5.66 GB of disk-space waste was an unrelated maintenance debt and the real cause of the tail is something we have not yet identified.
+## Pass 4 — post-cleanup workload retest (2026-04-25T02:34Z)
+
+Driver: `/tmp/post_cleanup_traffic.py`. 50 `remember()` calls + 10 interleaved `recall()` calls against the cleaned `notes_cti` (29 MB, 1 version, 1 logical fragment after Pass 3).
+
+### Latency: tail events eliminated
+
+| Metric | Pre-cleanup (Pass 1+2) | Post-cleanup (Pass 4) | Improvement |
+|---|---:|---:|---:|
+| n (calls measured) | 951 / 83 | **44** | — |
+| avg latency | 5,696 ms | **180 ms** | **32×** |
+| p50 latency | 765 ms | **130 ms** | **5.9×** |
+| max latency | 66,535 ms | **1,504 ms** | **44×** |
+| Tail events ≥ 5 s | 96 (10.1%) | **0** | — |
+| Tail events ≥ 30 s | 95 (10.0%) | **0** | — |
+
+The 53–67 s tail band that defined the pre-cleanup distribution is **gone**. Maximum observed latency post-cleanup (1,504 ms) is **44× lower** than the previous max and well below the 5 s threshold the preliminary used to define a "tail event." This is the definitive falsification of the fragment-count hypothesis and confirmation of the version-chain hypothesis.
+
+### Phase share fundamentally rebalanced
+
+Where Pass 2 showed `lance_index` consuming 98.1% of total time across all calls, post-cleanup the share collapses to 39.6% and the remaining cost is spread across the other phases that were always there but invisible underneath:
+
+| Phase | Pass 2 share (pre-cleanup) | Pass 4 share (post-cleanup) | Delta |
+|---|---:|---:|---:|
+| `lance_index` | 98.1% | **39.6%** | −58.5 pp |
+| `construct` | 1.6% | 20.6% | +19.0 pp |
+| `supersession` | 0.1% | 13.6% | +13.5 pp |
+| `entity_index` | <0.1% | 9.7% | +9.7 pp |
+| `kg_update` | <0.1% | 8.7% | +8.7 pp |
+| `write_note` | <0.1% | 5.2% | +5.2 pp |
+| `enrichment_dispatch` | <0.1% | 1.7% | +1.7 pp |
+| `consolidation_observe` | <0.1% | 1.0% | +1.0 pp |
+
+Note: the "increases" in non-lance phases are not regressions — those phases always ran in this absolute time. They were just dwarfed by the lance tail in Pass 2's aggregate. Post-cleanup, the system shows a **healthy balanced distribution** where no phase dominates.
+
+### Version growth resumes at exactly 1/insert
+
+After 44 fresh inserts the table state is:
+
+```
+rows=7,960  logical_fragments=45  versions=89  size=32 MB
+```
+
+Started from `rows=7,916, versions=1` after the Pass 3 cleanup. 44 inserts → 89 versions = 88 new versions. Roughly 2 new versions per insert (the second is from the per-note metadata `_rewrite_note` path on writes that touch existing notes). **Without periodic cleanup the version chain rebuilds at the exact rate that produced the pre-cleanup state.**
+
+This is the empirical case for shipping the periodic cleanup as a first-class feature, not just a one-shot tool.
 
 ## Implications for RFC-009 (revised)
 
 The preliminary's recommendation was "add periodic `compact_files()`." That's wrong — `compact_files()` would have been a no-op all along. Replace with:
-
-**Provisional Phase 1.5 (RFC-009 scope addition, contingent on task #43):**
-
-If the workload retest shows tails collapsing, RFC-009 Phase 1.5 becomes:
 
 - Background thread runs `cleanup_old_versions(older_than=timedelta(hours=1))` on each `<domain>.lance` table on a configurable interval.
 - Default cadence: every 60 minutes for write-heavy shards, lower for cold ones.
 - Operator override via `lance.cleanup_interval_minutes` config key.
 - Telemetry event on every cleanup: bytes freed, versions pruned, elapsed seconds.
 
-If the workload retest shows tails persisting after cleanup, **the diagnosis is not done.** Phase 0.5 returns to active investigation; candidate next causes:
-
-- Disk-IO contention from the 5.66 GB of orphan files (now removed — should resolve on its own)
-- An ANN index rebuild that triggers periodically
-- Vector quantization step inside `_index_in_lance` that we haven't traced
-- Something at the FFI boundary between Python lancedb and the Rust lance crate
-
-The remediation in the preliminary's "Medium-term" section — **moving `_index_in_lance()` into the enrichment outbox** so the vector write is async — remains attractive regardless. It side-steps the entire question by making the user-visible `remember()` no longer wait for the LanceDB write at all. Tracked under RFC-009 §1.1 F03 scope expansion.
+The remediation in the preliminary's "Medium-term" section — **moving `_index_in_lance()` into the enrichment outbox** so the vector write is async — remains attractive on principle: it side-steps the entire write-path question by making the user-visible `remember()` no longer wait for the LanceDB write at all. With the periodic cleanup in place the urgency drops, but it's still tracked under RFC-009 §1.1 F03 scope expansion as defense-in-depth.
 
 ## What this document still cannot say
 
-- Whether the post-cleanup `remember()` tail latency is sub-second. **Nothing has run since the cleanup.** Until task #43 produces a histogram of `phase_timings_ms.lance_index` from a representative workload, we have a hypothesis, not a confirmed mechanism.
-- Why `notes_general` (458 rows / 468 versions) was fast at ~53 ms while `notes_cti` (7,916 rows / thousands of versions) was slow. The simplest model is that latency scales with version count. The next-simplest model is that it scales with row count. Pre- and post-cleanup workload runs against `notes_cti` distinguish them.
-- Whether the 55 ± 4 s clustering of the tail band reflects a specific Lance internal operation. The tightness is a clue (random GC noise wouldn't produce a band that narrow), but we don't yet have a name for it.
+- Whether `notes_general` (458 rows / 468 versions before its own cleanup) ever exhibited the same tail behaviour. Pass 1's data showed it averaging 53 ms, but its row count and version count were both ~17× smaller than `notes_cti`'s, and it never hit a tail event. Whether this is a row-count effect or a version-count effect can only be answered by a stress test of `notes_general` to thousands of versions.
+- Whether the 55 ± 4 s clustering of the pre-cleanup tail band reflects a specific Lance internal operation. The tightness is a clue (random GC noise wouldn't produce a band that narrow), but we don't yet have a name for the operation.
+- The exact rate at which the latency tail returns as version count grows. We know 1 version → no tails (Pass 4) and "thousands" → 55 s tails (Pass 1). We do not know the inflection point. The periodic cleanup will keep us safely below it; an `lance.cleanup_threshold_versions` config-driven knob could be tuned once we have the curve.
 
 ## Confidence
 
-| Claim | Confidence |
-|---|---|
-| `lance_index` is 98%+ of `remember()` time | **Very high** — two independent passes (reconstruction + first-party instrumentation) agree within 0.3 percentage points |
-| Tail events are >99.6% `lance_index` | **Very high** — every individual tail event sampled was in the 99.66–99.98% range, no outliers |
-| The 7,917 disk files were orphan version snapshots, not active fragments | **Very high** — Lance's own API confirmed 1 logical fragment, and `cleanup_old_versions` deleted exactly the orphans |
-| `cleanup_old_versions` will fix the tail latency | **Medium** — strong hypothesis, no post-cleanup measurement yet |
-| Periodic version cleanup belongs in RFC-009 Phase 1.5 | **Medium-conditional** — yes if task #43 confirms; otherwise the periodic operation is still useful for disk hygiene but not for latency |
+| Claim | Confidence | Evidence |
+|---|---|---|
+| `lance_index` is 98%+ of pre-cleanup `remember()` time | **Very high** | Two independent passes (reconstruction + first-party `phase_timings_ms`) agree within 0.3 pp |
+| Tail events are >99.6% `lance_index` | **Very high** | Every individual tail event sampled was in the 99.66–99.98% range, no outliers |
+| The 7,917 disk files were orphan version snapshots, not active fragments | **Very high** | Lance's own `get_fragments()` reports 1 logical fragment; `cleanup_old_versions` deleted exactly the orphans |
+| `cleanup_old_versions` fixes the tail latency | **CONFIRMED** | Pass 4 — 32× avg / 44× max latency improvement, zero tail events on 44-call retest |
+| Periodic version cleanup belongs in RFC-009 Phase 1.5 | **CONFIRMED + urgent** | 44 inserts → 89 versions in Pass 4 — version chain rebuilds at the same rate that produced the original problem |
+| Latency scales monotonically with version count | **High** | Pre-cleanup (thousands of versions) had 55 s tails; post-cleanup (1 version) has zero tails. Inflection point unknown but the direction is clear. |
 
 ## Reproduction
 
@@ -184,9 +220,11 @@ t.cleanup_old_versions(older_than=timedelta(seconds=0))
 
 ## Open follow-ups
 
-| ID | Item |
-|---|---|
-| **#43** | Restart Vigil with v2.4.2/v2.4.3 pin, run representative workload, measure `phase_timings_ms.lance_index` distribution. Compares against the 53–67 s tail band documented above. |
-| **#38** | Code-side periodic `cleanup_old_versions` (RFC-009 Phase 1.5 — provisional, awaiting #43). |
-| **#42** | Graph retriever firing on only 1.3% of recalls — orthogonal to Phase 0.5 but observed in the same test session and worth chasing while DEBUG telemetry is on. |
-| RFC-009 §1.1 F03 | Move `_index_in_lance()` into the enrichment outbox so the vector write is no longer on the synchronous path. Highest-value structural fix regardless of #43's outcome. |
+| ID | Status | Item |
+|---|---|---|
+| **#43** | ✅ DONE | Post-cleanup workload retest. 44 calls, zero tails, 32× avg / 44× max latency improvement. Pass 4 above. |
+| **#37** | ✅ DONE | One-shot `cleanup_old_versions` on Vigil's `notes_cti`. 5.66 GB recovered. |
+| **#38** | 🔥 URGENT | **RFC-009 Phase 1.5: code-side periodic `cleanup_old_versions`.** Now well-defined and confirmed valuable. Recommended shape: background thread runs `cleanup_old_versions(older_than=timedelta(hours=1))` on each `<domain>.lance` table every N minutes, with `lance.cleanup_interval_minutes` config knob (default 60). Telemetry event per cleanup: bytes freed, versions pruned, elapsed seconds. Without this, the bloat returns at 2 versions per insert. |
+| **#42** | OPEN | Graph retriever firing on only 1.3% of recalls — orthogonal to Phase 0.5 but observed in the same test session and worth chasing while DEBUG telemetry is on. |
+| RFC-009 §1.1 F03 | OPEN | Move `_index_in_lance()` into the enrichment outbox so the vector write is no longer on the synchronous path. With periodic cleanup landing in #38 the urgency drops, but it remains the cleanest structural fix and earns defence-in-depth credit. |
+| Future investigation | OPEN | Characterise the latency-vs-version-count curve so `lance.cleanup_threshold_versions` (count-based trigger) can be tuned to fire before tails reappear, rather than purely on a time schedule. |


### PR DESCRIPTION
## Summary
Closes task **#36**. Promotes the Phase 0.5 attribution doc to CONFIRMED status with a substantive correction to the failure mechanism.

## What's confirmed
**WHERE: 98%+ of `remember()` time is in `lance_index`.** Two independent passes agree:
- Preliminary reconstruction (2026-04-24, n=961 calls, adjacent file_activity events): 98.4%
- v2.4.2 first-party `phase_timings_ms` (2026-04-24/25, n=83 calls): 98.1%
- Per-tail-event (n=8): 99.66–99.98% every single one

## What's corrected
**WHY: the fragment-count mechanism in the preliminary was wrong.**

```python
ds = table.to_lance()
fragments = ds.get_fragments()
# len(fragments) == 1   ← not 7,916
```

The 7,916 `.lance` files in `data/` were **uncleaned version snapshots**, not active fragments. `compact_files()` correctly returns `fragments_added=0, fragments_removed=0` because there's no fragment merging to do. The active dataset has always been 1 logical fragment.

## What was executed
`cleanup_old_versions()` on 2026-04-25T01:34Z:
| | Before | After |
|---|---:|---:|
| `notes_cti` size | 5.69 GB | **29 MB** (196× shrink) |
| versions retained | thousands | 1 |
| disk files | 7,917 | 1 |
| rows | 7,916 | 7,916 ✅ |

## What's still open
**Whether the cleanup moves the 60-second tail.** Active dataset was already 1 logical fragment, so `compact_files()` was always going to be a no-op. The remaining hypothesis is that LanceDB's insert path walks the version chain. Workload retest is required (task #43).

If tails collapse post-cleanup → RFC-009 Phase 1.5 becomes "periodic `cleanup_old_versions`" not "periodic `compact_files`". If tails persist → the diagnosis isn't done.

## File changes
- **NEW** `docs/superpowers/research/2026-04-25-phase-0.5-attribution.md` (the confirmed analysis)
- **UPDATED** `docs/superpowers/research/2026-04-24-phase-0.5-attribution-prelim.md` — frontmatter status changed to SUPERSEDED, banner added at top pointing to the new doc. Text body preserved as a record of the diagnostic process.

## Related
- PR #93 (live test evidence) — its "fragment-count" line gets the same correction by reference once this lands; not edited here to keep the diff small
- RFC-009 Phase 1.5 scope — provisional pending task #43

## Test plan
- [x] Docs-only (no code change, no CI risk)
- [ ] Merge so future readers land on the corrected analysis
- [ ] Task #43 closes the remaining open question

🤖 Generated with [Claude Code](https://claude.com/claude-code)