### PR TITLE
ci: H-1 partial — enable Ruff T20 (no print in production)

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -103,7 +103,12 @@ disallow_untyped_defs = true
 line-length = 100
 
 [tool.ruff.lint]
-select = ["E", "F", "I", "W", "N"]
+# GOV-003 §"Tooling and Automation" mandates the full set
+# {E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}. We ratchet incrementally:
+# T20 (no print) added 2026-04-25 (audit H-1 partial). The remaining
+# rules (S, B, UP, SIM, RUF, ANN) will be added in subsequent batches
+# once the surfaced findings are triaged.
+select = ["E", "F", "I", "W", "N", "T20"]
 ignore = [
     "E501",   # line too long — handled by formatter
     "E402",   # module-level import not at top — needed for conditional imports
@@ -111,6 +116,15 @@ ignore = [
 
 [tool.ruff.lint.per-file-ignores]
 "src/zettelforge/__init__.py" = ["F401", "E402"]  # re-exports and conditional imports
+# T20 (print) is forbidden in production code (GOV-003), but every CLI
+# entrypoint legitimately uses print() for stdout output. The patterns
+# below scope T20 to library code only.
+"src/zettelforge/__main__.py" = ["T20"]
+"src/zettelforge/demo.py" = ["T20"]
+"src/zettelforge/scripts/*.py" = ["T20"]
+"src/zettelforge/sigma/cli.py" = ["T20"]
+"src/zettelforge/yara/cli.py" = ["T20"]
+"src/zettelforge/vector_memory.py" = ["T20"]  # has argparse CLI at module bottom
 
 [tool.ruff.format]
 quote-style = "double"


### PR DESCRIPTION
## Summary
First incremental ratchet on audit finding H-1. GOV-003 §\"Tooling and Automation\" mandates the full rule set \`{E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}\` but ruff config currently has only \`{E, F, I, W, N}\`. This PR adds \`T20\` (no \`print()\` in production) — the smallest and most directly enforceable subset of the missing rules.

## Why T20 first
- Most directly tied to a real GOV-003 production-code rule (\"Never use \`print()\` or \`println!()\` for production output\")
- Enabling it surfaces concrete bugs (production code accidentally writing to stdout) rather than autofixable formatting churn
- Bounded scope: 87 findings, all auditable in one pass

## Where the 87 findings landed
| Path | Count | Verdict |
|---|---:|---|
| \`demo.py\` | 46 | CLI entrypoint — print() is correct |
| \`sigma/cli.py\` + \`yara/cli.py\` | 19 | CLI entrypoints |
| \`scripts/*.py\` | 13 | CLI scripts |
| \`__main__.py\` | 4 | CLI entrypoint |
| \`vector_memory.py\` | 5 | argparse CLI block at module bottom |
| **Library code** | **0** | All library code is clean |

Library code is already T20-compliant. Per-file-ignores scope T20 to library code only — new \`print()\` calls in non-CLI files will trip the lint job.

## Coming next (H-1 remaining)
- \`UP\` (pyupgrade) — usually \`--fix\`-able
- \`RUF\` (ruff-specific) — usually \`--fix\`-able
- \`SIM\` (simplify) — usually \`--fix\`-able
- \`B\` (bugbear) — small triage tail
- \`S\` (security/bandit) — likely surfaces real findings, needs careful review
- \`ANN\` (type annotations) — large tail; ratchet gradually

Each will land as a separate PR with its own triage explanation.

## Test plan
- [x] \`ruff check src/zettelforge/\` clean with \`T20\` enabled
- [x] Spec-drift + logging compliance tests pass (18/18)
- [ ] CI green
- [ ] Merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)