### PR TITLE
fix(entity_indexer): RFC-001 Warnings 4-6 — atomic save + 19-type invariant + thread-safety

### DIFF
--- a/src/zettelforge/entity_indexer.py
+++ b/src/zettelforge/entity_indexer.py
@@ -12,7 +12,9 @@ Conversational Entity Extension (RFC-001):
 import atexit
 import fcntl
 import json
+import os
 import re
+import tempfile
 import threading
 from pathlib import Path
 from typing import Dict, List, Optional, Set
@@ -379,7 +381,12 @@ class EntityIndexer:
         self.extractor = EntityExtractor()
         self._dirty = False
         self._flush_timer: Optional[threading.Timer] = None
-        self._flush_lock = threading.Lock()
+        # RLock so that paths which already hold the lock (e.g. add_note →
+        # _schedule_flush) don't deadlock on the timer-coordination
+        # acquisition. Same lock guards all index reads/writes/serialize
+        # so the dict comprehension in save() cannot race with mutating
+        # callers (RFC-001 Warning 6).
+        self._flush_lock = threading.RLock()
         atexit.register(self._flush_sync)
         self.load()
 
@@ -388,7 +395,7 @@ class EntityIndexer:
         if not self.index_path.exists():
             return False
         try:
-            with open(self.index_path) as f:
+            with self._flush_lock, open(self.index_path) as f:
                 data = json.load(f)
                 for entity_type in self.index:
                     if entity_type in data:
@@ -399,38 +406,80 @@ class EntityIndexer:
             return False
 
     def save(self) -> None:
-        """Save index to disk."""
+        """Save index to disk atomically.
+
+        RFC-001 Warning 4: previous implementation opened ``index_path``
+        in ``"w"`` mode (truncating) BEFORE acquiring ``flock``, so a
+        concurrent reader / crash mid-write left the file empty or
+        partial. This implementation writes to a temp file in the same
+        directory under the in-process lock, then atomically renames
+        into place. ``flock`` is taken on the temp file to interlock
+        cross-process writers; the rename is atomic on POSIX.
+        """
         self.index_path.parent.mkdir(parents=True, exist_ok=True)
-        with open(self.index_path, "w") as f:
-            fcntl.flock(f, fcntl.LOCK_EX)
+        # In-process critical section: serialize from a stable snapshot
+        # of self.index. This excludes concurrent add_note / remove_note
+        # via _flush_lock (RFC-001 Warning 6).
+        with self._flush_lock:
             data = {k: {kk: list(vv) for kk, vv in v.items()} for k, v in self.index.items()}
-            json.dump(data, f, indent=2)
-            fcntl.flock(f, fcntl.LOCK_UN)
+
+        fd, tmp_path = tempfile.mkstemp(
+            prefix=".entity_index.", suffix=".json.tmp", dir=str(self.index_path.parent)
+        )
+        try:
+            with os.fdopen(fd, "w") as f:
+                fcntl.flock(f, fcntl.LOCK_EX)
+                json.dump(data, f, indent=2)
+                f.flush()
+                os.fsync(f.fileno())
+                fcntl.flock(f, fcntl.LOCK_UN)
+            os.replace(tmp_path, self.index_path)  # atomic on POSIX
+        except Exception:
+            # Best-effort cleanup; raise so caller observes the failure.
+            if os.path.exists(tmp_path):
+                try:
+                    os.unlink(tmp_path)
+                except OSError:
+                    pass
+            raise
 
     def add_note(self, note_id: str, entities: Dict[str, List[str]]) -> None:
         """Add note to entity index."""
-        for entity_type, entity_list in entities.items():
-            if entity_type not in self.index:
-                self.index[entity_type] = {}
-            for entity in entity_list:
-                entity_lower = entity.lower()
-                if entity_lower not in self.index[entity_type]:
-                    self.index[entity_type][entity_lower] = set()
-                self.index[entity_type][entity_lower].add(note_id)
-        self._dirty = True
+        # Hold _flush_lock for the whole mutation so concurrent save() /
+        # remove_note() / load() can't observe a torn index. Same lock
+        # nests safely with _schedule_flush via RLock.
+        with self._flush_lock:
+            for entity_type, entity_list in entities.items():
+                if entity_type not in self.index:
+                    self.index[entity_type] = {}
+                for entity in entity_list:
+                    entity_lower = entity.lower()
+                    if entity_lower not in self.index[entity_type]:
+                        self.index[entity_type][entity_lower] = set()
+                    self.index[entity_type][entity_lower].add(note_id)
+            self._dirty = True
         self._schedule_flush()
 
     def remove_note(self, note_id: str) -> None:
-        """Remove a note ID from all entity sets in the index."""
-        for entity_type in list(self.index.keys()):
-            for entity_value in list(self.index[entity_type].keys()):
-                self.index[entity_type][entity_value].discard(note_id)
-                # Clean up empty sets
-                if not self.index[entity_type][entity_value]:
-                    del self.index[entity_type][entity_value]
-            if not self.index[entity_type]:
-                del self.index[entity_type]
-        self._dirty = True
+        """Remove a note ID from all entity sets in the index.
+
+        RFC-001 Warning 5: previous implementation deleted the entity-type
+        key when its dict emptied, breaking the 19-type invariant set up
+        in __init__ — code elsewhere (e.g. ``add_note`` re-checking
+        ``entity_type not in self.index``) relied on that invariant
+        existing. We now leave empty type-buckets in place; only the
+        per-value sets are pruned.
+        """
+        with self._flush_lock:
+            for entity_type in list(self.index.keys()):
+                for entity_value in list(self.index[entity_type].keys()):
+                    self.index[entity_type][entity_value].discard(note_id)
+                    # Clean up empty per-value sets only — preserve the
+                    # parent entity_type bucket so ENTITY_TYPES invariant
+                    # holds across the lifetime of the indexer.
+                    if not self.index[entity_type][entity_value]:
+                        del self.index[entity_type][entity_value]
+            self._dirty = True
         self._schedule_flush()
 
     def _schedule_flush(self) -> None:
@@ -442,10 +491,17 @@ class EntityIndexer:
                 self._flush_timer.start()
 
     def _flush_sync(self) -> None:
-        """Write index to disk if dirty."""
-        if self._dirty:
-            self.save()
-            self._dirty = False
+        """Write index to disk if dirty.
+
+        RFC-001 Warning 6: hold the lock across the dirty-check + save +
+        clear so the dirty flag and the on-disk state stay consistent
+        even if a concurrent add_note arrives between read and write.
+        RLock allows save() to re-enter for its own snapshot block.
+        """
+        with self._flush_lock:
+            if self._dirty:
+                self.save()
+                self._dirty = False
 
     def get_note_ids(self, entity_type: str, entity_value: str) -> List[str]:
         """Get note IDs for a specific entity."""

--- a/tests/test_entity_indexer_races.py
+++ b/tests/test_entity_indexer_races.py
@@ -1,0 +1,189 @@
+"""Regression tests for RFC-001 Warnings 4, 5, 6.
+
+W-4 — `save()` truncates before flock. Atomic write via temp+rename is
+       what we ship now; the test exercises that the file is never left
+       in a torn state when an exception fires mid-write.
+W-5 — `remove_note()` deleted entity-type keys when their dict went
+       empty, breaking the 19-type invariant the indexer set up at
+       __init__. Test asserts the type-bucket survives an empty.
+W-6 — `_flush_sync()` was not thread-safe on `self.index`. The dict
+       comprehension in `save()` could race with concurrent
+       `add_note()` mutations. Test runs both concurrently with a
+       lot of churn and asserts no exception escapes.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import threading
+from pathlib import Path
+
+import pytest
+
+from zettelforge.entity_indexer import EntityExtractor, EntityIndexer
+
+
+@pytest.fixture()
+def indexer(tmp_path: Path) -> EntityIndexer:
+    """Fresh indexer pointed at a tmp file."""
+    idx = EntityIndexer(index_path=str(tmp_path / "entity_index.json"))
+    yield idx
+    # Tear down any pending flush timer so the test process exits clean.
+    try:
+        if idx._flush_timer is not None:
+            idx._flush_timer.cancel()
+    except Exception:
+        pass
+
+
+# ── W-4: atomic save ──────────────────────────────────────────────────────
+
+
+class TestSaveAtomicity:
+    def test_save_writes_complete_json(self, indexer: EntityIndexer):
+        indexer.add_note("note_a", {"actor": ["APT28"], "tool": ["Cobalt Strike"]})
+        indexer.save()
+
+        # File exists and is valid JSON
+        assert indexer.index_path.exists()
+        with open(indexer.index_path) as f:
+            data = json.load(f)
+        assert "actor" in data
+        assert "apt28" in data["actor"]
+        assert "note_a" in data["actor"]["apt28"]
+
+    def test_save_does_not_leave_temp_files_on_success(
+        self, indexer: EntityIndexer, tmp_path: Path
+    ):
+        indexer.add_note("note_a", {"actor": ["APT28"]})
+        indexer.save()
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".entity_index.")]
+        assert leftovers == [], f"Temp files left behind: {leftovers}"
+
+    def test_save_cleans_up_temp_file_on_serialize_failure(
+        self, indexer: EntityIndexer, tmp_path: Path, monkeypatch
+    ):
+        indexer.add_note("note_a", {"actor": ["APT28"]})
+
+        # Force json.dump to raise mid-write.
+        def _boom(*_args, **_kwargs):
+            raise RuntimeError("simulated FS error")
+
+        monkeypatch.setattr("zettelforge.entity_indexer.json.dump", _boom)
+        with pytest.raises(RuntimeError):
+            indexer.save()
+
+        leftovers = [p for p in tmp_path.iterdir() if p.name.startswith(".entity_index.")]
+        assert leftovers == [], f"Temp file not cleaned: {leftovers}"
+
+    def test_save_uses_atomic_rename_pattern(
+        self, indexer: EntityIndexer, tmp_path: Path, monkeypatch
+    ):
+        """The final write must go through os.replace (atomic on POSIX),
+        not a direct open-in-write-mode that would truncate before flock."""
+        observed_replaces = []
+        real_replace = os.replace
+
+        def _spy(src, dst):
+            observed_replaces.append((str(src), str(dst)))
+            return real_replace(src, dst)
+
+        monkeypatch.setattr("zettelforge.entity_indexer.os.replace", _spy)
+
+        indexer.add_note("note_a", {"actor": ["APT28"]})
+        indexer.save()
+
+        assert any(str(indexer.index_path) == dst for _, dst in observed_replaces), (
+            f"Expected os.replace to land on {indexer.index_path}; observed: {observed_replaces}"
+        )
+
+
+# ── W-5: 19-type invariant ───────────────────────────────────────────────
+
+
+class TestEntityTypeInvariant:
+    def test_remove_note_preserves_empty_type_bucket(self, indexer: EntityIndexer):
+        # Set up: indexer starts with all ENTITY_TYPES keys, empty dicts.
+        all_types_before = set(indexer.index.keys())
+        assert all_types_before == set(EntityExtractor.ENTITY_TYPES)
+
+        # Add then remove a note that touched 'actor' and 'tool'.
+        indexer.add_note("note_a", {"actor": ["APT28"], "tool": ["Cobalt Strike"]})
+        indexer.remove_note("note_a")
+
+        # Both type buckets must still exist (empty), per RFC-001 W-5.
+        assert "actor" in indexer.index, (
+            "Removing the last note must NOT delete the entity-type key"
+        )
+        assert "tool" in indexer.index
+        assert indexer.index["actor"] == {}, "Empty bucket should be a present-but-empty dict"
+        assert indexer.index["tool"] == {}
+
+        # Full invariant survives.
+        assert set(indexer.index.keys()) == set(EntityExtractor.ENTITY_TYPES)
+
+    def test_remove_note_prunes_empty_per_value_sets(self, indexer: EntityIndexer):
+        """Per-value dicts SHOULD be cleaned when their note-set empties —
+        only the parent type-bucket is preserved."""
+        indexer.add_note("note_a", {"actor": ["APT28"]})
+        assert "apt28" in indexer.index["actor"]
+        indexer.remove_note("note_a")
+        assert "apt28" not in indexer.index["actor"], (
+            "Empty per-value sets should be pruned to keep the index compact"
+        )
+
+
+# ── W-6: thread-safety on save ↔ add_note ────────────────────────────────
+
+
+class TestConcurrentSaveAndMutate:
+    def test_save_during_concurrent_add_does_not_raise(self, indexer: EntityIndexer):
+        """Drive save() and add_note() concurrently with churn. Without
+        the W-6 fix this raised RuntimeError: dictionary changed size
+        during iteration. With the fix the lock serializes them."""
+        errors: list[BaseException] = []
+        stop = threading.Event()
+
+        def writer():
+            i = 0
+            while not stop.is_set() and i < 500:
+                try:
+                    indexer.add_note(
+                        f"note_{i}",
+                        {"actor": [f"APT{i % 5}"], "tool": [f"tool{i % 7}"]},
+                    )
+                except BaseException as exc:  # noqa: BLE001 — capture for the assert
+                    errors.append(exc)
+                    return
+                i += 1
+
+        def saver():
+            j = 0
+            while not stop.is_set() and j < 50:
+                try:
+                    indexer.save()
+                except BaseException as exc:  # noqa: BLE001
+                    errors.append(exc)
+                    return
+                j += 1
+
+        t1 = threading.Thread(target=writer)
+        t2 = threading.Thread(target=saver)
+        t1.start()
+        t2.start()
+        t1.join(timeout=10)
+        t2.join(timeout=10)
+        stop.set()
+
+        assert errors == [], f"Concurrent save+add raised: {errors[0]!r}"
+        # Final state is internally consistent.
+        assert "actor" in indexer.index
+        assert all(isinstance(v, dict) for v in indexer.index.values())
+
+    def test_flush_sync_clears_dirty_flag(self, indexer: EntityIndexer):
+        """_flush_sync must clear self._dirty even under the new locking."""
+        indexer.add_note("note_a", {"actor": ["APT28"]})
+        assert indexer._dirty is True
+        indexer._flush_sync()
+        assert indexer._dirty is False


### PR DESCRIPTION
## Summary
Closes the three open RFC-001 race conditions tracked in TODO.md as priority #4. Each fix is small, narrowly scoped, and protected by a regression test.

## Why this matters now
TODO.md priority #4 has been carrying these as a 3h scope item for weeks. With Phase 1.5 (#101) just landing on master, the entity-indexer's correctness story is the next highest-leverage gap before v2.5.0 work begins.

## The three races

**W-4 — atomic save**: `save()` opened the index file in `\"w\"` mode (which truncates) BEFORE acquiring `fcntl.flock`. A reader / crash / second writer between those operations saw an empty or partial file. Replaced with `tempfile.mkstemp()` → `os.replace()` (same pattern already used in `memory_store.py:340-356`).

**W-5 — 19-type invariant**: `remove_note()` ran `del self.index[entity_type]` when a type-bucket emptied. \`EntityIndexer.__init__\` establishes an invariant that every \`EntityExtractor.ENTITY_TYPES\` key exists; other callers (including \`add_note\`) lean on it. Now only per-value sets are pruned; the type-bucket survives as \`{}\`.

**W-6 — thread-safety on save↔add_note**: `save()`'s dict comprehension iterated `self.index` without locking. A concurrent `add_note()` mutation could raise `RuntimeError: dictionary changed size during iteration`. `_flush_lock` is now an `RLock` (so `_schedule_flush` can nest from inside `add_note`) and is held in `add_note`, `remove_note`, `save`, `load`, and `_flush_sync`.

## Tests (`tests/test_entity_indexer_races.py`)
| Test | Asserts |
|---|---|
| `test_save_writes_complete_json` | Round-trip after add+save |
| `test_save_does_not_leave_temp_files_on_success` | No `.entity_index.*` orphans |
| `test_save_cleans_up_temp_file_on_serialize_failure` | Temp unlinked when `json.dump` raises |
| `test_save_uses_atomic_rename_pattern` | `os.replace` is on the call path |
| `test_remove_note_preserves_empty_type_bucket` | Empty bucket stays present |
| `test_remove_note_prunes_empty_per_value_sets` | Per-value sets still get pruned |
| `test_save_during_concurrent_add_does_not_raise` | 500 adds × 50 saves with no exceptions |
| `test_flush_sync_clears_dirty_flag` | `_dirty` clears under the new lock |

Regression sweep: **60/60** pass across `test_entity_indexer_races + test_basic + test_consolidation + test_logging_compliance`.

## Test plan
- [x] Lint + format clean
- [x] 60/60 tests pass locally
- [ ] CI green
- [ ] Merge — closes RFC-001 W-4, W-5, W-6

🤖 Generated with [Claude Code](https://claude.com/claude-code)