### PR TITLE
ci: H-1 batch 2 — Ruff B (bugbear) + opportunistic SIM/RUF auto-fixes

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -118,10 +118,13 @@ line-length = 100
 [tool.ruff.lint]
 # GOV-003 §"Tooling and Automation" mandates the full set
 # {E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}. We ratchet incrementally:
-# T20 (no print) added 2026-04-25 (audit H-1 partial). The remaining
-# rules (S, B, UP, SIM, RUF, ANN) will be added in subsequent batches
-# once the surfaced findings are triaged.
-select = ["E", "F", "I", "W", "N", "T20"]
+# T20 (no print) + B (bugbear) added 2026-04-25 (audit H-1 partial).
+# The remaining rules (S, UP, SIM, RUF, ANN) will be added in
+# subsequent batches once the surfaced findings are triaged. Note:
+# this PR also opportunistically applied --fix for SIM/RUF auto-fixes
+# even though those rules aren't in select yet, so the codebase is
+# pre-clean for when they land next.
+select = ["E", "F", "I", "W", "N", "T20", "B"]
 ignore = [
     "E501",   # line too long — handled by formatter
     "E402",   # module-level import not at top — needed for conditional imports

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -42,10 +42,10 @@ from zettelforge.note_schema import MemoryNote
 from zettelforge.ontology import (
     ENTITY_TYPES,
     RELATION_TYPES,
-    OntologyValidator,  # noqa: F401  (advanced/optional — not in __all__)
-    TypedEntityStore,  # noqa: F401   (advanced/optional — not in __all__)
-    get_ontology_store,  # noqa: F401 (advanced/optional — not in __all__)
-    get_ontology_validator,  # noqa: F401 (advanced/optional — not in __all__)
+    OntologyValidator,
+    TypedEntityStore,
+    get_ontology_store,
+    get_ontology_validator,
 )
 from zettelforge.synthesis_generator import SynthesisGenerator, get_synthesis_generator
 from zettelforge.synthesis_validator import SynthesisValidator, get_synthesis_validator

--- a/src/zettelforge/consolidation.py
+++ b/src/zettelforge/consolidation.py
@@ -263,7 +263,7 @@ class ConsolidationEngine:
                 domain_groups.setdefault(domain, []).append(note)
 
             # Consolidate each domain group
-            for domain, notes in domain_groups.items():
+            for _domain, notes in domain_groups.items():
                 if len(notes) < 2:
                     continue
 
@@ -278,7 +278,7 @@ class ConsolidationEngine:
 
                 # Identify notes sharing 2+ entities (candidates for merge)
                 merge_candidates = set()
-                for entity_key, note_ids in entity_map.items():
+                for _entity_key, note_ids in entity_map.items():
                     if len(note_ids) >= 2:
                         for nid in note_ids:
                             merge_candidates.add(nid)

--- a/src/zettelforge/detection/__init__.py
+++ b/src/zettelforge/detection/__init__.py
@@ -16,8 +16,8 @@ from zettelforge.detection.explainer import RuleExplanation, explain
 
 __all__ = [
     "ALL_CONSUMERS",
-    "DetectionRule",
     "DetectionMatchConsumer",
+    "DetectionRule",
     "RuleExplanation",
     "RuleMatchEvent",
     "explain",

--- a/src/zettelforge/entity_indexer.py
+++ b/src/zettelforge/entity_indexer.py
@@ -350,7 +350,7 @@ class EntityExtractor:
             llm_results = self.extract_llm(text)
             # Merge LLM results with regex results (extend, don't overwrite)
             for etype, values in llm_results.items():
-                if etype in results and results[etype]:
+                if results.get(etype):
                     # Deduplicate across regex + LLM
                     merged = set(results[etype])
                     merged.update(values)

--- a/src/zettelforge/llm_providers/__init__.py
+++ b/src/zettelforge/llm_providers/__init__.py
@@ -28,11 +28,11 @@ __all__ = [
     "LLMProvider",
     "LLMProviderConfigurationError",
     "LocalProvider",
-    "OllamaProvider",
     "MockProvider",
-    "register",
-    "get",
+    "OllamaProvider",
     "available",
+    "get",
+    "register",
     "reset",
 ]
 

--- a/src/zettelforge/mcp/server.py
+++ b/src/zettelforge/mcp/server.py
@@ -61,7 +61,7 @@ def handle_tool_call(name: str, arguments: dict) -> dict:
     elif name == "zettelforge_recall":
         query = arguments.get("query", "")
         k = arguments.get("k", 10)
-        domain = arguments.get("domain", None)
+        domain = arguments.get("domain")
         start = time.perf_counter()
         results = mm.recall(query, domain=domain, k=k, exclude_superseded=False)
         latency = time.perf_counter() - start

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -595,7 +595,7 @@ class MemoryManager:
             try:
                 import re as _re
 
-                import dateparser  # noqa: F401
+                import dateparser  # noqa: F401 — probe-import; raises ImportError when unavailable
 
                 # Extract date-like strings from query
                 date_patterns = _re.findall(
@@ -696,7 +696,15 @@ class MemoryManager:
                 if reranker is not None:
                     docs = [n.content.raw[:512] for n in results]
                     scores = list(reranker.rerank(query, docs))
-                    paired = sorted(zip(scores, results), key=lambda x: x[0], reverse=True)
+                    # B905: strict=True — scores and results have identical
+                    # length by construction (one score per doc), so a length
+                    # mismatch would be a programming error, not a silent
+                    # truncation bug.
+                    paired = sorted(
+                        zip(scores, results, strict=True),
+                        key=lambda x: x[0],
+                        reverse=True,
+                    )
                     results = [note for _, note in paired]
             except Exception:
                 self._logger.warning("reranking_failed_using_original_order", exc_info=True)

--- a/src/zettelforge/scripts/human_eval_sampler.py
+++ b/src/zettelforge/scripts/human_eval_sampler.py
@@ -40,7 +40,7 @@ def _read_telemetry(data_dir: str) -> List[Dict[str, Any]]:
 def _format_briefing(event: Dict[str, Any], index: int) -> str:
     """Format a single synthesis event as a reviewable briefing."""
     query = event.get("query", "(no query text)")
-    confidence = event.get("confidence", None)
+    confidence = event.get("confidence")
     sources_count = event.get("result_count", 0)
     duration_ms = event.get("duration_ms", 0)
     cited = event.get("cited_notes", [])

--- a/src/zettelforge/sigma/__init__.py
+++ b/src/zettelforge/sigma/__init__.py
@@ -17,8 +17,8 @@ from zettelforge.sigma.parser import (
 from zettelforge.sigma.tags import resolve_sigma_tag
 
 __all__ = [
-    "SigmaRule",
     "SigmaParseError",
+    "SigmaRule",
     "SigmaValidationError",
     "from_rule_dict",
     "ingest_rule",

--- a/src/zettelforge/yara/cccs_metadata.py
+++ b/src/zettelforge/yara/cccs_metadata.py
@@ -249,10 +249,10 @@ def validate_metadata(rule_meta: dict[str, Any], tier: Tier = "warn") -> Validat
 
 
 __all__ = [
-    "ValidationResult",
-    "Tier",
     "CCCS_YARA_SPEC",
     "CCCS_YARA_VALUES",
     "REQUIRED_FIELDS",
+    "Tier",
+    "ValidationResult",
     "validate_metadata",
 ]

--- a/src/zettelforge/yara/entities.py
+++ b/src/zettelforge/yara/entities.py
@@ -266,4 +266,4 @@ def _split_mitre(value: Any) -> list[str]:
     return [t.upper() for t in tokens if t]
 
 
-__all__ = ["YaraRule", "rule_to_entities", "from_rule_dict"]
+__all__ = ["YaraRule", "from_rule_dict", "rule_to_entities"]


### PR DESCRIPTION
## Summary

Adds **`B` (flake8-bugbear)** to the ruff `select` list, advancing the GOV-003 §"Tooling and Automation" mandated rule set: `{E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}`. T20 landed in #106; this PR adds B.

Manual fixes for surfaced findings:
- `consolidation.py:266 / :281` — **B007** unused loop control variables renamed `_domain` / `_entity_key`
- `memory_manager.py:699` — **B905** `zip(scores, results, strict=True)` (explicit strictness)
- `memory_manager.py:598` — **F401** `noqa` annotation on `import dateparser` (probe-import; raises `ImportError` when unavailable)

Opportunistically applied 13 SIM + RUF auto-fixes across 11 files even though those rules aren't in `select` yet — pre-cleans the codebase for when those batches land.

## Why this batch shape

Per the comment in `pyproject.toml`, the audit H-1 ratchet lands one rule family at a time so each PR's lint failures are tractable to triage. Remaining: `S` (security), `UP` (pyupgrade — ~700 mostly-autofixable), `SIM` / `RUF` manual triage (36 non-autofixable), `ANN` (gradual annotation ratchet).

## Test plan

- [x] `ruff check src/` clean with `B` enabled
- [x] `pytest tests/ -x` green locally (85/85 excluding env-dependent `test_ingest_relationship`)
- [ ] CI green (lint + governance + test 3.12/3.13 + pip-audit + snyk + codeql)

🤖 Generated with [Claude Code](https://claude.com/claude-code)