### PR TITLE
ci: H-1 batch 3 — Ruff UP (pyupgrade) PEP 585/604 modernization

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,13 +124,11 @@ line-length = 100
 [tool.ruff.lint]
 # GOV-003 §"Tooling and Automation" mandates the full set
 # {E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}. We ratchet incrementally:
-# T20 (no print) + B (bugbear) added 2026-04-25 (audit H-1 partial).
-# The remaining rules (S, UP, SIM, RUF, ANN) will be added in
-# subsequent batches once the surfaced findings are triaged. Note:
-# this PR also opportunistically applied --fix for SIM/RUF auto-fixes
-# even though those rules aren't in select yet, so the codebase is
-# pre-clean for when they land next.
-select = ["E", "F", "I", "W", "N", "T20", "B"]
+# T20 + B added 2026-04-25; UP (pyupgrade — PEP 585/604 modernization)
+# added 2026-04-25 (audit H-1 partial). The remaining rules (S, SIM,
+# RUF, ANN) will be added in subsequent batches once the surfaced
+# findings are triaged.
+select = ["E", "F", "I", "W", "N", "T20", "B", "UP"]
 ignore = [
     "E501",   # line too long — handled by formatter
     "E402",   # module-level import not at top — needed for conditional imports

--- a/src/zettelforge/alias_resolver.py
+++ b/src/zettelforge/alias_resolver.py
@@ -1,6 +1,5 @@
 import json
 from pathlib import Path
-from typing import Optional
 
 from zettelforge.log import get_logger
 
@@ -21,7 +20,7 @@ class AliasResolver:
     falls back to local JSON/hardcoded aliases.
     """
 
-    def __init__(self, alias_file: Optional[str] = None):
+    def __init__(self, alias_file: str | None = None):
         from zettelforge.memory_store import get_default_data_dir
 
         if alias_file is None:
@@ -46,7 +45,7 @@ class AliasResolver:
     def load(self):
         if self.alias_file.exists():
             try:
-                with open(self.alias_file, "r") as f:
+                with open(self.alias_file) as f:
                     data = json.load(f)
                     for k, v in data.items():
                         if k not in self.aliases:
@@ -55,7 +54,7 @@ class AliasResolver:
             except Exception:
                 _logger.debug("typedb_alias_lookup_failed", exc_info=True)
 
-    def _try_typedb_resolve(self, entity_type: str, entity_lower: str) -> Optional[str]:
+    def _try_typedb_resolve(self, entity_type: str, entity_lower: str) -> str | None:
         """Query TypeDB for alias-of relation. Returns canonical name or None."""
         if self._typedb_available is False:
             return None

--- a/src/zettelforge/blended_retriever.py
+++ b/src/zettelforge/blended_retriever.py
@@ -10,13 +10,13 @@ similarity scores from VectorRetriever. Uses min-max normalization
 per signal before weighted fusion.
 """
 
-from typing import Callable, Dict, List, Optional
+from collections.abc import Callable
 
 from zettelforge.graph_retriever import ScoredResult
 from zettelforge.note_schema import MemoryNote
 
 
-def _normalize_scores(scored_list: List[tuple]) -> List[tuple]:
+def _normalize_scores(scored_list: list[tuple]) -> list[tuple]:
     """Min-max normalize scores to [0, 1] range.
 
     If all scores are equal or list is empty, returns uniform scores.
@@ -40,12 +40,12 @@ class BlendedRetriever:
 
     def blend(
         self,
-        vector_results: List[tuple],  # List[Tuple[MemoryNote, float]] - actual similarity scores
-        graph_results: List[ScoredResult],
-        policy: Dict[str, float],
-        note_lookup: Callable[[str], Optional[MemoryNote]],
+        vector_results: list[tuple],  # List[Tuple[MemoryNote, float]] - actual similarity scores
+        graph_results: list[ScoredResult],
+        policy: dict[str, float],
+        note_lookup: Callable[[str], MemoryNote | None],
         k: int = 10,
-    ) -> List[MemoryNote]:
+    ) -> list[MemoryNote]:
         """
         Blend vector and graph results with normalized score fusion.
 
@@ -67,7 +67,7 @@ class BlendedRetriever:
         norm_graph = _normalize_scores(graph_scored)
 
         # Build combined score map: note_id -> (blended_score, MemoryNote)
-        scores: Dict[str, tuple] = {}
+        scores: dict[str, tuple] = {}
 
         # Vector signal
         for note, norm_score in norm_vector:
@@ -91,12 +91,12 @@ class BlendedRetriever:
 
     def blend_rrf(
         self,
-        vector_results: List[tuple],  # List[Tuple[MemoryNote, float]]
-        graph_results: List[ScoredResult],
-        note_lookup: Callable[[str], Optional[MemoryNote]],
+        vector_results: list[tuple],  # List[Tuple[MemoryNote, float]]
+        graph_results: list[ScoredResult],
+        note_lookup: Callable[[str], MemoryNote | None],
         k: int = 10,
         rrf_k: int = 60,
-    ) -> List[MemoryNote]:
+    ) -> list[MemoryNote]:
         """
         Reciprocal Rank Fusion (RRF) — rank-based fusion that is robust
         to score scale differences.
@@ -105,7 +105,7 @@ class BlendedRetriever:
         This is the standard fusion method used in production retrieval
         systems (Elastic, Vespa, etc.).
         """
-        scores: Dict[str, tuple] = {}
+        scores: dict[str, tuple] = {}
 
         # Vector signal — rank by original similarity score
         sorted_vector = sorted(vector_results, key=lambda x: x[1], reverse=True)

--- a/src/zettelforge/cache.py
+++ b/src/zettelforge/cache.py
@@ -8,7 +8,7 @@
 """
 
 import time
-from typing import Any, Dict, Optional
+from typing import Any
 
 
 class SmartCache:
@@ -19,12 +19,12 @@ class SmartCache:
     def __init__(self, maxsize: int = 10000, ttl_seconds: int = 3600):
         self.maxsize = maxsize
         self.ttl_seconds = ttl_seconds
-        self._cache: Dict = {}
+        self._cache: dict = {}
         self._hits = 0
         self._misses = 0
         self._last_cleanup = time.time()
 
-    def get(self, key: str) -> Optional[Any]:
+    def get(self, key: str) -> Any | None:
         """Get item from cache with TTL check."""
         self._cleanup_if_needed()
 
@@ -64,7 +64,7 @@ class SmartCache:
         for k in expired:
             del self._cache[k]
 
-    def get_stats(self) -> Dict:
+    def get_stats(self) -> dict:
         """Return cache performance metrics."""
         total = self._hits + self._misses
         hit_rate = self._hits / total if total > 0 else 0

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -20,7 +20,7 @@ import os
 import re
 from dataclasses import dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from zettelforge.log import get_logger
 
@@ -104,16 +104,16 @@ class LLMConfig:
     max_retries: int = 2
     fallback: str = ""  # empty preserves implicit local→ollama fallback
     local_backend: str = "llama-cpp-python"  # RFC-011: "llama-cpp-python" or "onnxruntime-genai"
-    extra: Dict[str, Any] = field(default_factory=dict)
+    extra: dict[str, Any] = field(default_factory=dict)
 
     # Keys under ``extra`` that are commonly used for secrets. Matched
     # case-insensitively as substrings so ``openai_api_key``, ``client_secret``,
     # ``auth_token``, ``azure_ad_token``, ``credentials_json`` all redact.
     _SENSITIVE_EXTRA_KEYS = ("key", "token", "secret", "password", "credential", "auth")
 
-    def _redact_extra(self) -> Dict[str, Any]:
+    def _redact_extra(self) -> dict[str, Any]:
         """Return ``extra`` with sensitive-looking values replaced by ``'***'``."""
-        redacted: Dict[str, Any] = {}
+        redacted: dict[str, Any] = {}
         for k, v in self.extra.items():
             k_low = k.lower() if isinstance(k, str) else ""
             if isinstance(v, str) and v and any(s in k_low for s in self._SENSITIVE_EXTRA_KEYS):
@@ -160,7 +160,7 @@ class RetrievalConfig:
 class SynthesisConfig:
     max_context_tokens: int = 3000
     default_format: str = "direct_answer"
-    tier_filter: List[str] = field(default_factory=lambda: ["A", "B"])
+    tier_filter: list[str] = field(default_factory=lambda: ["A", "B"])
 
 
 @dataclass
@@ -238,7 +238,7 @@ class ZettelForgeConfig:
     opencti: OpenCTIConfig = field(default_factory=OpenCTIConfig)
 
 
-def _find_config_file() -> Optional[Path]:
+def _find_config_file() -> Path | None:
     """Find config.yaml in standard locations."""
     candidates = [
         Path("config.yaml"),
@@ -467,7 +467,7 @@ def _apply_env(cfg: ZettelForgeConfig):
 
 # ── Singleton ──────────────────────────────────────────────
 
-_config: Optional[ZettelForgeConfig] = None
+_config: ZettelForgeConfig | None = None
 
 
 def get_config() -> ZettelForgeConfig:

--- a/src/zettelforge/consolidation.py
+++ b/src/zettelforge/consolidation.py
@@ -16,7 +16,7 @@ This addresses SAGA Gap 2: Temporal Memory Maintenance.
 import threading
 import time
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 from zettelforge.log import get_logger
 from zettelforge.ocsf import STATUS_SUCCESS, log_api_activity
@@ -55,13 +55,13 @@ class SemanticShiftDetector:
         self.min_epg_size = min_epg_size
 
         # Active window state
-        self._epg_entities: Dict[str, int] = {}  # entity -> count
-        self._epg_topics: Dict[str, float] = {}  # domain -> weight
+        self._epg_entities: dict[str, int] = {}  # entity -> count
+        self._epg_topics: dict[str, float] = {}  # domain -> weight
         self._epg_count: int = 0
-        self._last_note_time: Optional[datetime] = None
+        self._last_note_time: datetime | None = None
         self._lock = threading.Lock()
 
-    def observe(self, note_entities: Dict[str, List[str]], note_domain: str) -> None:
+    def observe(self, note_entities: dict[str, list[str]], note_domain: str) -> None:
         """Update the EPG state with a new note's entities and domain."""
         with self._lock:
             self._epg_count += 1
@@ -82,10 +82,10 @@ class SemanticShiftDetector:
 
     def detect_shift(
         self,
-        note_entities: Dict[str, List[str]],
+        note_entities: dict[str, list[str]],
         note_domain: str,
-        note_time: Optional[datetime] = None,
-    ) -> Tuple[bool, Dict[str, Any]]:
+        note_time: datetime | None = None,
+    ) -> tuple[bool, dict[str, Any]]:
         """
         Check whether a new note represents a semantic shift from the EPG.
 
@@ -97,7 +97,7 @@ class SemanticShiftDetector:
                 return False, {"reason": "epg_too_small", "epg_count": self._epg_count}
 
             shift_signals = []
-            metadata: Dict[str, Any] = {"epg_count": self._epg_count}
+            metadata: dict[str, Any] = {"epg_count": self._epg_count}
 
             # --- Signal 1: Entity novelty ---
             new_entities = 0
@@ -153,7 +153,7 @@ class SemanticShiftDetector:
             self._epg_count = 0
             self._last_note_time = None
 
-    def get_state(self) -> Dict[str, Any]:
+    def get_state(self) -> dict[str, Any]:
         """Get current EPG state for diagnostics."""
         with self._lock:
             return {
@@ -185,30 +185,30 @@ class ConsolidationEngine:
     contradiction checks before promoting to TAN.
     """
 
-    def __init__(self, memory_manager, shift_detector: Optional[SemanticShiftDetector] = None):
+    def __init__(self, memory_manager, shift_detector: SemanticShiftDetector | None = None):
         self._mm = memory_manager
         self._detector = shift_detector or SemanticShiftDetector()
         self._logger = get_logger("zettelforge.consolidation.engine")
         self._consolidation_count: int = 0
-        self._last_consolidation_time: Optional[str] = None
+        self._last_consolidation_time: str | None = None
 
     def should_consolidate(
         self,
-        note_entities: Dict[str, List[str]],
+        note_entities: dict[str, list[str]],
         note_domain: str,
-        note_time: Optional[datetime] = None,
-    ) -> Tuple[bool, Dict[str, Any]]:
+        note_time: datetime | None = None,
+    ) -> tuple[bool, dict[str, Any]]:
         """Check if consolidation should be triggered for this note."""
         return self._detector.detect_shift(note_entities, note_domain, note_time)
 
-    def consolidate(self, force: bool = False) -> Dict[str, Any]:
+    def consolidate(self, force: bool = False) -> dict[str, Any]:
         """
         Execute consolidation: EPG → TAN.
 
         Returns consolidation report with stats.
         """
         start = time.perf_counter()
-        report: Dict[str, Any] = {
+        report: dict[str, Any] = {
             "triggered_at": datetime.now().isoformat(),
             "forced": force,
             "notes_examined": 0,
@@ -250,14 +250,14 @@ class ConsolidationEngine:
                 return report
 
             # Build entity cache before domain grouping (avoid redundant extraction)
-            entity_cache: Dict[str, Dict[str, List[str]]] = {}
+            entity_cache: dict[str, dict[str, list[str]]] = {}
             for note in epg_notes:
                 entity_cache[note.id] = self._mm.indexer.extractor.extract_all(
                     note.content.raw, use_llm=False
                 )
 
             # Group by domain
-            domain_groups: Dict[str, list] = {}
+            domain_groups: dict[str, list] = {}
             for note in epg_notes:
                 domain = note.metadata.domain or "general"
                 domain_groups.setdefault(domain, []).append(note)
@@ -268,7 +268,7 @@ class ConsolidationEngine:
                     continue
 
                 # Find overlapping entity pairs for potential merges
-                entity_map: Dict[str, List[str]] = {}  # entity_key -> [note_ids]
+                entity_map: dict[str, list[str]] = {}  # entity_key -> [note_ids]
                 for note in notes:
                     entities = entity_cache[note.id]
                     for etype, values in entities.items():
@@ -339,7 +339,7 @@ class ConsolidationEngine:
         return report
 
     def _detect_contradictions(
-        self, notes: list, entity_cache: Dict[str, Dict[str, List[str]]]
+        self, notes: list, entity_cache: dict[str, dict[str, list[str]]]
     ) -> set:
         """
         SSGM-inspired contradiction detection.
@@ -383,7 +383,7 @@ class ConsolidationEngine:
 
         return contradicted
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get consolidation engine statistics."""
         return {
             "consolidation_count": self._consolidation_count,
@@ -425,16 +425,16 @@ class ConsolidationMiddleware:
         )
         self._engine = ConsolidationEngine(memory_manager, self._detector)
         self.auto_consolidate = auto_consolidate
-        self._async_thread: Optional[threading.Thread] = None
+        self._async_thread: threading.Thread | None = None
         self._thread_lock = threading.Lock()
         self._logger = get_logger("zettelforge.consolidation.middleware")
 
     def before_write(
         self,
-        note_entities: Dict[str, List[str]],
+        note_entities: dict[str, list[str]],
         note_domain: str,
-        note_time: Optional[datetime] = None,
-    ) -> Tuple[bool, Optional[Dict[str, Any]]]:
+        note_time: datetime | None = None,
+    ) -> tuple[bool, dict[str, Any] | None]:
         """
         Call before writing a note to the store.
 
@@ -479,11 +479,11 @@ class ConsolidationMiddleware:
             self._async_thread = threading.Thread(target=_consolidate, daemon=True)
             self._async_thread.start()
 
-    def consolidate_now(self) -> Dict[str, Any]:
+    def consolidate_now(self) -> dict[str, Any]:
         """Manually trigger consolidation (blocking)."""
         return self._engine.consolidate(force=True)
 
-    def get_stats(self) -> Dict[str, Any]:
+    def get_stats(self) -> dict[str, Any]:
         """Get middleware statistics."""
         stats = self._engine.get_stats()
         stats["auto_consolidate"] = self.auto_consolidate

--- a/src/zettelforge/detection/base.py
+++ b/src/zettelforge/detection/base.py
@@ -12,7 +12,7 @@ added for the shared explainer (§3c).
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 
 @dataclass
@@ -28,18 +28,18 @@ class DetectionRule:
     title: str
     source_format: str  # "sigma" | "yara" | "unknown"
     content_sha256: str
-    description: Optional[str] = None
-    author: Optional[str] = None
-    date: Optional[str] = None
-    modified: Optional[str] = None
+    description: str | None = None
+    author: str | None = None
+    date: str | None = None
+    modified: str | None = None
     references: list[str] = field(default_factory=list)
     tags: list[str] = field(default_factory=list)
-    level: Optional[str] = None  # informational | low | medium | high | critical
-    status: Optional[str] = None  # experimental | test | stable | deprecated
-    tlp: Optional[str] = None
-    license: Optional[str] = None
-    source_repo: Optional[str] = None
-    source_path: Optional[str] = None
+    level: str | None = None  # informational | low | medium | high | critical
+    status: str | None = None  # experimental | test | stable | deprecated
+    tlp: str | None = None
+    license: str | None = None
+    source_repo: str | None = None
+    source_path: str | None = None
     extra: dict[str, Any] = field(default_factory=dict)
 
     def explain_prompt(self) -> str:

--- a/src/zettelforge/detection/explainer.py
+++ b/src/zettelforge/detection/explainer.py
@@ -25,7 +25,7 @@ import os
 import time
 from dataclasses import dataclass, field
 from datetime import datetime, timezone
-from typing import TYPE_CHECKING, Optional
+from typing import TYPE_CHECKING
 
 from zettelforge import llm_client
 from zettelforge.json_parse import extract_json
@@ -139,10 +139,10 @@ def _reset_rate_limiter() -> None:
 
 
 def explain(
-    rule: "DetectionRule",
+    rule: DetectionRule,
     *,
     rule_body: str,
-    provider: Optional[str] = None,
+    provider: str | None = None,
 ) -> RuleExplanation:
     """Generate a semantic explanation of a detection rule.
 

--- a/src/zettelforge/entity_indexer.py
+++ b/src/zettelforge/entity_indexer.py
@@ -17,7 +17,6 @@ import re
 import tempfile
 import threading
 from pathlib import Path
-from typing import Dict, List, Optional, Set
 
 from zettelforge.json_parse import extract_json
 from zettelforge.log import get_logger
@@ -29,7 +28,7 @@ class EntityExtractor:
     """Extract entities from text using regex (CTI) and LLM (conversational) patterns."""
 
     # Regex fast-path for CTI entities — deterministic, zero-latency
-    REGEX_PATTERNS: Dict[str, re.Pattern] = {
+    REGEX_PATTERNS: dict[str, re.Pattern] = {
         "cve": re.compile(r"(CVE-\d{4}-\d{4,})", re.IGNORECASE),
         "intrusion_set": re.compile(
             r"\b((?:apt|unc|ta|fin|temp)\s*-?\s*\d+)\b",
@@ -68,7 +67,7 @@ class EntityExtractor:
     }
 
     # All entity types the system recognizes
-    ENTITY_TYPES: List[str] = [
+    ENTITY_TYPES: list[str] = [
         # CTI (regex)
         "cve",
         "intrusion_set",
@@ -191,7 +190,7 @@ class EntityExtractor:
         re.IGNORECASE,
     )
 
-    def _filter_false_positive_hashes(self, candidates: List[str], text: str) -> List[str]:
+    def _filter_false_positive_hashes(self, candidates: list[str], text: str) -> list[str]:
         """Remove hash candidates that appear in code or VCS contexts.
 
         Strategy: build the set of hex strings that sit on a line whose content
@@ -210,7 +209,7 @@ class EntityExtractor:
             return candidates
 
         # Build set of hex strings that live on a code-context line
-        fp_hashes: Set[str] = set()
+        fp_hashes: set[str] = set()
         for line in text.splitlines():
             if self._CODE_CONTEXT_PATTERN.search(line):
                 # Mark every hex string on this line as a false positive
@@ -219,9 +218,9 @@ class EntityExtractor:
 
         return [c for c in candidates if c.lower() not in fp_hashes]
 
-    def extract_regex(self, text: str) -> Dict[str, List[str]]:
+    def extract_regex(self, text: str) -> dict[str, list[str]]:
         """Extract CTI + IOC + conversational entities using regex. Fast, no LLM."""
-        results: Dict[str, List[str]] = {}
+        results: dict[str, list[str]] = {}
 
         # Hash IOC types that need false-positive filtering
         hash_types = {"md5", "sha1", "sha256"}
@@ -247,7 +246,7 @@ class EntityExtractor:
 
         return results
 
-    def extract_llm(self, text: str) -> Dict[str, List[str]]:
+    def extract_llm(self, text: str) -> dict[str, list[str]]:
         """Extract conversational entities using LLM NER.
 
         Returns dict with person, location, organization, event, activity, temporal keys.
@@ -289,14 +288,14 @@ class EntityExtractor:
             _logger.warning("llm_entity_extraction_failed", exc_info=True)
             return empty
 
-    def _parse_ner_output(self, output: str, expected_types: List[str]) -> Dict[str, List[str]]:
+    def _parse_ner_output(self, output: str, expected_types: list[str]) -> dict[str, list[str]]:
         """Parse LLM NER output into normalized entity dict."""
         parsed = extract_json(output, expect="object")
         return self._parse_ner_output_from_parsed(parsed, output, expected_types)
 
     def _parse_ner_output_from_parsed(
-        self, parsed, output: str, expected_types: List[str]
-    ) -> Dict[str, List[str]]:
+        self, parsed, output: str, expected_types: list[str]
+    ) -> dict[str, list[str]]:
         """Build normalized entity dict from a pre-parsed JSON object."""
         empty = {t: [] for t in expected_types}
 
@@ -312,7 +311,7 @@ class EntityExtractor:
             return empty
 
         # Normalize values
-        results: Dict[str, List[str]] = {}
+        results: dict[str, list[str]] = {}
         for etype in expected_types:
             values = parsed.get(etype, [])
             if isinstance(values, list):
@@ -328,7 +327,7 @@ class EntityExtractor:
 
         return results
 
-    def extract_all(self, text: str, use_llm: bool = False) -> Dict[str, List[str]]:
+    def extract_all(self, text: str, use_llm: bool = False) -> dict[str, list[str]]:
         """Extract all entity types from text.
 
         Uses regex for CTI types (always) and LLM for conversational types
@@ -369,18 +368,18 @@ class EntityExtractor:
 class EntityIndexer:
     """Index notes by entities for fast lookup"""
 
-    def __init__(self, index_path: Optional[str] = None):
+    def __init__(self, index_path: str | None = None):
         from zettelforge.memory_store import get_default_data_dir
 
         if index_path is None:
             index_path = get_default_data_dir() / "entity_index.json"
         self.index_path = Path(index_path)
-        self.index: Dict[str, Dict[str, Set[str]]] = {
+        self.index: dict[str, dict[str, set[str]]] = {
             etype: {} for etype in EntityExtractor.ENTITY_TYPES
         }
         self.extractor = EntityExtractor()
         self._dirty = False
-        self._flush_timer: Optional[threading.Timer] = None
+        self._flush_timer: threading.Timer | None = None
         # RLock so that paths which already hold the lock (e.g. add_note →
         # _schedule_flush) don't deadlock on the timer-coordination
         # acquisition. Same lock guards all index reads/writes/serialize
@@ -443,7 +442,7 @@ class EntityIndexer:
                     pass
             raise
 
-    def add_note(self, note_id: str, entities: Dict[str, List[str]]) -> None:
+    def add_note(self, note_id: str, entities: dict[str, list[str]]) -> None:
         """Add note to entity index."""
         # Hold _flush_lock for the whole mutation so concurrent save() /
         # remove_note() / load() can't observe a torn index. Same lock
@@ -503,13 +502,13 @@ class EntityIndexer:
                 self.save()
                 self._dirty = False
 
-    def get_note_ids(self, entity_type: str, entity_value: str) -> List[str]:
+    def get_note_ids(self, entity_type: str, entity_value: str) -> list[str]:
         """Get note IDs for a specific entity."""
         if entity_type not in self.index:
             return []
         return list(self.index[entity_type].get(entity_value.lower(), []))
 
-    def search_entities(self, query: str, limit: int = 10) -> Dict[str, List[str]]:
+    def search_entities(self, query: str, limit: int = 10) -> dict[str, list[str]]:
         """Search for entities matching a query across all types.
 
         Useful for recall when the entity type is unknown.
@@ -522,14 +521,14 @@ class EntityIndexer:
             Dict mapping entity type to list of matching entity values.
         """
         query_lower = query.lower()
-        results: Dict[str, List[str]] = {}
+        results: dict[str, list[str]] = {}
         for etype, entities in self.index.items():
             matches = [ev for ev in entities.keys() if ev.startswith(query_lower)][:limit]
             if matches:
                 results[etype] = matches
         return results
 
-    def stats(self) -> Dict:
+    def stats(self) -> dict:
         """Get index statistics."""
         return {
             entity_type: {
@@ -539,7 +538,7 @@ class EntityIndexer:
             for entity_type, entities in self.index.items()
         }
 
-    def build(self) -> Dict:
+    def build(self) -> dict:
         """Rebuild index from all notes."""
         from zettelforge.memory_store import MemoryStore
 

--- a/src/zettelforge/extensions.py
+++ b/src/zettelforge/extensions.py
@@ -10,7 +10,7 @@ If no extensions are installed, all features use built-in backends.
 
 import logging
 import os
-from typing import Any, Optional
+from typing import Any
 
 _logger = logging.getLogger("zettelforge.extensions")
 _extensions: dict[str, Any] = {}
@@ -49,7 +49,7 @@ def has_extension(name: str) -> bool:
     return name in _extensions
 
 
-def get_extension(name: str) -> Optional[Any]:
+def get_extension(name: str) -> Any | None:
     """Get a loaded extension module, or None."""
     if not _loaded:
         load_extensions()

--- a/src/zettelforge/fact_extractor.py
+++ b/src/zettelforge/fact_extractor.py
@@ -6,7 +6,6 @@ Only the important facts proceed to storage, reducing redundancy and noise.
 """
 
 from dataclasses import dataclass
-from typing import List
 
 from zettelforge.json_parse import extract_json
 from zettelforge.log import get_logger
@@ -37,7 +36,7 @@ class FactExtractor:
         self,
         content: str,
         context: str = "",
-    ) -> List[ExtractedFact]:
+    ) -> list[ExtractedFact]:
         prompt = self._build_prompt(content, context)
 
         try:
@@ -61,7 +60,7 @@ class FactExtractor:
         parts.append("\nJSON:")
         return "\n".join(parts)
 
-    def _parse_extraction_response(self, raw: str) -> List[ExtractedFact]:
+    def _parse_extraction_response(self, raw: str) -> list[ExtractedFact]:
         if not raw:
             # Was previously a silent return — empty completions vanished
             # entirely from the audit trail, undercounting LLM failures.

--- a/src/zettelforge/governance_validator.py
+++ b/src/zettelforge/governance_validator.py
@@ -6,7 +6,7 @@ Automatically validates operations against our governance documentation
 """
 
 from pathlib import Path
-from typing import Any, Dict, List, Tuple
+from typing import Any
 
 
 class GovernanceValidator:
@@ -18,7 +18,7 @@ class GovernanceValidator:
         self.governance_dir = governance_dir
         self.rules = self._load_governance_rules()
 
-    def _load_governance_rules(self) -> Dict:
+    def _load_governance_rules(self) -> dict:
         """Load key governance rules relevant to memory operations."""
         rules = {
             "GOV-003": {"python_standards": True, "type_hints": True, "naming": True},
@@ -28,7 +28,7 @@ class GovernanceValidator:
         }
         return rules
 
-    def validate_operation(self, operation: str, data: Any = None) -> Tuple[bool, List[str]]:
+    def validate_operation(self, operation: str, data: Any = None) -> tuple[bool, list[str]]:
         """
         Validate an operation against governance rules.
 

--- a/src/zettelforge/graph_retriever.py
+++ b/src/zettelforge/graph_retriever.py
@@ -7,7 +7,6 @@ Score formula: 1 / (1 + hop_distance)
 """
 
 from dataclasses import dataclass, field
-from typing import Dict, List, Set
 
 from zettelforge.knowledge_graph import KnowledgeGraph
 
@@ -19,7 +18,7 @@ class ScoredResult:
     note_id: str
     score: float
     hops: int
-    path: List[str] = field(default_factory=list)
+    path: list[str] = field(default_factory=list)
 
 
 class GraphRetriever:
@@ -30,13 +29,13 @@ class GraphRetriever:
 
     def retrieve_note_ids(
         self,
-        query_entities: Dict[str, List[str]],
+        query_entities: dict[str, list[str]],
         max_depth: int = 2,
-    ) -> List[ScoredResult]:
+    ) -> list[ScoredResult]:
         if not query_entities:
             return []
 
-        best: Dict[str, ScoredResult] = {}
+        best: dict[str, ScoredResult] = {}
 
         for entity_type, values in query_entities.items():
             for entity_value in values:
@@ -51,14 +50,14 @@ class GraphRetriever:
         start_type: str,
         start_value: str,
         max_depth: int,
-        best: Dict[str, ScoredResult],
+        best: dict[str, ScoredResult],
     ):
         start_node = self.kg.get_node(start_type, start_value)
         if not start_node:
             return
 
         start_node_id = start_node["node_id"]
-        visited: Set[str] = set()
+        visited: set[str] = set()
         queue = [(start_node_id, 0, [f"{start_type}:{start_value}"])]
 
         while queue:

--- a/src/zettelforge/integrations/langchain_retriever.py
+++ b/src/zettelforge/integrations/langchain_retriever.py
@@ -18,7 +18,7 @@ Usage:
 
 from __future__ import annotations
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from langchain_core.callbacks import CallbackManagerForRetrieverRun
 from langchain_core.documents import Document
@@ -46,13 +46,13 @@ class ZettelForgeRetriever(BaseRetriever):
 
     memory_manager: MemoryManager = Field(exclude=True)
     k: int = 10
-    domain: Optional[str] = None
+    domain: str | None = None
     include_links: bool = True
     exclude_superseded: bool = True
 
     def _get_relevant_documents(
         self, query: str, *, run_manager: CallbackManagerForRetrieverRun
-    ) -> List[Document]:
+    ) -> list[Document]:
         """Retrieve documents from ZettelForge memory.
 
         Calls MemoryManager.recall() and converts each MemoryNote
@@ -66,9 +66,9 @@ class ZettelForgeRetriever(BaseRetriever):
             exclude_superseded=self.exclude_superseded,
         )
 
-        documents: List[Document] = []
+        documents: list[Document] = []
         for note in notes:
-            metadata: Dict[str, Any] = {
+            metadata: dict[str, Any] = {
                 "note_id": note.id,
                 "source_type": note.content.source_type,
                 "source_ref": note.content.source_ref,

--- a/src/zettelforge/intent_classifier.py
+++ b/src/zettelforge/intent_classifier.py
@@ -13,7 +13,6 @@ Task 3: Lightweight intent classifier to weight traversal policy
 """
 
 from enum import Enum
-from typing import Dict, Optional, Tuple
 
 from zettelforge.log import get_logger
 
@@ -115,7 +114,7 @@ class IntentClassifier:
         self.use_llm_fallback = use_llm_fallback
         self._llm_client = None
 
-    def classify(self, query: str) -> Tuple[QueryIntent, Dict]:
+    def classify(self, query: str) -> tuple[QueryIntent, dict]:
         """
         Classify query intent.
         Returns (intent, metadata) where metadata includes confidence and reasoning.
@@ -155,7 +154,7 @@ class IntentClassifier:
 
         return QueryIntent.EXPLORATORY, {"confidence": 0.3, "method": "default", "scores": scores}
 
-    def _classify_llm(self, query: str) -> Tuple[QueryIntent, Dict]:
+    def _classify_llm(self, query: str) -> tuple[QueryIntent, dict]:
         """Use LLM for ambiguous queries."""
         prompt = f"""Classify this query into one of these intents:
 - factual: Entity lookup (CVE, actor, tool, malware)
@@ -181,7 +180,7 @@ Respond with just the intent name (factual, temporal, relational, exploratory, o
 
         return QueryIntent.EXPLORATORY, {"confidence": 0.5, "method": "llm_fallback", "scores": {}}
 
-    def get_traversal_policy(self, intent: QueryIntent) -> Dict:
+    def get_traversal_policy(self, intent: QueryIntent) -> dict:
         """
         Get traversal policy weights based on intent.
         Returns dict of (retriever_weight, graph_weight, temporal_weight)
@@ -235,7 +234,7 @@ Respond with just the intent name (factual, temporal, relational, exploratory, o
 
 
 # Global instance
-_classifier: Optional[IntentClassifier] = None
+_classifier: IntentClassifier | None = None
 
 
 def get_intent_classifier() -> IntentClassifier:

--- a/src/zettelforge/json_parse.py
+++ b/src/zettelforge/json_parse.py
@@ -8,14 +8,13 @@ All structured-output call sites delegate here instead of inline regex+json.load
 import json
 import logging
 import re
-from typing import Optional, Union
 
 _logger = logging.getLogger("zettelforge.json_parse")
 
 _parse_stats = {"success": 0, "failure": 0}
 
 
-def extract_json(raw: Optional[str], expect: str = "object") -> Optional[Union[dict, list]]:
+def extract_json(raw: str | None, expect: str = "object") -> dict | list | None:
     """Extract JSON from LLM output, handling code fences and surrounding text.
 
     Args:

--- a/src/zettelforge/knowledge_graph.py
+++ b/src/zettelforge/knowledge_graph.py
@@ -21,7 +21,6 @@ import uuid
 from collections import deque
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 
 class KnowledgeGraph:
@@ -30,7 +29,7 @@ class KnowledgeGraph:
     Uses JSONL for append-only persistence.
     """
 
-    def __init__(self, data_dir: Optional[str] = None):
+    def __init__(self, data_dir: str | None = None):
         from zettelforge.memory_store import get_default_data_dir
 
         base_dir = Path(data_dir) if data_dir else get_default_data_dir()
@@ -38,16 +37,16 @@ class KnowledgeGraph:
         self.edges_file = base_dir / "kg_edges.jsonl"
 
         # In-memory caches
-        self._nodes: Dict[str, Dict] = {}  # node_id -> node data
-        self._node_index: Dict[str, Dict[str, str]] = {}  # entity_type -> entity_value -> node_id
-        self._edges: Dict[str, Dict] = {}  # edge_id -> edge data
-        self._edges_from: Dict[str, List[Dict]] = {}  # node_id -> outgoing edges
-        self._edges_to: Dict[str, List[Dict]] = {}  # node_id -> incoming edges
+        self._nodes: dict[str, dict] = {}  # node_id -> node data
+        self._node_index: dict[str, dict[str, str]] = {}  # entity_type -> entity_value -> node_id
+        self._edges: dict[str, dict] = {}  # edge_id -> edge data
+        self._edges_from: dict[str, list[dict]] = {}  # node_id -> outgoing edges
+        self._edges_to: dict[str, list[dict]] = {}  # node_id -> incoming edges
 
         # ===== Temporal Index (Task 2) =====
         # Temporal edges indexed by timestamp
-        self._temporal_index: Dict[str, List[Dict]] = {}  # timestamp -> temporal edges
-        self._entity_timeline: Dict[str, List[Dict]] = {}  # entity_value -> timeline of states
+        self._temporal_index: dict[str, list[dict]] = {}  # timestamp -> temporal edges
+        self._entity_timeline: dict[str, list[dict]] = {}  # entity_value -> timeline of states
 
         self._lock = threading.RLock()
         self._load_all()
@@ -55,7 +54,7 @@ class KnowledgeGraph:
     def _load_all(self):
         """Load nodes and edges from JSONL files."""
         if self.nodes_file.exists():
-            with open(self.nodes_file, "r") as f:
+            with open(self.nodes_file) as f:
                 for line in f:
                     if line.strip():
                         try:
@@ -65,7 +64,7 @@ class KnowledgeGraph:
                             continue
 
         if self.edges_file.exists():
-            with open(self.edges_file, "r") as f:
+            with open(self.edges_file) as f:
                 for line in f:
                     if line.strip():
                         try:
@@ -80,7 +79,7 @@ class KnowledgeGraph:
                         except json.JSONDecodeError:
                             continue
 
-    def _cache_node(self, node: Dict):
+    def _cache_node(self, node: dict):
         self._nodes[node["node_id"]] = node
         etype = node["entity_type"]
         evalue = node["entity_value"]
@@ -88,7 +87,7 @@ class KnowledgeGraph:
             self._node_index[etype] = {}
         self._node_index[etype][evalue] = node["node_id"]
 
-    def _cache_edge(self, edge: Dict):
+    def _cache_edge(self, edge: dict):
         self._edges[edge["edge_id"]] = edge
 
         from_id = edge["from_node_id"]
@@ -116,7 +115,7 @@ class KnowledgeGraph:
 
     # ===== Temporal Indexing (Task 2) =====
 
-    def _parse_timestamp(self, ts_string: str) -> Optional[datetime]:
+    def _parse_timestamp(self, ts_string: str) -> datetime | None:
         """Parse various timestamp formats."""
         if not ts_string:
             return None
@@ -136,7 +135,7 @@ class KnowledgeGraph:
                 continue
         return None
 
-    def _index_temporal_edge(self, edge: Dict):
+    def _index_temporal_edge(self, edge: dict):
         """Index a temporal edge in the temporal index."""
         ts = edge.get("properties", {}).get("timestamp") or edge.get("created_at", "")
         if ts:
@@ -168,7 +167,7 @@ class KnowledgeGraph:
         to_value: str,
         relationship: str,  # TEMPORAL_BEFORE, TEMPORAL_AFTER, SUPERSEDES
         timestamp: str,
-        properties: Optional[Dict] = None,
+        properties: dict | None = None,
     ) -> str:
         """Add a temporal edge with timestamp."""
         props = properties or {}
@@ -183,7 +182,7 @@ class KnowledgeGraph:
 
         return edge_id
 
-    def get_entity_timeline(self, entity_type: str, entity_value: str) -> List[Dict]:
+    def get_entity_timeline(self, entity_type: str, entity_value: str) -> list[dict]:
         """Get timeline of states for an entity."""
         entity_key = f"{entity_type}:{entity_value}"
         timeline = self._entity_timeline.get(entity_key, [])
@@ -192,7 +191,7 @@ class KnowledgeGraph:
         timeline.sort(key=lambda x: x["timestamp"] or "")
         return timeline
 
-    def get_changes_since(self, timestamp: str) -> List[Dict]:
+    def get_changes_since(self, timestamp: str) -> list[dict]:
         """Get all entity changes since a given timestamp."""
         changes = []
 
@@ -215,9 +214,7 @@ class KnowledgeGraph:
 
     # ===== Core Graph Operations =====
 
-    def add_node(
-        self, entity_type: str, entity_value: str, properties: Optional[Dict] = None
-    ) -> str:
+    def add_node(self, entity_type: str, entity_value: str, properties: dict | None = None) -> str:
         """Add or update a node. Returns node_id."""
         with self._lock:
             # Check if exists
@@ -251,7 +248,7 @@ class KnowledgeGraph:
         to_type: str,
         to_value: str,
         relationship: str,
-        properties: Optional[Dict] = None,
+        properties: dict | None = None,
     ) -> str:
         """Add or update a relationship edge between two entities. Auto-creates nodes."""
         with self._lock:
@@ -300,24 +297,24 @@ class KnowledgeGraph:
 
             return edge_id
 
-    def _append_jsonl(self, path: Path, data: Dict):
+    def _append_jsonl(self, path: Path, data: dict):
         """Append to JSONL file atomically-ish."""
         path.parent.mkdir(parents=True, exist_ok=True)
         with open(path, "a") as f:
             f.write(json.dumps(data) + "\n")
 
-    def get_node(self, entity_type: str, entity_value: str) -> Optional[Dict]:
+    def get_node(self, entity_type: str, entity_value: str) -> dict | None:
         """Get node by type and value."""
         node_id = self._node_index.get(entity_type, {}).get(entity_value)
         if node_id:
             return self._nodes.get(node_id)
         return None
 
-    def get_node_by_id(self, node_id: str) -> Optional[Dict]:
+    def get_node_by_id(self, node_id: str) -> dict | None:
         """Get node by its internal node_id."""
         return self._nodes.get(node_id)
 
-    def get_outgoing_edges(self, node_id: str) -> List[Dict]:
+    def get_outgoing_edges(self, node_id: str) -> list[dict]:
         """Return all outgoing edges for a node_id.
 
         Each edge dict contains at minimum: edge_id, from_node_id, to_node_id,
@@ -326,8 +323,8 @@ class KnowledgeGraph:
         return list(self._edges_from.get(node_id, []))
 
     def get_neighbors(
-        self, entity_type: str, entity_value: str, relationship: Optional[str] = None
-    ) -> List[Dict]:
+        self, entity_type: str, entity_value: str, relationship: str | None = None
+    ) -> list[dict]:
         """Get all adjacent nodes (outgoing edges) for a given node."""
         node_id = self._node_index.get(entity_type, {}).get(entity_value)
         if not node_id:
@@ -348,7 +345,7 @@ class KnowledgeGraph:
                 )
         return neighbors
 
-    def traverse(self, start_type: str, start_value: str, max_depth: int = 2) -> List[Dict]:
+    def traverse(self, start_type: str, start_value: str, max_depth: int = 2) -> list[dict]:
         """Traverse the graph up to max_depth."""
         start_node_id = self._node_index.get(start_type, {}).get(start_value)
         if not start_node_id:
@@ -385,7 +382,7 @@ class KnowledgeGraph:
 
     def get_causal_edges(
         self, entity_type: str, entity_value: str, max_depth: int = 3, max_visited: int = 50
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """BFS over OUTGOING causal edges — traces forward from cause to effects."""
         node_id = self._node_index.get(entity_type, {}).get(entity_value.lower())
         if not node_id:
@@ -412,7 +409,7 @@ class KnowledgeGraph:
 
     def get_incoming_causal(
         self, entity_type: str, entity_value: str, max_depth: int = 3, max_visited: int = 50
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """BFS over INCOMING causal edges — traces back to root causes ('why' queries)."""
         node_id = self._node_index.get(entity_type, {}).get(entity_value.lower())
         if not node_id:
@@ -437,7 +434,7 @@ class KnowledgeGraph:
 
         return causal_edges
 
-    def get_latest_state(self, entity_type: str, entity_value: str) -> Optional[Dict]:
+    def get_latest_state(self, entity_type: str, entity_value: str) -> dict | None:
         """Get the latest known state of an entity."""
         timeline = self.get_entity_timeline(entity_type, entity_value)
         if timeline:
@@ -446,7 +443,7 @@ class KnowledgeGraph:
 
 
 # Global singleton
-_kg_instance: Optional[KnowledgeGraph] = None
+_kg_instance: KnowledgeGraph | None = None
 _kg_lock = threading.Lock()
 
 

--- a/src/zettelforge/lance_maintenance.py
+++ b/src/zettelforge/lance_maintenance.py
@@ -34,9 +34,10 @@ from __future__ import annotations
 import os
 import threading
 import time
+from collections.abc import Callable
 from datetime import timedelta
 from pathlib import Path
-from typing import Any, Callable, Dict, Optional
+from typing import Any
 
 from zettelforge.log import get_logger
 
@@ -57,7 +58,7 @@ class LanceVersionMaintenance:
         db: Any,
         interval_minutes_provider: Callable[[], int],
         older_than_seconds_provider: Callable[[], int],
-        table_root: Optional[Path] = None,
+        table_root: Path | None = None,
         clock: Callable[[], float] = time.monotonic,
         sleep: Callable[[float], None] = time.sleep,
     ) -> None:
@@ -90,7 +91,7 @@ class LanceVersionMaintenance:
         self._sleep = sleep
 
         self._lock = threading.Lock()
-        self._threads: Dict[str, threading.Thread] = {}
+        self._threads: dict[str, threading.Thread] = {}
         self._stop_event = threading.Event()
 
     # ── Lifecycle ───────────────────────────────────────────────────────
@@ -140,7 +141,7 @@ class LanceVersionMaintenance:
             t.start()
             _logger.info("lance_maintenance_thread_started", table=table_name)
 
-    def stop(self, timeout: Optional[float] = None) -> None:
+    def stop(self, timeout: float | None = None) -> None:
         """Signal all threads to exit on their next loop boundary.
 
         Threads check :py:attr:`_stop_event` between sleep wakeups.
@@ -207,13 +208,13 @@ class LanceVersionMaintenance:
             elapsed_seconds=elapsed_s,
         )
 
-    def _table_dir(self, table_name: str) -> Optional[Path]:
+    def _table_dir(self, table_name: str) -> Path | None:
         if self._table_root is None:
             return None
         return Path(self._table_root) / f"{table_name}.lance"
 
 
-def _safe_dir_size(path: Optional[Path]) -> int:
+def _safe_dir_size(path: Path | None) -> int:
     if path is None or not path.exists():
         return 0
     total = 0
@@ -226,7 +227,7 @@ def _safe_dir_size(path: Optional[Path]) -> int:
     return total
 
 
-def _extract_versions_pruned(stats: Any) -> Optional[int]:
+def _extract_versions_pruned(stats: Any) -> int | None:
     """LanceDB returns a metrics object that varies by version.
 
     Best-effort: try common attribute names; otherwise return ``None``

--- a/src/zettelforge/llm_client.py
+++ b/src/zettelforge/llm_client.py
@@ -18,7 +18,7 @@ Example::
 from __future__ import annotations
 
 import os
-from typing import Any, Dict, Optional
+from typing import Any
 
 from zettelforge.llm_providers import LLMProviderConfigurationError, registry
 from zettelforge.log import get_logger
@@ -78,7 +78,7 @@ def get_ollama_url() -> str:
 # ── Provider kwargs ──────────────────────────────────────────────────────────
 
 
-def _provider_kwargs(provider_name: str) -> Dict[str, Any]:
+def _provider_kwargs(provider_name: str) -> dict[str, Any]:
     """Build constructor kwargs for a provider from current config + env.
 
     The registry caches instances keyed by name, so these kwargs are only
@@ -86,7 +86,7 @@ def _provider_kwargs(provider_name: str) -> Dict[str, Any]:
     config changes at runtime — it clears both the cached config and the
     cached provider instances.
     """
-    kwargs: Dict[str, Any] = {}
+    kwargs: dict[str, Any] = {}
 
     try:
         from zettelforge.config import get_config
@@ -157,7 +157,7 @@ def _provider_kwargs(provider_name: str) -> Dict[str, Any]:
     return {k: v for k, v in kwargs.items() if v != ""}
 
 
-def _fallback_provider(primary: str) -> Optional[str]:
+def _fallback_provider(primary: str) -> str | None:
     """Return the fallback provider name for ``primary`` (or ``None``)."""
     try:
         from zettelforge.config import get_config
@@ -183,7 +183,7 @@ def generate(
     prompt: str,
     max_tokens: int = 400,
     temperature: float = 0.1,
-    system: Optional[str] = None,
+    system: str | None = None,
     json_mode: bool = False,
 ) -> str:
     """Generate text from a prompt via the configured LLM provider.
@@ -286,7 +286,7 @@ def _generate_local(
     prompt: str,
     max_tokens: int,
     temperature: float,
-    system: Optional[str],
+    system: str | None,
     json_mode: bool = False,
 ) -> str:
     """Deprecated compat shim — prefer :func:`generate`."""
@@ -300,7 +300,7 @@ def _generate_ollama(
     prompt: str,
     max_tokens: int,
     temperature: float,
-    system: Optional[str] = None,
+    system: str | None = None,
     json_mode: bool = False,
 ) -> str:
     """Deprecated compat shim — prefer :func:`generate`."""

--- a/src/zettelforge/llm_providers/base.py
+++ b/src/zettelforge/llm_providers/base.py
@@ -16,7 +16,7 @@ so the caller can surface the error instead of silently falling back.
 
 from __future__ import annotations
 
-from typing import Optional, Protocol, runtime_checkable
+from typing import Protocol, runtime_checkable
 
 
 class LLMProviderConfigurationError(Exception):
@@ -46,7 +46,7 @@ class LLMProvider(Protocol):
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         """Generate text from a prompt.

--- a/src/zettelforge/llm_providers/litellm_provider.py
+++ b/src/zettelforge/llm_providers/litellm_provider.py
@@ -16,7 +16,7 @@ Usage::
 from __future__ import annotations
 
 import time
-from typing import Any, Optional
+from typing import Any
 
 from zettelforge.log import get_logger
 
@@ -67,7 +67,7 @@ class LiteLLMProvider:
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         try:

--- a/src/zettelforge/llm_providers/local_provider.py
+++ b/src/zettelforge/llm_providers/local_provider.py
@@ -13,7 +13,7 @@ inference engine via an internal ``LocalBackend`` protocol.
 from __future__ import annotations
 
 import threading
-from typing import Any, Optional
+from typing import Any
 
 from zettelforge.log import get_logger
 
@@ -45,7 +45,7 @@ class _LocalBackend:
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         """Generate text. Returns empty string on recoverable failure."""
@@ -111,7 +111,7 @@ class LlamaCppBackend(_LocalBackend):
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         llm = self._get_llm()
@@ -201,7 +201,7 @@ class OnnxGenAIBackend(_LocalBackend):
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         self._load()
@@ -320,7 +320,7 @@ class LocalProvider:
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         return self._get_impl().generate(

--- a/src/zettelforge/llm_providers/mock_provider.py
+++ b/src/zettelforge/llm_providers/mock_provider.py
@@ -6,7 +6,7 @@ Records every call and returns canned responses in order. See
 
 from __future__ import annotations
 
-from typing import Any, Optional
+from typing import Any
 
 
 class MockProvider:
@@ -23,7 +23,7 @@ class MockProvider:
 
     name = "mock"
 
-    def __init__(self, responses: Optional[list[str]] = None, **_: Any) -> None:
+    def __init__(self, responses: list[str] | None = None, **_: Any) -> None:
         self._responses: list[str] = list(responses) if responses else ["mock response"]
         self._call_count = 0
         self.calls: list[dict[str, Any]] = []
@@ -33,7 +33,7 @@ class MockProvider:
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         self.calls.append(

--- a/src/zettelforge/llm_providers/ollama_provider.py
+++ b/src/zettelforge/llm_providers/ollama_provider.py
@@ -8,7 +8,7 @@ registry can build instances from :class:`~zettelforge.config.LLMConfig`.
 from __future__ import annotations
 
 import time
-from typing import Any, Optional
+from typing import Any
 
 from zettelforge.log import get_logger
 
@@ -51,7 +51,7 @@ class OllamaProvider:
         prompt: str,
         max_tokens: int = 400,
         temperature: float = 0.1,
-        system: Optional[str] = None,
+        system: str | None = None,
         json_mode: bool = False,
     ) -> str:
         import ollama

--- a/src/zettelforge/llm_providers/registry.py
+++ b/src/zettelforge/llm_providers/registry.py
@@ -7,19 +7,18 @@ first access. Callers resolve via :func:`get`. See RFC-002.
 from __future__ import annotations
 
 import threading
-from typing import Dict, Type
 
 from zettelforge.llm_providers.base import LLMProvider
 from zettelforge.log import get_logger
 
 _logger = get_logger("zettelforge.llm_providers.registry")
 
-_registry: Dict[str, Type[LLMProvider]] = {}
-_instances: Dict[str, LLMProvider] = {}
+_registry: dict[str, type[LLMProvider]] = {}
+_instances: dict[str, LLMProvider] = {}
 _lock = threading.Lock()
 
 
-def register(name: str, provider_class: Type[LLMProvider]) -> None:
+def register(name: str, provider_class: type[LLMProvider]) -> None:
     """Register a provider class by name.
 
     Raises:

--- a/src/zettelforge/log.py
+++ b/src/zettelforge/log.py
@@ -11,7 +11,6 @@ import os
 import sys
 from logging.handlers import RotatingFileHandler
 from pathlib import Path
-from typing import Optional
 
 import structlog
 
@@ -36,8 +35,8 @@ class _AuditFilter(logging.Filter):
 
 def configure_logging(
     level: str = "INFO",
-    log_file: Optional[str] = None,
-    audit_log_file: Optional[str] = None,
+    log_file: str | None = None,
+    audit_log_file: str | None = None,
     log_to_stderr: bool = True,
     max_bytes: int = 10 * 1024 * 1024,
     backup_count: int = 9,

--- a/src/zettelforge/mcp/server.py
+++ b/src/zettelforge/mcp/server.py
@@ -5,7 +5,6 @@ import os
 import sys
 import threading
 import time
-from typing import Optional
 
 from zettelforge import MemoryManager, __version__
 
@@ -15,7 +14,7 @@ from zettelforge import MemoryManager, __version__
 # backend defaults to sqlite when the server actually runs.
 os.environ.setdefault("ZETTELFORGE_BACKEND", "sqlite")
 
-_mm: Optional[MemoryManager] = None
+_mm: MemoryManager | None = None
 _mm_lock = threading.Lock()
 
 

--- a/src/zettelforge/memory_evolver.py
+++ b/src/zettelforge/memory_evolver.py
@@ -8,7 +8,7 @@ with new context from the incoming note.
 Based on: A-Mem (arXiv:2502.12110, NeurIPS 2025)
 """
 
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 from zettelforge.json_parse import extract_json
 from zettelforge.llm_client import generate
@@ -56,7 +56,7 @@ class MemoryEvolver:
 
     # ── Candidate discovery ─────────────────────────────────────────────
 
-    def find_evolution_candidates(self, note: MemoryNote) -> List[MemoryNote]:
+    def find_evolution_candidates(self, note: MemoryNote) -> list[MemoryNote]:
         """Find top-k notes similar to *note* that might benefit from evolution.
 
         Uses the memory manager's recall path (vector + entity + reranking)
@@ -80,7 +80,7 @@ class MemoryEvolver:
         self,
         new_note: MemoryNote,
         neighbor: MemoryNote,
-    ) -> Optional[Dict]:
+    ) -> dict | None:
         """Ask the LLM whether *neighbor* should be updated given *new_note*.
 
         Returns a dict with keys ``action``, ``reason``, ``updated_content``
@@ -206,7 +206,7 @@ class MemoryEvolver:
 
     # ── Main entry point ────────────────────────────────────────────────
 
-    def evolve_neighbors(self, new_note: MemoryNote) -> Dict[str, Any]:
+    def evolve_neighbors(self, new_note: MemoryNote) -> dict[str, Any]:
         """Find candidates and evolve neighbors of *new_note*.
 
         Returns a report dict::
@@ -220,7 +220,7 @@ class MemoryEvolver:
                 "evolved_ids": [str],
             }
         """
-        report: Dict[str, Any] = {
+        report: dict[str, Any] = {
             "candidates_found": 0,
             "evaluated": 0,
             "evolved": 0,

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -15,7 +15,7 @@ import time
 import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any
 
 import structlog
 
@@ -80,7 +80,7 @@ class MemoryManager:
     Main interface for agent memory operations.
     """
 
-    def __init__(self, jsonl_path: Optional[str] = None, lance_path: Optional[str] = None):
+    def __init__(self, jsonl_path: str | None = None, lance_path: str | None = None):
         # Derive data_dir from jsonl_path if provided (tests pass custom paths)
         _data_dir = None
         if jsonl_path:
@@ -135,8 +135,8 @@ class MemoryManager:
         self._telemetry = get_telemetry()
         # Correlation slot — recall stores its query_id/results here so
         # synthesize() can attach synthesis telemetry to the same query_id.
-        self._telemetry_query_id: Optional[str] = None
-        self._telemetry_retrieved_notes: Optional[List] = None
+        self._telemetry_query_id: str | None = None
+        self._telemetry_retrieved_notes: list | None = None
 
         # Dual-stream enrichment: background worker for LLM causal extraction
         self._enrichment_queue: queue.Queue = queue.Queue(maxsize=500)
@@ -158,7 +158,7 @@ class MemoryManager:
         domain: str = "general",
         evolve: bool = False,
         sync: bool = False,
-    ) -> Tuple[MemoryNote, str]:
+    ) -> tuple[MemoryNote, str]:
         """
         Create a new memory note from content.
 
@@ -218,7 +218,7 @@ class MemoryManager:
         sync: bool,
         request_id: str,
         start: float,
-    ) -> Tuple[MemoryNote, str]:
+    ) -> tuple[MemoryNote, str]:
         """Inner body of remember(); split out so trace_id binding can wrap it."""
         # Governance validation
         try:
@@ -277,7 +277,7 @@ class MemoryManager:
         # [RFC-009 Phase 0.5] Per-phase timings to attribute remember() latency.
         # Emitted in ocsf_api_activity.phase_timings_ms so the RFC-007 aggregator
         # can bucket them without schema changes.
-        phase_timings_ms: Dict[str, float] = {}
+        phase_timings_ms: dict[str, float] = {}
 
         _p = time.perf_counter()
         note = self.constructor.construct(
@@ -424,7 +424,7 @@ class MemoryManager:
         context: str = "",
         min_importance: int = 3,
         max_facts: int = 5,
-    ) -> List[Tuple[Optional[MemoryNote], str]]:
+    ) -> list[tuple[MemoryNote | None, str]]:
         """
         Mem0-style two-phase pipeline: extract salient facts, then decide ADD/UPDATE/DELETE/NOOP.
 
@@ -482,7 +482,7 @@ class MemoryManager:
         min_importance: int = 3,
         max_facts: int = 10,
         chunk_size: int = 3000,
-    ) -> List[Tuple[Optional[MemoryNote], str]]:
+    ) -> list[tuple[MemoryNote | None, str]]:
         """
         Ingest a news report or threat report.
 
@@ -541,13 +541,13 @@ class MemoryManager:
     def recall(
         self,
         query: str,
-        domain: Optional[str] = None,
+        domain: str | None = None,
         k: int = 10,
         include_links: bool = True,
         exclude_superseded: bool = True,
         include_expired: bool = False,
-        actor: Optional[str] = None,
-    ) -> List[MemoryNote]:
+        actor: str | None = None,
+    ) -> list[MemoryNote]:
         """
         Retrieve memories relevant to query using blended vector + graph retrieval.
 
@@ -581,7 +581,7 @@ class MemoryManager:
         # requires real similarity scores for min-max fusion. Without this,
         # commit 0e1c73 fails with ValueError: too many values to unpack.
         _vector_start = time.perf_counter()
-        vector_scored: List[tuple] = self.retriever.retrieve(
+        vector_scored: list[tuple] = self.retriever.retrieve(
             query=query,
             domain=domain,
             k=k,
@@ -759,7 +759,7 @@ class MemoryManager:
         )
         return results
 
-    def recall_entity(self, entity_type: str, entity_value: str, k: int = 5) -> List[MemoryNote]:
+    def recall_entity(self, entity_type: str, entity_value: str, k: int = 5) -> list[MemoryNote]:
         """
         Fast lookup by entity type and value.
         entity_type: 'cve', 'actor', 'threat_actor', 'intrusion_set', 'tool',
@@ -778,11 +778,11 @@ class MemoryManager:
                 notes.append(note)
         return notes
 
-    def recall_cve(self, cve_id: str, k: int = 5) -> List[MemoryNote]:
+    def recall_cve(self, cve_id: str, k: int = 5) -> list[MemoryNote]:
         """Fast lookup by CVE-ID (case-insensitive)"""
         return self.recall_entity("cve", cve_id.upper(), k)
 
-    def recall_actor(self, actor_name: str, k: int = 5) -> List[MemoryNote]:
+    def recall_actor(self, actor_name: str, k: int = 5) -> list[MemoryNote]:
         """Fast lookup by threat actor name.
 
         Searches legacy 'actor', STIX 'threat_actor', and STIX
@@ -801,16 +801,16 @@ class MemoryManager:
                     seen.add(note.id)
         return results
 
-    def recall_technique(self, technique_id: str, k: int = 25) -> List[MemoryNote]:
+    def recall_technique(self, technique_id: str, k: int = 25) -> list[MemoryNote]:
         """Fast lookup by MITRE ATT&CK technique ID (e.g., T1059)."""
         return self.recall_entity("attack_pattern", technique_id.upper(), k)
 
-    def recall_tool(self, tool_name: str, k: int = 5) -> List[MemoryNote]:
+    def recall_tool(self, tool_name: str, k: int = 5) -> list[MemoryNote]:
         """Fast lookup by tool name"""
         return self.recall_entity("tool", tool_name.lower(), k)
 
     def get_context(
-        self, query: str, domain: Optional[str] = None, k: int = 10, token_budget: int = 4000
+        self, query: str, domain: str | None = None, k: int = 10, token_budget: int = 4000
     ) -> str:
         """
         Get formatted memory context for agent prompt injection.
@@ -819,7 +819,7 @@ class MemoryManager:
             query=query, domain=domain, k=k, token_budget=token_budget
         )
 
-    def get_stats(self) -> Dict:
+    def get_stats(self) -> dict:
         """Get memory system statistics"""
         return {
             **self.stats,
@@ -827,7 +827,7 @@ class MemoryManager:
             "entity_index": self.indexer.stats(),
         }
 
-    def _update_knowledge_graph(self, note: MemoryNote, resolved_entities: Dict[str, List[str]]):
+    def _update_knowledge_graph(self, note: MemoryNote, resolved_entities: dict[str, list[str]]):
         now = datetime.now().isoformat()
         edge_props = {"first_observed": now, "confidence": note.metadata.confidence}
 
@@ -1120,7 +1120,7 @@ class MemoryManager:
             except Exception:
                 self._logger.warning("enrichment_drain_failed", exc_info=True)
 
-    def evolve_note(self, note_id: str, sync: bool = False) -> Optional[Dict]:
+    def evolve_note(self, note_id: str, sync: bool = False) -> dict | None:
         """Trigger neighbor evolution for an existing note.
 
         Intended for manual or MCP invocation.
@@ -1188,8 +1188,8 @@ class MemoryManager:
         return True
 
     def _check_supersession(
-        self, new_note: MemoryNote, resolved_entities: Dict[str, List[str]]
-    ) -> Optional[MemoryNote]:
+        self, new_note: MemoryNote, resolved_entities: dict[str, list[str]]
+    ) -> MemoryNote | None:
         from datetime import datetime
 
         _entity_keys = [
@@ -1207,7 +1207,7 @@ class MemoryManager:
         ]
 
         # Build the new note's normalised entity sets once.
-        new_entities: Dict[str, set] = {
+        new_entities: dict[str, set] = {
             k: set(e.lower() for e in resolved_entities.get(k, [])) for k in _entity_keys
         }
 
@@ -1215,7 +1215,7 @@ class MemoryManager:
         # least one entity value with the new note — O(E) instead of O(N).
         # Also pre-compute per-candidate overlap counts while traversing the index
         # so we never need to re-extract entities from raw content.
-        candidate_overlap: Dict[str, int] = {}
+        candidate_overlap: dict[str, int] = {}
         for key in _entity_keys:
             for evalue in new_entities[key]:
                 nids = self.store.get_note_ids_for_entity(key, evalue)
@@ -1281,7 +1281,7 @@ class MemoryManager:
         to_type: str,
         to_value: str,
         relationship: str,
-        properties: Optional[Dict] = None,
+        properties: dict | None = None,
     ) -> None:
         """Ingest a STIX relationship into the knowledge graph.
 
@@ -1318,7 +1318,7 @@ class MemoryManager:
         entity_value: str,
         max_depth: int = 3,
         direction: str = "forward",
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """Trace causal provenance chain from an entity.
 
         Args:
@@ -1357,14 +1357,14 @@ class MemoryManager:
             )
         return chain
 
-    def get_entity_relationships(self, entity_type: str, entity_value: str) -> List[Dict]:
+    def get_entity_relationships(self, entity_type: str, entity_value: str) -> list[dict]:
         """Get direct relationships for an entity from the knowledge graph."""
         # Resolve alias if necessary
         canonical = self.resolver.resolve(entity_type, entity_value)
 
         return self.store.get_kg_neighbors(entity_type, canonical)
 
-    def traverse_graph(self, start_type: str, start_value: str, max_depth: int = 2) -> List[Dict]:
+    def traverse_graph(self, start_type: str, start_value: str, max_depth: int = 2) -> list[dict]:
         """Traverse relationships from a starting entity.
 
         Depth is capped at 2 without the enterprise extension.
@@ -1388,9 +1388,9 @@ class MemoryManager:
         query: str,
         format: str = "direct_answer",
         k: int = 10,
-        tier_filter: List[str] = None,
-        actor: Optional[str] = None,
-    ) -> Dict[str, Any]:
+        tier_filter: list[str] = None,
+        actor: str | None = None,
+    ) -> dict[str, Any]:
         """
         Synthesize an answer from retrieved memories (Phase 7 RAG-as-Answer).
 
@@ -1455,7 +1455,7 @@ class MemoryManager:
         )
         return result
 
-    def validate_synthesis(self, response: Dict) -> Tuple[bool, List[str]]:
+    def validate_synthesis(self, response: dict) -> tuple[bool, list[str]]:
         """
         Validate a synthesis response for quality.
 
@@ -1465,7 +1465,7 @@ class MemoryManager:
         validator = get_synthesis_validator()
         return validator.validate_response(response)
 
-    def check_synthesis_quality(self, response: Dict) -> Dict:
+    def check_synthesis_quality(self, response: dict) -> dict:
         """
         Compute quality score for a synthesis response.
 
@@ -1476,7 +1476,7 @@ class MemoryManager:
 
 
 # Global memory manager instance
-_memory_manager: Optional[MemoryManager] = None
+_memory_manager: MemoryManager | None = None
 
 
 def get_memory_manager() -> MemoryManager:

--- a/src/zettelforge/memory_store.py
+++ b/src/zettelforge/memory_store.py
@@ -12,9 +12,9 @@ import os
 import tempfile
 import threading
 import time
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional
 
 from zettelforge.log import get_logger
 from zettelforge.note_schema import MemoryNote
@@ -41,9 +41,9 @@ class MemoryStore:
 
     def __init__(
         self,
-        jsonl_path: Optional[str] = None,
-        lance_path: Optional[str] = None,
-        embedding_dim: Optional[int] = None,
+        jsonl_path: str | None = None,
+        lance_path: str | None = None,
+        embedding_dim: int | None = None,
     ):
         data_dir = get_default_data_dir()
 
@@ -65,11 +65,11 @@ class MemoryStore:
         self.jsonl_path.parent.mkdir(parents=True, exist_ok=True)
         self.lance_path.mkdir(parents=True, exist_ok=True)
         self._lancedb = None
-        self._note_cache: Optional[Dict[str, MemoryNote]] = None
-        self._source_ref_index: Optional[Dict[str, str]] = None  # source_ref -> note_id
+        self._note_cache: dict[str, MemoryNote] | None = None
+        self._source_ref_index: dict[str, str] | None = None  # source_ref -> note_id
 
         self._dirty_access: set = set()  # note IDs with unsaved access updates
-        self._access_flush_timer: Optional[threading.Timer] = None
+        self._access_flush_timer: threading.Timer | None = None
         self._access_flush_lock = threading.Lock()
         atexit.register(self._flush_access)
 
@@ -151,7 +151,7 @@ class MemoryStore:
         self._source_ref_index = {}
         if not self.jsonl_path.exists():
             return
-        with open(self.jsonl_path, "r") as f:
+        with open(self.jsonl_path) as f:
             for line in f:
                 if line.strip():
                     try:
@@ -283,13 +283,13 @@ class MemoryStore:
                 duration_ms=duration_ms,
             )
 
-    def read_all_notes(self) -> List[MemoryNote]:
+    def read_all_notes(self) -> list[MemoryNote]:
         """Read all notes from JSONL store"""
         notes = []
         if not self.jsonl_path.exists():
             return notes
 
-        with open(self.jsonl_path, "r") as f:
+        with open(self.jsonl_path) as f:
             for line in f:
                 if line.strip():
                     try:
@@ -307,7 +307,7 @@ class MemoryStore:
         # Dead code below — kept for reference of old disk-based path
         if not self.jsonl_path.exists():
             return
-        with open(self.jsonl_path, "r") as f:
+        with open(self.jsonl_path) as f:
             for line in f:
                 if line.strip():
                     try:
@@ -316,12 +316,12 @@ class MemoryStore:
                     except Exception as e:
                         _logger.warning("note_parse_failed", error=str(e))
 
-    def get_note_by_id(self, note_id: str) -> Optional[MemoryNote]:
+    def get_note_by_id(self, note_id: str) -> MemoryNote | None:
         """Retrieve a specific note by ID. O(1) via cache."""
         self._ensure_cache()
         return self._note_cache.get(note_id)
 
-    def get_note_by_source_ref(self, source_ref: str) -> Optional[MemoryNote]:
+    def get_note_by_source_ref(self, source_ref: str) -> MemoryNote | None:
         """Find a note by its source_ref field. O(1) via index. Returns None if not found."""
         self._ensure_cache()
         note_id = self._source_ref_index.get(source_ref)
@@ -329,11 +329,11 @@ class MemoryStore:
             return None
         return self._note_cache.get(note_id)
 
-    def get_notes_by_domain(self, domain: str) -> List[MemoryNote]:
+    def get_notes_by_domain(self, domain: str) -> list[MemoryNote]:
         """Retrieve all notes for a specific domain"""
         return [n for n in self.iterate_notes() if n.metadata.domain == domain]
 
-    def get_recent_notes(self, limit: int = 10) -> List[MemoryNote]:
+    def get_recent_notes(self, limit: int = 10) -> list[MemoryNote]:
         """Get most recent notes"""
         notes = list(self.iterate_notes())
         notes.sort(key=lambda n: n.created_at, reverse=True)
@@ -343,7 +343,7 @@ class MemoryStore:
         """Count total notes"""
         if not self.jsonl_path.exists():
             return 0
-        with open(self.jsonl_path, "r") as f:
+        with open(self.jsonl_path) as f:
             return sum(1 for line in f if line.strip())
 
     def _rewrite_note(self, note: MemoryNote) -> None:
@@ -352,7 +352,7 @@ class MemoryStore:
             return
 
         # Hold an exclusive lock on the canonical file for the entire read-write-replace cycle
-        with open(self.jsonl_path, "r") as lock_fh:
+        with open(self.jsonl_path) as lock_fh:
             fcntl.flock(lock_fh, fcntl.LOCK_EX)
             try:
                 # Read all notes under the lock

--- a/src/zettelforge/memory_updater.py
+++ b/src/zettelforge/memory_updater.py
@@ -6,7 +6,6 @@ ADD (new), UPDATE (refine), DELETE (contradict), or NOOP (duplicate).
 """
 
 from enum import Enum
-from typing import List, Optional, Tuple
 
 from zettelforge.json_parse import extract_json
 from zettelforge.log import get_logger
@@ -28,12 +27,12 @@ class MemoryUpdater:
         self.model = model
         self.top_s = top_s
 
-    def find_similar(self, fact_text: str, domain: Optional[str] = None) -> List[MemoryNote]:
+    def find_similar(self, fact_text: str, domain: str | None = None) -> list[MemoryNote]:
         return self.mm.retriever.retrieve(
             query=fact_text, domain=domain, k=self.top_s, include_links=False
         )
 
-    def decide(self, fact_text: str, similar_notes: List[MemoryNote]) -> UpdateOperation:
+    def decide(self, fact_text: str, similar_notes: list[MemoryNote]) -> UpdateOperation:
         if not similar_notes:
             return UpdateOperation.ADD
 
@@ -61,9 +60,9 @@ class MemoryUpdater:
         fact_text: str,
         importance: int,
         source_ref: str,
-        similar_notes: List[MemoryNote],
+        similar_notes: list[MemoryNote],
         domain: str = "cti",
-    ) -> Tuple[Optional[MemoryNote], str]:
+    ) -> tuple[MemoryNote | None, str]:
         if operation == UpdateOperation.NOOP:
             return None, "noop"
 
@@ -97,7 +96,7 @@ class MemoryUpdater:
 
         return None, "unknown"
 
-    def _build_decision_prompt(self, fact_text: str, similar_notes: List[MemoryNote]) -> str:
+    def _build_decision_prompt(self, fact_text: str, similar_notes: list[MemoryNote]) -> str:
         existing = "\n".join(f"- [{n.id}] {n.content.raw[:200]}" for n in similar_notes)
         return f"""Compare this new fact against existing memory entries.
 Decide one operation: ADD, UPDATE, DELETE, or NOOP.

--- a/src/zettelforge/note_constructor.py
+++ b/src/zettelforge/note_constructor.py
@@ -10,7 +10,6 @@ Causal Triple Extension (2026-04-06):
 
 import re
 from datetime import datetime
-from typing import Dict, List
 
 from zettelforge.alias_resolver import AliasResolver
 from zettelforge.json_parse import extract_json
@@ -26,7 +25,7 @@ from zettelforge.vector_memory import get_embedding
 class NoteConstructor:
     """Construct enriched memory notes from raw content"""
 
-    def extract_entities(self, text: str) -> Dict[str, List[str]]:
+    def extract_entities(self, text: str) -> dict[str, list[str]]:
         """Extract entities from text using the shared EntityExtractor."""
         from zettelforge.entity_indexer import EntityExtractor
 
@@ -79,7 +78,7 @@ class NoteConstructor:
             return context
         return text[:100]
 
-    def _extract_keywords(self, text: str) -> List[str]:
+    def _extract_keywords(self, text: str) -> list[str]:
         """Extract keywords from text."""
         # Simple keyword extraction
         words = re.findall(r"\b[a-zA-Z]{4,}\b", text.lower())
@@ -103,7 +102,7 @@ class NoteConstructor:
         "related_to",
     ]
 
-    def extract_causal_triples(self, text: str, note_id: str = "") -> List[Dict[str, str]]:
+    def extract_causal_triples(self, text: str, note_id: str = "") -> list[dict[str, str]]:
         """
         Use LLM to extract causal triples from text.  [Enterprise]
         Returns list of {subject, relation, object, note_id}
@@ -163,7 +162,7 @@ JSON:"""
             _logger.warning("causal_extraction_failed", error=str(e))
             return []
 
-    def store_causal_edges(self, triples: List[Dict], note_id: str = "", backend=None) -> int:
+    def store_causal_edges(self, triples: list[dict], note_id: str = "", backend=None) -> int:
         """
         Store causal triples as edges in KnowledgeGraph.
         Returns number of edges added.

--- a/src/zettelforge/note_schema.py
+++ b/src/zettelforge/note_schema.py
@@ -4,7 +4,6 @@ Roland Fleet Agentic Memory Architecture V1.0
 """
 
 from datetime import datetime
-from typing import Dict, List, Optional
 
 from pydantic import BaseModel, Field
 
@@ -15,23 +14,23 @@ class Content(BaseModel):
     raw: str
     source_type: str  # conversation | task_output | ingestion | observation
     source_ref: str  # subagent:task_id or conversation:session_id
-    previous_raw: Optional[str] = None  # Original content before evolution (for rollback)
+    previous_raw: str | None = None  # Original content before evolution (for rollback)
 
 
 class Semantic(BaseModel):
     """LLM-generated semantic enrichment"""
 
     context: str  # One-sentence contextual summary
-    keywords: List[str] = Field(default_factory=list, max_length=7)
-    tags: List[str] = Field(default_factory=list, max_length=5)
-    entities: List[str] = Field(default_factory=list)
+    keywords: list[str] = Field(default_factory=list, max_length=7)
+    tags: list[str] = Field(default_factory=list, max_length=5)
+    entities: list[str] = Field(default_factory=list)
 
 
 class Embedding(BaseModel):
     """Embedding vector and metadata"""
 
     model: str = "nomic-ai/nomic-embed-text-v1.5-Q"
-    vector: List[float] = Field(default_factory=list)
+    vector: list[float] = Field(default_factory=list)
     dimensions: int = 768
     input_hash: str = ""  # SHA256 of concatenated text fields
 
@@ -39,10 +38,10 @@ class Embedding(BaseModel):
 class Links(BaseModel):
     """Conceptual links to other notes"""
 
-    related: List[str] = Field(default_factory=list)
-    superseded_by: Optional[str] = None
-    supersedes: List[str] = Field(default_factory=list)  # Notes this note supersedes
-    causal_chain: List[str] = Field(default_factory=list)
+    related: list[str] = Field(default_factory=list)
+    superseded_by: str | None = None
+    supersedes: list[str] = Field(default_factory=list)  # Notes this note supersedes
+    causal_chain: list[str] = Field(default_factory=list)
 
 
 class VulnerabilityMeta(BaseModel):
@@ -53,10 +52,10 @@ class VulnerabilityMeta(BaseModel):
     probability, and CISA KEV membership.
     """
 
-    cvss_v3_score: Optional[float] = None  # 0.0–10.0; None if not yet scored
-    cvss_v3_vector: Optional[str] = None  # e.g. "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
-    epss_score: Optional[float] = None  # 0.0–1.0, daily exploitation probability
-    epss_percentile: Optional[float] = None  # 0.0–1.0, relative to all scored CVEs
+    cvss_v3_score: float | None = None  # 0.0–10.0; None if not yet scored
+    cvss_v3_vector: str | None = None  # e.g. "CVSS:3.1/AV:N/AC:L/PR:N/UI:N/S:U/C:H/I:H/A:H"
+    epss_score: float | None = None  # 0.0–1.0, daily exploitation probability
+    epss_percentile: float | None = None  # 0.0–1.0, relative to all scored CVEs
     cisa_kev: bool = False  # True if in CISA Known Exploited Vulnerabilities catalog
 
 
@@ -64,18 +63,18 @@ class Metadata(BaseModel):
     """Note lifecycle and access metadata"""
 
     access_count: int = 0
-    last_accessed: Optional[str] = None
+    last_accessed: str | None = None
     evolution_count: int = 0
     confidence: float = 1.0  # Decays for inferred/evolved content
-    ttl: Optional[int] = None  # Time-to-live in days
+    ttl: int | None = None  # Time-to-live in days
     domain: str = "general"  # security_ops | project | personal | research
     persistence_semantics: str = "memory"  # knowledge, memory, wisdom, intelligence
-    ttl_anchor: Optional[str] = None  # ISO timestamp for TTL calculation (set on backfill)
+    ttl_anchor: str | None = None  # ISO timestamp for TTL calculation (set on backfill)
     tier: str = "B"  # Epistemic tier: A (authoritative) | B (operational) | C (support)
     importance: int = 5  # 1-10 scale, used by extraction phase for prioritization
     tlp: str = ""  # TLP marking: WHITE, GREEN, AMBER, RED, or empty (unclassified)
     stix_confidence: int = -1  # STIX confidence 0-100, -1 = unset
-    vuln: Optional[VulnerabilityMeta] = None  # Populated for CVE notes during OpenCTI sync
+    vuln: VulnerabilityMeta | None = None  # Populated for CVE notes during OpenCTI sync
 
 
 class MemoryNote(BaseModel):
@@ -85,8 +84,8 @@ class MemoryNote(BaseModel):
     version: int = 1
     created_at: str  # ISO 8601 timestamp
     updated_at: str  # ISO 8601 timestamp
-    evolved_from: Optional[str] = None
-    evolved_by: List[str] = Field(default_factory=list)
+    evolved_from: str | None = None
+    evolved_by: list[str] = Field(default_factory=list)
 
     content: Content
     semantic: Semantic
@@ -99,7 +98,7 @@ class MemoryNote(BaseModel):
         self.metadata.access_count += 1
         self.metadata.last_accessed = datetime.now().isoformat()
 
-    def increment_evolution(self, evolved_by_note_id: Optional[str] = None):
+    def increment_evolution(self, evolved_by_note_id: str | None = None):
         """Record evolution event"""
         self.metadata.evolution_count += 1
         if evolved_by_note_id:
@@ -112,20 +111,20 @@ class MemoryNote(BaseModel):
         """Check if note should be flagged for human review"""
         return self.metadata.confidence < 0.5 or self.metadata.evolution_count > 5
 
-    def is_expired(self, ttl_days: Optional[Dict[str, int]] = None) -> bool:
+    def is_expired(self, ttl_days: dict[str, int] | None = None) -> bool:
         """Check if this note has expired based on its persistence semantics.
 
         Args:
             ttl_days: Override TTL per type. Defaults:
                 knowledge=None (never), memory=30, wisdom=90, intelligence=7
         """
-        defaults: Dict[str, Optional[int]] = {
+        defaults: dict[str, int | None] = {
             "knowledge": None,
             "memory": 30,
             "wisdom": 90,
             "intelligence": 7,
         }
-        ttls: Dict[str, Optional[int]] = {**defaults, **(ttl_days or {})}
+        ttls: dict[str, int | None] = {**defaults, **(ttl_days or {})}
 
         ttl = ttls.get(self.metadata.persistence_semantics)
         if ttl is None:

--- a/src/zettelforge/observability.py
+++ b/src/zettelforge/observability.py
@@ -9,8 +9,8 @@
 """
 
 import time
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, Dict
 
 from zettelforge.log import get_logger
 
@@ -57,7 +57,7 @@ class Observability:
         else:
             self.metrics["cache_misses"] += 1
 
-    def get_metrics(self) -> Dict:
+    def get_metrics(self) -> dict:
         total_ops = self.metrics["operations"]
         avg_latency = self.metrics["total_latency_ms"] / total_ops if total_ops > 0 else 0
         return {

--- a/src/zettelforge/ocsf.py
+++ b/src/zettelforge/ocsf.py
@@ -18,7 +18,7 @@ Event classes:
 from datetime import datetime, timezone
 from importlib.metadata import PackageNotFoundError, version
 from pathlib import Path
-from typing import Any, Optional
+from typing import Any
 
 from zettelforge.log import get_logger
 
@@ -126,9 +126,9 @@ def log_api_activity(
     operation: str,
     status_id: int = STATUS_SUCCESS,
     severity_id: int = SEVERITY_INFO,
-    actor: Optional[str] = None,
-    resource: Optional[str] = None,
-    duration_ms: Optional[float] = None,
+    actor: str | None = None,
+    resource: str | None = None,
+    duration_ms: float | None = None,
     **details: Any,
 ) -> None:
     """Emit an OCSF API Activity event (class 6002).
@@ -163,7 +163,7 @@ def log_authentication(
     auth_protocol: str,
     status_id: int = STATUS_SUCCESS,
     severity_id: int = SEVERITY_INFO,
-    src_endpoint: Optional[str] = None,
+    src_endpoint: str | None = None,
     **details: Any,
 ) -> None:
     """Emit an OCSF Authentication event (class 3001).
@@ -196,8 +196,8 @@ def log_authorization(
     resource: str,
     status_id: int = STATUS_SUCCESS,
     severity_id: int = SEVERITY_INFO,
-    privileges: Optional[str] = None,
-    policy: Optional[str] = None,
+    privileges: str | None = None,
+    policy: str | None = None,
     **details: Any,
 ) -> None:
     """Emit an OCSF Authorization event (class 3003).
@@ -231,9 +231,9 @@ def log_config_change(
     resource: str,
     status_id: int = STATUS_SUCCESS,
     severity_id: int = SEVERITY_INFO,
-    actor: Optional[str] = None,
-    prev_value: Optional[str] = None,
-    new_value: Optional[str] = None,
+    actor: str | None = None,
+    prev_value: str | None = None,
+    new_value: str | None = None,
     **details: Any,
 ) -> None:
     """Emit an OCSF Configuration Change event (class 5002).
@@ -269,8 +269,8 @@ def log_file_activity(
     activity: str,
     status_id: int = STATUS_SUCCESS,
     severity_id: int = SEVERITY_INFO,
-    actor: Optional[str] = None,
-    duration_ms: Optional[float] = None,
+    actor: str | None = None,
+    duration_ms: float | None = None,
     **details: Any,
 ) -> None:
     """Emit an OCSF File Activity event (class 1001).
@@ -336,8 +336,8 @@ def log_account_change(
     activity: str,
     status_id: int = STATUS_SUCCESS,
     severity_id: int = SEVERITY_INFO,
-    prev_value: Optional[str] = None,
-    new_value: Optional[str] = None,
+    prev_value: str | None = None,
+    new_value: str | None = None,
     **details: Any,
 ) -> None:
     """Emit an OCSF Account Change event (class 3005).

--- a/src/zettelforge/ontology.py
+++ b/src/zettelforge/ontology.py
@@ -10,7 +10,7 @@ import json
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 import yaml
 
@@ -362,7 +362,7 @@ class OntologyValidator:
     Validates entity and relation operations against type constraints.
     """
 
-    def __init__(self, schema_path: Optional[str] = None):
+    def __init__(self, schema_path: str | None = None):
         self.schema_path = schema_path
         self.custom_types = {}
         self.custom_relations = {}
@@ -377,11 +377,11 @@ class OntologyValidator:
             self.custom_types = schema.get("types", {})
             self.custom_relations = schema.get("relations", {})
 
-    def get_type_definition(self, type_name: str) -> Dict:
+    def get_type_definition(self, type_name: str) -> dict:
         """Get type definition, falling back to defaults."""
         return self.custom_types.get(type_name, ENTITY_TYPES.get(type_name, {}))
 
-    def validate_entity(self, entity_type: str, properties: Dict) -> tuple[bool, List[str]]:
+    def validate_entity(self, entity_type: str, properties: dict) -> tuple[bool, list[str]]:
         """
         Validate entity against type constraints.
         Returns (is_valid, error_messages)
@@ -427,7 +427,7 @@ class OntologyValidator:
 
     def validate_relation(
         self, from_type: str, relation_type: str, to_type: str
-    ) -> tuple[bool, List[str]]:
+    ) -> tuple[bool, list[str]]:
         """
         Validate relation is allowed between types.
         Returns (is_valid, error_messages)
@@ -456,15 +456,15 @@ class TypedEntityStore:
     Integrates with ZettelForge KnowledgeGraph.
     """
 
-    def __init__(self, data_dir: str, validator: Optional[OntologyValidator] = None):
+    def __init__(self, data_dir: str, validator: OntologyValidator | None = None):
         self.data_dir = Path(data_dir)
         self.entities_file = self.data_dir / "ontology_entities.jsonl"
         self.relations_file = self.data_dir / "ontology_relations.jsonl"
         self.validator = validator or OntologyValidator()
 
         # In-memory cache
-        self._entities: Dict[str, Dict] = {}
-        self._relations: List[Dict] = []
+        self._entities: dict[str, dict] = {}
+        self._relations: list[dict] = []
 
         self._load()
 
@@ -484,21 +484,21 @@ class TypedEntityStore:
                         rel = json.loads(line)
                         self._relations.append(rel)
 
-    def _save_entity(self, entity: Dict):
+    def _save_entity(self, entity: dict):
         """Append entity to JSONL."""
         self.data_dir.mkdir(parents=True, exist_ok=True)
         with open(self.entities_file, "a") as f:
             f.write(json.dumps(entity) + "\n")
 
-    def _save_relation(self, relation: Dict):
+    def _save_relation(self, relation: dict):
         """Append relation to JSONL."""
         self.data_dir.mkdir(parents=True, exist_ok=True)
         with open(self.relations_file, "a") as f:
             f.write(json.dumps(relation) + "\n")
 
     def create_entity(
-        self, entity_type: str, properties: Dict, entity_id: Optional[str] = None
-    ) -> tuple[Optional[str], bool, List[str]]:
+        self, entity_type: str, properties: dict, entity_id: str | None = None
+    ) -> tuple[str | None, bool, list[str]]:
         """
         Create typed entity with validation.
         Returns (entity_id, success, errors)
@@ -527,8 +527,8 @@ class TypedEntityStore:
         return entity_id, True, []
 
     def create_relation(
-        self, from_id: str, relation_type: str, to_id: str, properties: Optional[Dict] = None
-    ) -> tuple[bool, List[str]]:
+        self, from_id: str, relation_type: str, to_id: str, properties: dict | None = None
+    ) -> tuple[bool, list[str]]:
         """
         Create relation with validation.
         Returns (success, errors)
@@ -589,15 +589,15 @@ class TypedEntityStore:
 
         return False
 
-    def get_entity(self, entity_id: str) -> Optional[Dict]:
+    def get_entity(self, entity_id: str) -> dict | None:
         """Get entity by ID."""
         return self._entities.get(entity_id)
 
-    def query_by_type(self, entity_type: str) -> List[Dict]:
+    def query_by_type(self, entity_type: str) -> list[dict]:
         """Query all entities of a type."""
         return [e for e in self._entities.values() if e["type"] == entity_type]
 
-    def query_by_property(self, entity_type: str, property_name: str, value: Any) -> List[Dict]:
+    def query_by_property(self, entity_type: str, property_name: str, value: Any) -> list[dict]:
         """Query entities by property value."""
         results = []
         for entity in self._entities.values():
@@ -606,7 +606,7 @@ class TypedEntityStore:
                     results.append(entity)
         return results
 
-    def get_related(self, entity_id: str, relation_type: Optional[str] = None) -> List[Dict]:
+    def get_related(self, entity_id: str, relation_type: str | None = None) -> list[dict]:
         """Get related entities."""
         results = []
         for rel in self._relations:
@@ -623,17 +623,17 @@ class TypedEntityStore:
                         )
         return results
 
-    def list_types(self) -> List[str]:
+    def list_types(self) -> list[str]:
         """List all entity types in store."""
         return list(set(e["type"] for e in self._entities.values()))
 
 
 # Global singleton
-_ontology_store: Optional[TypedEntityStore] = None
+_ontology_store: TypedEntityStore | None = None
 _ontology_lock = None  # Will be imported
 
 
-def get_ontology_store(data_dir: Optional[str] = None) -> TypedEntityStore:
+def get_ontology_store(data_dir: str | None = None) -> TypedEntityStore:
     """Get global ontology store instance."""
     import threading
 

--- a/src/zettelforge/retry.py
+++ b/src/zettelforge/retry.py
@@ -5,8 +5,9 @@ Implements resilient patterns per GOV-011 (Security & Reliability)
 
 import random
 import time
+from collections.abc import Callable
 from functools import wraps
-from typing import Callable, TypeVar
+from typing import TypeVar
 
 from zettelforge.log import get_logger
 from zettelforge.observability import Observability

--- a/src/zettelforge/scripts/compact_lance.py
+++ b/src/zettelforge/scripts/compact_lance.py
@@ -55,7 +55,7 @@ import sys
 import time
 from dataclasses import asdict, dataclass, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass
@@ -65,13 +65,13 @@ class TableReport:
     table: str
     mode: str  # "compact" | "optimize" | "dry-run"
     before_fragments: int = 0
-    after_fragments: Optional[int] = None
+    after_fragments: int | None = None
     before_bytes: int = 0
-    after_bytes: Optional[int] = None
-    row_count: Optional[int] = None
-    elapsed_seconds: Optional[float] = None
-    error: Optional[str] = None
-    lance_metrics: Dict[str, Any] = field(default_factory=dict)
+    after_bytes: int | None = None
+    row_count: int | None = None
+    elapsed_seconds: float | None = None
+    error: str | None = None
+    lance_metrics: dict[str, Any] = field(default_factory=dict)
 
 
 def _dir_size_bytes(path: Path) -> int:
@@ -92,7 +92,7 @@ def _count_fragments(lance_dir: Path) -> int:
     return sum(1 for _ in data_dir.glob("*.lance"))
 
 
-def _discover_tables(vectordb_dir: Path) -> List[str]:
+def _discover_tables(vectordb_dir: Path) -> list[str]:
     """Return the list of ``<name>`` for every ``<name>.lance/`` directory."""
     if not vectordb_dir.is_dir():
         return []
@@ -143,7 +143,7 @@ def _process_one(
     return report
 
 
-def _serialize_lance_metrics(metrics: Any) -> Dict[str, Any]:
+def _serialize_lance_metrics(metrics: Any) -> dict[str, Any]:
     """Best-effort serialize a Lance metrics object.
 
     Lance returns dataclass-shaped objects whose layout shifts between
@@ -159,7 +159,7 @@ def _serialize_lance_metrics(metrics: Any) -> Dict[str, Any]:
             return dataclasses.asdict(metrics)
         except Exception:
             pass  # fall through to attribute enumeration
-    out: Dict[str, Any] = {}
+    out: dict[str, Any] = {}
     for k in dir(metrics):
         if k.startswith("_"):
             continue
@@ -173,7 +173,7 @@ def _serialize_lance_metrics(metrics: Any) -> Dict[str, Any]:
     return out
 
 
-def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     p = argparse.ArgumentParser(
         description="Compact ZettelForge LanceDB shards to flatten insert-latency tails.",
         formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -217,7 +217,7 @@ def _parse_args(argv: Optional[List[str]] = None) -> argparse.Namespace:
     return p.parse_args(argv)
 
 
-def main(argv: Optional[List[str]] = None) -> int:
+def main(argv: list[str] | None = None) -> int:
     args = _parse_args(argv)
 
     try:
@@ -268,12 +268,12 @@ def main(argv: Optional[List[str]] = None) -> int:
 
     db = lancedb.connect(str(vectordb_dir))
 
-    reports: List[TableReport] = []
+    reports: list[TableReport] = []
     for name in tables:
         print(f"[{mode}] {name} ...", file=sys.stderr)
         reports.append(_process_one(db, vectordb_dir, name, mode))
 
-    payload: Dict[str, Any] = {
+    payload: dict[str, Any] = {
         "data_dir": str(data_dir),
         "mode": mode,
         "tables": [asdict(r) for r in reports],

--- a/src/zettelforge/scripts/human_eval_sampler.py
+++ b/src/zettelforge/scripts/human_eval_sampler.py
@@ -18,12 +18,12 @@ import random
 import sys
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
-def _read_telemetry(data_dir: str) -> List[Dict[str, Any]]:
+def _read_telemetry(data_dir: str) -> list[dict[str, Any]]:
     """Read all synthesis events from all daily telemetry JSONL files."""
-    events: List[Dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
     base = Path(data_dir)
     for path in sorted(base.glob("telemetry_*.jsonl")):
         if not path.exists():
@@ -37,7 +37,7 @@ def _read_telemetry(data_dir: str) -> List[Dict[str, Any]]:
     return events
 
 
-def _format_briefing(event: Dict[str, Any], index: int) -> str:
+def _format_briefing(event: dict[str, Any], index: int) -> str:
     """Format a single synthesis event as a reviewable briefing."""
     query = event.get("query", "(no query text)")
     confidence = event.get("confidence")
@@ -80,7 +80,7 @@ def _build_rubric_template() -> str:
 
 def main(
     dates_dir: str = str(Path.home() / ".amem" / "telemetry"),
-    date_str: Optional[str] = None,
+    date_str: str | None = None,
     count: int = 20,
     write_events: bool = False,
 ) -> str:

--- a/src/zettelforge/scripts/telemetry_aggregator.py
+++ b/src/zettelforge/scripts/telemetry_aggregator.py
@@ -19,7 +19,7 @@ from collections import Counter
 from dataclasses import asdict, dataclass, field
 from datetime import datetime, timedelta
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 
 @dataclass
@@ -27,20 +27,20 @@ class DailyMetrics:
     """Aggregated telemetry report for a single day."""
 
     date: str
-    total_queries: Optional[int] = None
-    total_synthesis: Optional[int] = None
-    avg_recall_latency_ms: Optional[float] = None
-    avg_synthesis_latency_ms: Optional[float] = None
-    avg_confidence: Optional[float] = None
-    notes_per_query: Optional[float] = None
-    tier_distribution: Dict[str, int] = field(default_factory=dict)
-    feedback_count: Optional[int] = None
-    avg_utility: Optional[float] = None
-    top_utility_notes: List[str] = field(default_factory=list)
-    unused_notes_count: Optional[int] = None
+    total_queries: int | None = None
+    total_synthesis: int | None = None
+    avg_recall_latency_ms: float | None = None
+    avg_synthesis_latency_ms: float | None = None
+    avg_confidence: float | None = None
+    notes_per_query: float | None = None
+    tier_distribution: dict[str, int] = field(default_factory=dict)
+    feedback_count: int | None = None
+    avg_utility: float | None = None
+    top_utility_notes: list[str] = field(default_factory=list)
+    unused_notes_count: int | None = None
 
 
-def _load_events(data_dir: str, date_str: str) -> List[Dict[str, Any]]:
+def _load_events(data_dir: str, date_str: str) -> list[dict[str, Any]]:
     """Load today's telemetry JSONL, return empty list if missing."""
     path = Path(data_dir) / f"telemetry_{date_str}.jsonl"
     if not path.exists():
@@ -52,7 +52,7 @@ def _load_events(data_dir: str, date_str: str) -> List[Dict[str, Any]]:
     return events
 
 
-def _aggregate(events: List[Dict[str, Any]], date_str: str, data_dir: str) -> Dict[str, Any]:
+def _aggregate(events: list[dict[str, Any]], date_str: str, data_dir: str) -> dict[str, Any]:
     """Aggregate all events for one day into the daily report schema."""
     if not events:
         report = DailyMetrics(date=date_str)
@@ -151,7 +151,7 @@ def _aggregate(events: List[Dict[str, Any]], date_str: str, data_dir: str) -> Di
     }
 
 
-def main(date_str: Optional[str] = None) -> None:
+def main(date_str: str | None = None) -> None:
     data_dir = Path.home() / ".amem" / "telemetry"
 
     if date_str is None:

--- a/src/zettelforge/scripts/telemetry_dashboard.py
+++ b/src/zettelforge/scripts/telemetry_dashboard.py
@@ -28,7 +28,7 @@ import os
 from collections import Counter
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List
+from typing import Any
 
 try:
     import pandas as pd
@@ -45,12 +45,12 @@ DEFAULT_DATA_DIR = "~/.amem/telemetry"
 # ── Data loading ─────────────────────────────────────────────────────────
 
 
-def load_events(data_dir: Path) -> List[Dict[str, Any]]:
+def load_events(data_dir: Path) -> list[dict[str, Any]]:
     """Load all telemetry events across every ``telemetry_*.jsonl`` file.
 
     Tolerates corrupt lines so one bad entry doesn't break the dashboard.
     """
-    events: List[Dict[str, Any]] = []
+    events: list[dict[str, Any]] = []
     if not data_dir.exists():
         return events
     for path in sorted(data_dir.glob("telemetry_*.jsonl")):
@@ -65,9 +65,9 @@ def load_events(data_dir: Path) -> List[Dict[str, Any]]:
     return events
 
 
-def to_dataframe(events: List[Dict[str, Any]]) -> "pd.DataFrame":
+def to_dataframe(events: list[dict[str, Any]]) -> pd.DataFrame:
     """Normalize events into a DataFrame with a ``date`` column for grouping."""
-    rows: List[Dict[str, Any]] = []
+    rows: list[dict[str, Any]] = []
     for ev in events:
         ts = ev.get("timestamp")
         if isinstance(ts, (int, float)):
@@ -95,7 +95,7 @@ def to_dataframe(events: List[Dict[str, Any]]) -> "pd.DataFrame":
 # ── Computations (pure functions — tested in test_telemetry_dashboard.py) ──
 
 
-def daily_volume(df: "pd.DataFrame") -> "pd.DataFrame":
+def daily_volume(df: pd.DataFrame) -> pd.DataFrame:
     """Count recall vs synthesis events per day."""
     subset = df[df["event_type"].isin(["recall", "synthesis"])]
     if subset.empty:
@@ -104,7 +104,7 @@ def daily_volume(df: "pd.DataFrame") -> "pd.DataFrame":
     return grouped
 
 
-def latency_percentiles(df: "pd.DataFrame", event_type: str) -> Dict[str, float]:
+def latency_percentiles(df: pd.DataFrame, event_type: str) -> dict[str, float]:
     """Return p50 / p95 / max latency for ``event_type`` (recall or synthesis)."""
     subset = df[(df["event_type"] == event_type) & df["duration_ms"].notna()]
     if subset.empty:
@@ -116,7 +116,7 @@ def latency_percentiles(df: "pd.DataFrame", event_type: str) -> Dict[str, float]
     }
 
 
-def tier_distribution(df: "pd.DataFrame") -> Dict[str, int]:
+def tier_distribution(df: pd.DataFrame) -> dict[str, int]:
     """Sum tier counts across all DEBUG-mode recall events."""
     totals: Counter[str] = Counter()
     for dist in df["tier_distribution"].dropna():
@@ -126,7 +126,7 @@ def tier_distribution(df: "pd.DataFrame") -> Dict[str, int]:
     return dict(totals)
 
 
-def utility_trend(df: "pd.DataFrame") -> "pd.DataFrame":
+def utility_trend(df: pd.DataFrame) -> pd.DataFrame:
     """Daily mean utility across feedback events (auto + explicit)."""
     feedback = df[(df["event_type"] == "feedback") & df["utility"].notna()]
     if feedback.empty:
@@ -134,7 +134,7 @@ def utility_trend(df: "pd.DataFrame") -> "pd.DataFrame":
     return feedback.groupby("date")["utility"].mean().reset_index(name="mean_utility")
 
 
-def unused_notes(df: "pd.DataFrame") -> List[str]:
+def unused_notes(df: pd.DataFrame) -> list[str]:
     """Notes that appear in at least one recall result but never get cited.
 
     Useful signal: a note retrieved repeatedly but never cited in

--- a/src/zettelforge/sigma/entities.py
+++ b/src/zettelforge/sigma/entities.py
@@ -24,7 +24,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 import yaml
 
@@ -39,13 +39,13 @@ class SigmaRule(DetectionRule):
     Adds Phase 1b Sigma-specific fields on top of the shared contract.
     """
 
-    logsource_product: Optional[str] = None
-    logsource_service: Optional[str] = None
-    logsource_category: Optional[str] = None
-    rule_level: Optional[str] = None  # raw Sigma ``level`` before enum mapping
-    rule_status: Optional[str] = None  # raw Sigma ``status`` before enum mapping
-    sigma_format_version: Optional[str] = None
-    detection_body: Optional[str] = None
+    logsource_product: str | None = None
+    logsource_service: str | None = None
+    logsource_category: str | None = None
+    rule_level: str | None = None  # raw Sigma ``level`` before enum mapping
+    rule_status: str | None = None  # raw Sigma ``status`` before enum mapping
+    sigma_format_version: str | None = None
+    detection_body: str | None = None
     rule_type: str = "detection"  # detection | correlation | filter
     fields: list[str] = field(default_factory=list)
     falsepositives: list[str] = field(default_factory=list)

--- a/src/zettelforge/sigma/ingest.py
+++ b/src/zettelforge/sigma/ingest.py
@@ -17,7 +17,7 @@ from __future__ import annotations
 
 import logging
 from pathlib import Path
-from typing import Any, Optional, Union
+from typing import Any
 
 import yaml
 
@@ -33,7 +33,7 @@ _log = logging.getLogger(__name__)
 
 # What the caller may pass as ``rule`` — a parsed dict, a raw YAML string, or
 # a Path to a .yml/.yaml file.
-RuleSource = Union[dict, str, Path]
+RuleSource = dict | str | Path
 
 
 def ingest_rule(
@@ -41,7 +41,7 @@ def ingest_rule(
     mm: Any,
     *,
     domain: str = "detection",
-    source_ref: Optional[str] = None,
+    source_ref: str | None = None,
 ) -> tuple[Any, list[dict[str, Any]]]:
     """Ingest a single Sigma rule.
 
@@ -156,7 +156,7 @@ def ingest_rules_dir(
 # ── Internals ────────────────────────────────────────────────────────────────
 
 
-def _coerce(rule: RuleSource) -> tuple[dict[str, Any], Optional[str]]:
+def _coerce(rule: RuleSource) -> tuple[dict[str, Any], str | None]:
     """Turn the caller's input into ``(parsed_dict, default_source_ref)``."""
     if isinstance(rule, dict):
         return rule, None

--- a/src/zettelforge/sigma/tags.py
+++ b/src/zettelforge/sigma/tags.py
@@ -16,7 +16,6 @@ Everything else returns ``None`` — the caller still persists the raw
 from __future__ import annotations
 
 import re
-from typing import Optional
 
 # attack.g\d+ / attack.s\d+  → IntrusionSet / Malware (not emitted as
 # techniques). Only technique tags (T + digits, optionally .digits) become
@@ -26,7 +25,7 @@ _ATTACK_GROUP_RE = re.compile(r"^g\d+$", re.IGNORECASE)
 _ATTACK_SOFTWARE_RE = re.compile(r"^s\d+$", re.IGNORECASE)
 
 
-def _normalize_cve(suffix: str) -> Optional[str]:
+def _normalize_cve(suffix: str) -> str | None:
     """Normalize a Sigma CVE suffix (``2021-44228`` or ``2021.44228``) to
     canonical ``CVE-YYYY-NNNN`` form. Returns ``None`` if it doesn't match."""
     # Sigma writes cve.2024.3094 (dots) per the spec, but many rules in
@@ -40,7 +39,7 @@ def _normalize_cve(suffix: str) -> Optional[str]:
     return f"CVE-{year}-{num}"
 
 
-def resolve_sigma_tag(tag: str) -> Optional[tuple[str, str]]:
+def resolve_sigma_tag(tag: str) -> tuple[str, str] | None:
     """Resolve a Sigma tag to a typed entity reference.
 
     Returns ``(entity_type, entity_value)`` for tags that upgrade to a

--- a/src/zettelforge/sqlite_backend.py
+++ b/src/zettelforge/sqlite_backend.py
@@ -14,9 +14,10 @@ import sqlite3
 import threading
 import uuid
 from collections import defaultdict, deque
+from collections.abc import Iterator
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, Iterator, List, Optional
+from typing import Any
 
 from zettelforge.note_schema import (
     Content,
@@ -328,7 +329,7 @@ class SQLiteBackend(StorageBackend):
                 pass
             conn.close()
 
-    def health_check(self) -> Dict[str, Any]:
+    def health_check(self) -> dict[str, Any]:
         if self._conn is None:
             return {
                 "status": "closed",
@@ -373,7 +374,7 @@ class SQLiteBackend(StorageBackend):
             self.db_path, "Update", actor="SQLiteBackend.rewrite_note", note_id=note.id
         )
 
-    def get_note_by_id(self, note_id: str) -> Optional[MemoryNote]:
+    def get_note_by_id(self, note_id: str) -> MemoryNote | None:
         with self._write_lock:
             self._check_open()
             cur = self._conn.execute("SELECT * FROM notes WHERE id = ?", (note_id,))
@@ -382,7 +383,7 @@ class SQLiteBackend(StorageBackend):
             return None
         return _row_to_note(row)
 
-    def get_note_by_source_ref(self, source_ref: str) -> Optional[MemoryNote]:
+    def get_note_by_source_ref(self, source_ref: str) -> MemoryNote | None:
         with self._write_lock:
             self._check_open()
             cur = self._conn.execute(
@@ -407,14 +408,14 @@ class SQLiteBackend(StorageBackend):
             for row in rows:
                 yield _row_to_note(row)
 
-    def get_notes_by_domain(self, domain: str) -> List[MemoryNote]:
+    def get_notes_by_domain(self, domain: str) -> list[MemoryNote]:
         with self._write_lock:
             self._check_open()
             cur = self._conn.execute("SELECT * FROM notes WHERE domain = ?", (domain,))
             rows = cur.fetchall()
         return [_row_to_note(r) for r in rows]
 
-    def get_recent_notes(self, limit: int = 10) -> List[MemoryNote]:
+    def get_recent_notes(self, limit: int = 10) -> list[MemoryNote]:
         with self._write_lock:
             self._check_open()
             cur = self._conn.execute(
@@ -454,7 +455,7 @@ class SQLiteBackend(StorageBackend):
 
     # ── Vector Index Sync ───────────────────────────────────────────────
 
-    def reindex_vector(self, note_id: str, vector: List[float]) -> None:
+    def reindex_vector(self, note_id: str, vector: list[float]) -> None:
         """Update embedding vector in SQLite.  LanceDB sync is external.
 
         Targeted UPDATE inside a single lock acquisition — avoids the
@@ -480,7 +481,7 @@ class SQLiteBackend(StorageBackend):
         self,
         entity_type: str,
         entity_value: str,
-        properties: Optional[Dict] = None,
+        properties: dict | None = None,
     ) -> str:
         now = datetime.now().isoformat()
         props_json = json.dumps(properties or {})
@@ -512,7 +513,7 @@ class SQLiteBackend(StorageBackend):
             self._conn.commit()
         return node_id
 
-    def get_kg_node(self, entity_type: str, entity_value: str) -> Optional[Dict]:
+    def get_kg_node(self, entity_type: str, entity_value: str) -> dict | None:
         with self._write_lock:
             self._check_open()
             cur = self._conn.execute(
@@ -540,8 +541,8 @@ class SQLiteBackend(StorageBackend):
         to_type: str,
         to_value: str,
         relationship: str,
-        note_id: Optional[str] = None,
-        properties: Optional[Dict] = None,
+        note_id: str | None = None,
+        properties: dict | None = None,
     ) -> str:
         with self._write_lock:
             self._check_open()
@@ -594,8 +595,8 @@ class SQLiteBackend(StorageBackend):
         self,
         entity_type: str,
         entity_value: str,
-        relationship: Optional[str] = None,
-    ) -> List[Dict]:
+        relationship: str | None = None,
+    ) -> list[dict]:
         with self._write_lock:
             self._check_open()
             # Resolve node_id
@@ -646,7 +647,7 @@ class SQLiteBackend(StorageBackend):
         start_type: str,
         start_value: str,
         max_depth: int = 2,
-    ) -> List[List[Dict]]:
+    ) -> list[list[dict]]:
         """BFS/DFS traversal up to max_depth.  Returns list of paths."""
         with self._write_lock:
             self._check_open()
@@ -660,9 +661,9 @@ class SQLiteBackend(StorageBackend):
 
         start_node_id = row["node_id"]
         visited: set = set()
-        results: List[List[Dict]] = []
+        results: list[list[dict]] = []
 
-        def _dfs(current_id: str, depth: int, path: List[Dict]):
+        def _dfs(current_id: str, depth: int, path: list[dict]):
             if depth > max_depth or current_id in visited:
                 return
             visited.add(current_id)
@@ -697,7 +698,7 @@ class SQLiteBackend(StorageBackend):
 
     # ── Temporal KG ─────────────────────────────────────────────────────
 
-    def get_entity_timeline(self, entity_type: str, entity_value: str) -> List[Dict]:
+    def get_entity_timeline(self, entity_type: str, entity_value: str) -> list[dict]:
         """Get temporal timeline of states for an entity via temporal edges."""
         with self._write_lock:
             self._check_open()
@@ -733,7 +734,7 @@ class SQLiteBackend(StorageBackend):
         timeline.sort(key=lambda x: x["timestamp"] or "")
         return timeline
 
-    def get_changes_since(self, timestamp: str) -> List[Dict]:
+    def get_changes_since(self, timestamp: str) -> list[dict]:
         """Get all temporal edge changes since a given ISO-8601 timestamp."""
         with self._write_lock:
             self._check_open()
@@ -762,7 +763,7 @@ class SQLiteBackend(StorageBackend):
             )
         return changes
 
-    def get_kg_node_by_id(self, node_id: str) -> Optional[Dict]:
+    def get_kg_node_by_id(self, node_id: str) -> dict | None:
         """Lookup a KG node by its internal node_id."""
         with self._write_lock:
             self._check_open()
@@ -785,7 +786,7 @@ class SQLiteBackend(StorageBackend):
         entity_value: str,
         max_depth: int = 3,
         max_visited: int = 50,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """BFS over outgoing causal edges — traces forward from cause to effects."""
         with self._write_lock:
             self._check_open()
@@ -800,7 +801,7 @@ class SQLiteBackend(StorageBackend):
         start_id = row["node_id"]
         visited: set = set()
         bfs_queue: deque = deque([(start_id, 0)])
-        causal_edges: List[Dict] = []
+        causal_edges: list[dict] = []
 
         while bfs_queue and len(visited) < max_visited:
             current_id, depth = bfs_queue.popleft()
@@ -831,7 +832,7 @@ class SQLiteBackend(StorageBackend):
         entity_value: str,
         max_depth: int = 3,
         max_visited: int = 50,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """BFS over incoming causal edges — traces back to root causes."""
         with self._write_lock:
             self._check_open()
@@ -846,7 +847,7 @@ class SQLiteBackend(StorageBackend):
         start_id = row["node_id"]
         visited: set = set()
         bfs_queue: deque = deque([(start_id, 0)])
-        causal_edges: List[Dict] = []
+        causal_edges: list[dict] = []
 
         while bfs_queue and len(visited) < max_visited:
             current_id, depth = bfs_queue.popleft()
@@ -889,7 +890,7 @@ class SQLiteBackend(StorageBackend):
             self._conn.execute("DELETE FROM entity_index WHERE note_id = ?", (note_id,))
             self._conn.commit()
 
-    def get_note_ids_for_entity(self, entity_type: str, entity_value: str) -> List[str]:
+    def get_note_ids_for_entity(self, entity_type: str, entity_value: str) -> list[str]:
         with self._write_lock:
             self._check_open()
             cur = self._conn.execute(
@@ -899,7 +900,7 @@ class SQLiteBackend(StorageBackend):
             rows = cur.fetchall()
         return [r["note_id"] for r in rows]
 
-    def search_entities(self, query: str, limit: int = 10) -> Dict[str, List[str]]:
+    def search_entities(self, query: str, limit: int = 10) -> dict[str, list[str]]:
         """Prefix search across entity types."""
         with self._write_lock:
             self._check_open()
@@ -909,7 +910,7 @@ class SQLiteBackend(StorageBackend):
                 (f"{query}%", limit),
             )
             rows = cur.fetchall()
-        result: Dict[str, List[str]] = defaultdict(list)
+        result: dict[str, list[str]] = defaultdict(list)
         for row in rows:
             result[row["entity_type"]].append(row["entity_value"])
         return dict(result)

--- a/src/zettelforge/storage_backend.py
+++ b/src/zettelforge/storage_backend.py
@@ -10,7 +10,8 @@ BLOCKER-3 prep: KG edge methods accept note_id for provenance tracking.
 """
 
 from abc import ABC, abstractmethod
-from typing import Any, Dict, Iterator, List, Optional
+from collections.abc import Iterator
+from typing import Any
 
 from zettelforge.note_schema import MemoryNote
 
@@ -40,12 +41,12 @@ class StorageBackend(ABC):
         ...
 
     @abstractmethod
-    def get_note_by_id(self, note_id: str) -> Optional[MemoryNote]:
+    def get_note_by_id(self, note_id: str) -> MemoryNote | None:
         """O(1) lookup by note ID."""
         ...
 
     @abstractmethod
-    def get_note_by_source_ref(self, source_ref: str) -> Optional[MemoryNote]:
+    def get_note_by_source_ref(self, source_ref: str) -> MemoryNote | None:
         """O(1) lookup by source_ref.  Returns None if not found."""
         ...
 
@@ -55,12 +56,12 @@ class StorageBackend(ABC):
         ...
 
     @abstractmethod
-    def get_notes_by_domain(self, domain: str) -> List[MemoryNote]:
+    def get_notes_by_domain(self, domain: str) -> list[MemoryNote]:
         """All notes in a domain.  Used by vector retriever domain filter."""
         ...
 
     @abstractmethod
-    def get_recent_notes(self, limit: int = 10) -> List[MemoryNote]:
+    def get_recent_notes(self, limit: int = 10) -> list[MemoryNote]:
         """Most recent notes by created_at."""
         ...
 
@@ -90,7 +91,7 @@ class StorageBackend(ABC):
     # ── Vector Index Sync (BLOCKER-2 fix) ────────────────────────────────
 
     @abstractmethod
-    def reindex_vector(self, note_id: str, vector: List[float]) -> None:
+    def reindex_vector(self, note_id: str, vector: list[float]) -> None:
         """Update a note's embedding vector and trigger LanceDB re-sync.
 
         Called by rebuild_index.py when re-embedding notes with a new model.
@@ -105,7 +106,7 @@ class StorageBackend(ABC):
         self,
         entity_type: str,
         entity_value: str,
-        properties: Optional[Dict] = None,
+        properties: dict | None = None,
     ) -> str:
         """Add or update a KG node.  Returns node_id."""
         ...
@@ -118,8 +119,8 @@ class StorageBackend(ABC):
         to_type: str,
         to_value: str,
         relationship: str,
-        note_id: Optional[str] = None,
-        properties: Optional[Dict] = None,
+        note_id: str | None = None,
+        properties: dict | None = None,
     ) -> str:
         """Add a KG edge.  note_id tracks provenance (BLOCKER-3 fix).
 
@@ -130,7 +131,7 @@ class StorageBackend(ABC):
         ...
 
     @abstractmethod
-    def get_kg_node(self, entity_type: str, entity_value: str) -> Optional[Dict]:
+    def get_kg_node(self, entity_type: str, entity_value: str) -> dict | None:
         """Lookup a KG node by type + value."""
         ...
 
@@ -139,8 +140,8 @@ class StorageBackend(ABC):
         self,
         entity_type: str,
         entity_value: str,
-        relationship: Optional[str] = None,
-    ) -> List[Dict]:
+        relationship: str | None = None,
+    ) -> list[dict]:
         """Get adjacent nodes via outgoing edges."""
         ...
 
@@ -150,22 +151,22 @@ class StorageBackend(ABC):
         start_type: str,
         start_value: str,
         max_depth: int = 2,
-    ) -> List[List[Dict]]:
+    ) -> list[list[dict]]:
         """BFS/DFS traversal up to max_depth.  Returns list of paths."""
         ...
 
     @abstractmethod
-    def get_entity_timeline(self, entity_type: str, entity_value: str) -> List[Dict]:
+    def get_entity_timeline(self, entity_type: str, entity_value: str) -> list[dict]:
         """Get temporal timeline of states for an entity."""
         ...
 
     @abstractmethod
-    def get_changes_since(self, timestamp: str) -> List[Dict]:
+    def get_changes_since(self, timestamp: str) -> list[dict]:
         """Get all entity changes since a given ISO-8601 timestamp."""
         ...
 
     @abstractmethod
-    def get_kg_node_by_id(self, node_id: str) -> Optional[Dict]:
+    def get_kg_node_by_id(self, node_id: str) -> dict | None:
         """Lookup a KG node by its internal node_id.
 
         Needed by provenance_chain() which accesses nodes by ID directly.
@@ -180,7 +181,7 @@ class StorageBackend(ABC):
         to_value: str,
         relationship: str,
         timestamp: str,
-        properties: Optional[Dict] = None,
+        properties: dict | None = None,
     ) -> str:
         """Add a temporal edge with timestamp baked into properties.
 
@@ -200,7 +201,7 @@ class StorageBackend(ABC):
         entity_value: str,
         max_depth: int = 3,
         max_visited: int = 50,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """BFS over outgoing causal edges — traces forward from cause to effects."""
         ...
 
@@ -211,7 +212,7 @@ class StorageBackend(ABC):
         entity_value: str,
         max_depth: int = 3,
         max_visited: int = 50,
-    ) -> List[Dict]:
+    ) -> list[dict]:
         """BFS over incoming causal edges — traces back to root causes."""
         ...
 
@@ -228,12 +229,12 @@ class StorageBackend(ABC):
         ...
 
     @abstractmethod
-    def get_note_ids_for_entity(self, entity_type: str, entity_value: str) -> List[str]:
+    def get_note_ids_for_entity(self, entity_type: str, entity_value: str) -> list[str]:
         """Get note IDs associated with an entity."""
         ...
 
     @abstractmethod
-    def search_entities(self, query: str, limit: int = 10) -> Dict[str, List[str]]:
+    def search_entities(self, query: str, limit: int = 10) -> dict[str, list[str]]:
         """Prefix search across entity types.  Returns type -> matching values."""
         ...
 
@@ -249,7 +250,7 @@ class StorageBackend(ABC):
         """Flush pending writes and release resources."""
         ...
 
-    def health_check(self) -> Dict[str, Any]:
+    def health_check(self) -> dict[str, Any]:
         """Return backend health status.  Override for richer diagnostics."""
         return {"status": "ok", "backend": self.__class__.__name__}
 

--- a/src/zettelforge/synthesis_generator.py
+++ b/src/zettelforge/synthesis_generator.py
@@ -9,7 +9,6 @@ Supports multiple response formats: direct_answer, synthesized_brief, timeline_a
 import hashlib
 import threading
 import time
-from typing import Dict, List, Optional
 
 from zettelforge.json_parse import extract_json
 from zettelforge.log import get_logger
@@ -45,8 +44,8 @@ class SynthesisGenerator:
         memory_manager=None,
         format: str = "direct_answer",
         k: int = 10,
-        tier_filter: List[str] = None,
-    ) -> Dict:
+        tier_filter: list[str] = None,
+    ) -> dict:
         """
         Synthesize an answer from retrieved notes.
 
@@ -92,7 +91,7 @@ class SynthesisGenerator:
             "sources": [self._note_to_source(n) for n in notes[:10]],
         }
 
-    def _retrieve_notes(self, query: str, memory_manager, k: int, tier_filter: List[str]):
+    def _retrieve_notes(self, query: str, memory_manager, k: int, tier_filter: list[str]):
         """Retrieve notes via hybrid search (entity + vector)."""
         if memory_manager is None:
             return []
@@ -125,7 +124,7 @@ class SynthesisGenerator:
 
         return unique_notes[:k]
 
-    def _build_context(self, notes: List) -> str:
+    def _build_context(self, notes: list) -> str:
         """Build context string for LLM."""
         context_parts = []
         for note in notes[:10]:
@@ -135,7 +134,7 @@ class SynthesisGenerator:
                 context_parts.append(f"Summary: {note.semantic.context}")
         return "\n".join(context_parts)
 
-    def _generate_synthesis(self, query: str, context: str, format: str) -> Dict:
+    def _generate_synthesis(self, query: str, context: str, format: str) -> dict:
         """Generate synthesis using LLM."""
         system_prompt = self._get_system_prompt(format)
         user_prompt = self._build_prompt(query, context, format)
@@ -162,7 +161,7 @@ class SynthesisGenerator:
         }
         return prompts.get(format, prompts["direct_answer"])
 
-    def _get_json_format(self, format: str) -> Dict:
+    def _get_json_format(self, format: str) -> dict:
         formats = {
             "direct_answer": {
                 "type": "object",
@@ -243,7 +242,7 @@ CONTEXT:
 
 Format as valid JSON matching the specified schema."""
 
-    def _fallback_synthesis(self, query: str, format: str) -> Dict:
+    def _fallback_synthesis(self, query: str, format: str) -> dict:
         if format == "direct_answer":
             return {
                 "answer": f"No specific answer found for: {query[:50]}...",
@@ -259,7 +258,7 @@ Format as valid JSON matching the specified schema."""
         else:
             return {"error": "No data available"}
 
-    def _note_to_source(self, note) -> Dict:
+    def _note_to_source(self, note) -> dict:
         return {
             "note_id": note.id,
             "relevance_score": min(1.0, note.metadata.confidence),
@@ -271,7 +270,7 @@ Format as valid JSON matching the specified schema."""
         return len(text) // 4
 
 
-_synthesis_gen: Optional[SynthesisGenerator] = None
+_synthesis_gen: SynthesisGenerator | None = None
 _synthesis_lock = threading.Lock()
 
 

--- a/src/zettelforge/synthesis_validator.py
+++ b/src/zettelforge/synthesis_validator.py
@@ -4,7 +4,6 @@ A-MEM Agentic Memory Architecture V1.0
 """
 
 import threading
-from typing import Dict, List, Optional, Tuple
 
 
 class SynthesisValidator:
@@ -24,7 +23,7 @@ class SynthesisValidator:
         self.max_summary_length = max_summary_length
         self.max_answer_length = max_answer_length
 
-    def validate_response(self, response: Dict) -> Tuple[bool, List[str]]:
+    def validate_response(self, response: dict) -> tuple[bool, list[str]]:
         """Validate a complete synthesis response."""
         errors = []
         synthesis = response.get("synthesis", {})
@@ -46,7 +45,7 @@ class SynthesisValidator:
 
         return len(errors) == 0, errors
 
-    def check_quality_score(self, response: Dict) -> Dict:
+    def check_quality_score(self, response: dict) -> dict:
         """Compute a quality score for a response."""
         synthesis = response.get("synthesis", {})
         sources = response.get("sources", [])
@@ -72,7 +71,7 @@ class SynthesisValidator:
         }
 
 
-_validator: Optional[SynthesisValidator] = None
+_validator: SynthesisValidator | None = None
 _validator_lock = threading.Lock()
 
 

--- a/src/zettelforge/telemetry.py
+++ b/src/zettelforge/telemetry.py
@@ -25,7 +25,7 @@ import uuid
 from dataclasses import dataclass, field
 from datetime import datetime
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Any
 
 _QUERY_TTL_SECONDS = 3600  # evict tracked queries older than this on start_query
 
@@ -35,9 +35,9 @@ class _QueryContext:
     """In-memory bookkeeping for an active query. Not persisted."""
 
     query: str
-    actor: Optional[str]
+    actor: str | None
     start_ts: float
-    results: List[Any] = field(default_factory=list)
+    results: list[Any] = field(default_factory=list)
 
 
 class TelemetryCollector:
@@ -61,12 +61,12 @@ class TelemetryCollector:
         self._data_dir = Path(os.path.expanduser(data_dir))
         self._logger_name = logger_name
         self._write_lock = threading.Lock()
-        self._queries: Dict[str, _QueryContext] = {}
+        self._queries: dict[str, _QueryContext] = {}
         self._queries_lock = threading.Lock()
 
     # ── Query lifecycle ────────────────────────────────────────────────
 
-    def start_query(self, query: str, actor: Optional[str] = None) -> str:
+    def start_query(self, query: str, actor: str | None = None) -> str:
         """Begin tracking a query. Returns ``query_id`` (UUID4 hex) for correlation.
 
         Evicts tracked queries older than 1 hour on each call so memory use
@@ -84,7 +84,7 @@ class TelemetryCollector:
                 del self._queries[qid]
         return query_id
 
-    def _get_context(self, query_id: str) -> Optional[_QueryContext]:
+    def _get_context(self, query_id: str) -> _QueryContext | None:
         with self._queries_lock:
             return self._queries.get(query_id)
 
@@ -93,7 +93,7 @@ class TelemetryCollector:
     def log_recall(
         self,
         query_id: str,
-        results: List[Any],
+        results: list[Any],
         intent: str,
         vector_latency_ms: int = 0,
         graph_latency_ms: int = 0,
@@ -111,7 +111,7 @@ class TelemetryCollector:
         query_text = self._truncate_query(ctx.query if ctx else "", debug)
         actor = ctx.actor if ctx else None
 
-        event: Dict[str, Any] = {
+        event: dict[str, Any] = {
             "event_type": "recall",
             "timestamp": time.time(),
             "query_id": query_id,
@@ -139,7 +139,7 @@ class TelemetryCollector:
     def log_synthesis(
         self,
         query_id: str,
-        result: Dict[str, Any],
+        result: dict[str, Any],
         synthesis_latency_ms: int = 0,
     ) -> None:
         """Write a synthesis event to today's telemetry JSONL.
@@ -158,7 +158,7 @@ class TelemetryCollector:
         cited_notes = _cited_note_ids(result)
         sources_count = _sources_count(result)
 
-        event: Dict[str, Any] = {
+        event: dict[str, Any] = {
             "event_type": "synthesis",
             "timestamp": time.time(),
             "query_id": query_id,
@@ -183,7 +183,7 @@ class TelemetryCollector:
         query_id: str,
         note_id: str,
         utility: int,
-        agent: Optional[str] = None,
+        agent: str | None = None,
     ) -> None:
         """Write an explicit feedback event. Utility is 1–5."""
         event = {
@@ -199,8 +199,8 @@ class TelemetryCollector:
     def auto_feedback_from_synthesis(
         self,
         query_id: str,
-        retrieved_notes: List[Any],
-        synthesis_result: Dict[str, Any],
+        retrieved_notes: list[Any],
+        synthesis_result: dict[str, Any],
     ) -> None:
         """Infer utility from citation patterns. DEBUG mode only.
 
@@ -225,7 +225,7 @@ class TelemetryCollector:
     def _debug_enabled(self) -> bool:
         return logging.getLogger(self._logger_name).isEnabledFor(logging.DEBUG)
 
-    def _duration_ms(self, ctx: Optional[_QueryContext]) -> int:
+    def _duration_ms(self, ctx: _QueryContext | None) -> int:
         if ctx is None:
             return 0
         return int((time.time() - ctx.start_ts) * 1000)
@@ -234,11 +234,11 @@ class TelemetryCollector:
         limit = 500 if debug else 200
         return query[:limit]
 
-    def _path_for(self, when: Optional[datetime] = None) -> Path:
+    def _path_for(self, when: datetime | None = None) -> Path:
         when = when or datetime.now()
         return self._data_dir / f"telemetry_{when.strftime('%Y-%m-%d')}.jsonl"
 
-    def _append(self, event: Dict[str, Any]) -> None:
+    def _append(self, event: dict[str, Any]) -> None:
         """Serialize and append one JSONL line. Creates data_dir on first write."""
         path = self._path_for()
         line = json.dumps(event, default=str)
@@ -251,11 +251,11 @@ class TelemetryCollector:
 # ── Helpers (duck-typed; avoid importing MemoryNote to keep this standalone) ──
 
 
-def _note_id(note: Any) -> Optional[str]:
+def _note_id(note: Any) -> str | None:
     return getattr(note, "id", None)
 
 
-def _note_summary(note: Any, rank: int) -> Dict[str, Any]:
+def _note_summary(note: Any, rank: int) -> dict[str, Any]:
     metadata = getattr(note, "metadata", None)
     content = getattr(note, "content", None)
     return {
@@ -267,8 +267,8 @@ def _note_summary(note: Any, rank: int) -> Dict[str, Any]:
     }
 
 
-def _tier_distribution(notes: List[Any]) -> Dict[str, int]:
-    dist: Dict[str, int] = {}
+def _tier_distribution(notes: list[Any]) -> dict[str, int]:
+    dist: dict[str, int] = {}
     for note in notes:
         metadata = getattr(note, "metadata", None)
         tier = getattr(metadata, "tier", None) if metadata is not None else None
@@ -286,9 +286,9 @@ def _stringify_intent(intent: Any) -> str:
     return str(intent)
 
 
-def _cited_note_ids(synthesis_result: Dict[str, Any]) -> List[str]:
+def _cited_note_ids(synthesis_result: dict[str, Any]) -> list[str]:
     sources = synthesis_result.get("sources", [])
-    ids: List[str] = []
+    ids: list[str] = []
     for source in sources:
         if isinstance(source, dict):
             nid = source.get("note_id")
@@ -299,14 +299,14 @@ def _cited_note_ids(synthesis_result: Dict[str, Any]) -> List[str]:
     return ids
 
 
-def _sources_count(synthesis_result: Dict[str, Any]) -> int:
+def _sources_count(synthesis_result: dict[str, Any]) -> int:
     metadata = synthesis_result.get("metadata")
     if isinstance(metadata, dict) and "sources_count" in metadata:
         return int(metadata["sources_count"])
     return len(synthesis_result.get("sources", []) or [])
 
 
-def _confidence(synthesis_result: Dict[str, Any]) -> Optional[float]:
+def _confidence(synthesis_result: dict[str, Any]) -> float | None:
     # Synthesis schema varies — confidence may sit under "synthesis"
     # (per schema in synthesis_generator.py) or at the top level.
     synthesis = synthesis_result.get("synthesis")
@@ -319,7 +319,7 @@ def _confidence(synthesis_result: Dict[str, Any]) -> Optional[float]:
 
 # ── Singleton ──────────────────────────────────────────────────────────
 
-_telemetry_instance: Optional[TelemetryCollector] = None
+_telemetry_instance: TelemetryCollector | None = None
 _telemetry_singleton_lock = threading.Lock()
 
 

--- a/src/zettelforge/vector_memory.py
+++ b/src/zettelforge/vector_memory.py
@@ -21,7 +21,6 @@ import threading
 import uuid
 from datetime import datetime
 from pathlib import Path
-from typing import Dict, List, Optional
 
 from zettelforge.log import get_logger
 
@@ -99,7 +98,7 @@ def preload_embedding_model() -> None:
 # ── Embedding ────────────────────────────────────────────────────────────────
 
 
-def get_embedding(text: str, model: Optional[str] = None) -> List[float]:
+def get_embedding(text: str, model: str | None = None) -> list[float]:
     """Generate embedding. Uses fastembed (in-process) by default, ollama/HTTP as fallback."""
     provider = get_embedding_provider()
 
@@ -141,7 +140,7 @@ def get_embedding(text: str, model: Optional[str] = None) -> List[float]:
     return [random.random() for _ in range(dim)]
 
 
-def get_embedding_batch(texts: List[str], model: Optional[str] = None) -> List[List[float]]:
+def get_embedding_batch(texts: list[str], model: str | None = None) -> list[list[float]]:
     """Batch embed. Native batch with fastembed, sequential with ollama."""
     provider = get_embedding_provider()
 
@@ -188,7 +187,7 @@ class VectorMemory:
     Stores entries in LanceDB with Nomic embeddings.
     """
 
-    def __init__(self, db_path: Optional[str] = None):
+    def __init__(self, db_path: str | None = None):
         from zettelforge.memory_store import get_default_data_dir
 
         if db_path is None:
@@ -197,7 +196,7 @@ class VectorMemory:
         self.db = None
         self.table = None
         self.embedding_model = get_embedding_model()
-        self._embedding_cache: Dict[str, List[float]] = {}
+        self._embedding_cache: dict[str, list[float]] = {}
 
     def init(self):
         """Connect to or create the LanceDB database."""
@@ -216,7 +215,7 @@ class VectorMemory:
         """Stable hash of text content for dedup."""
         return hashlib.sha256(text.encode("utf-8")).hexdigest()[:32]
 
-    def _chunk_text(self, text: str, max_tokens: int = 512, overlap: int = 128) -> List[str]:
+    def _chunk_text(self, text: str, max_tokens: int = 512, overlap: int = 128) -> list[str]:
         """
         Simple token-aware text chunker.
         Splits on sentence boundaries, groups up to max_tokens.
@@ -243,13 +242,13 @@ class VectorMemory:
     def add(
         self,
         text: str,
-        tags: Optional[List[str]] = None,
+        tags: list[str] | None = None,
         session_key: str = "default",
         source: str = "session",
-        metadata: Optional[Dict] = None,
+        metadata: dict | None = None,
         chunk: bool = True,
         overwrite: bool = False,
-    ) -> List[str]:
+    ) -> list[str]:
         """
         Add a memory entry. Returns list of chunk IDs added.
         """
@@ -301,9 +300,9 @@ class VectorMemory:
         self,
         query: str,
         top_k: int = 5,
-        source_filter: Optional[str] = None,
-        session_filter: Optional[str] = None,
-    ) -> List[Dict]:
+        source_filter: str | None = None,
+        session_filter: str | None = None,
+    ) -> list[dict]:
         """
         Semantic search across all memory entries.
         """
@@ -338,7 +337,7 @@ class VectorMemory:
             for r in results
         ]
 
-    def get_recent(self, session_key: Optional[str] = None, limit: int = 20) -> List[Dict]:
+    def get_recent(self, session_key: str | None = None, limit: int = 20) -> list[dict]:
         """Get most recent memory entries."""
         if self.table is None:
             self.init()
@@ -349,7 +348,7 @@ class VectorMemory:
 
         return q.to_list()
 
-    def delete(self, content_hash: Optional[str] = None, entry_id: Optional[str] = None):
+    def delete(self, content_hash: str | None = None, entry_id: str | None = None):
         """Delete by content_hash or entry ID."""
         if self.table is None:
             self.init()
@@ -365,7 +364,7 @@ class VectorMemory:
             self.init()
         return len(self.table.to_list())
 
-    def stats(self) -> Dict:
+    def stats(self) -> dict:
         """Return memory store statistics."""
         if self.table is None:
             self.init()

--- a/src/zettelforge/vector_retriever.py
+++ b/src/zettelforge/vector_retriever.py
@@ -5,8 +5,6 @@ A-MEM Agentic Memory Architecture V1.0
 Retrieves relevant notes based on embedding similarity with domain filtering.
 """
 
-from typing import List, Optional
-
 import numpy as np
 
 from zettelforge.alias_resolver import AliasResolver
@@ -19,7 +17,7 @@ from zettelforge.vector_memory import get_embedding
 _logger = get_logger("zettelforge.retriever")
 
 
-def cosine_similarity(a: List[float], b: List[float]) -> float:
+def cosine_similarity(a: list[float], b: list[float]) -> float:
     """Compute cosine similarity between two vectors."""
     a_arr = np.array(a)
     b_arr = np.array(b)
@@ -40,7 +38,7 @@ class VectorRetriever:
         entity_boost: float = 2.5,
         exact_match_boost: float = 1.0,
         regenerate_invalid_embeddings: bool = True,  # NEW: Regenerate if missing/invalid
-        memory_store: Optional[MemoryStore] = None,
+        memory_store: MemoryStore | None = None,
         note_lookup=None,  # Callable(note_id) -> MemoryNote, for cross-backend lookup
     ):
         self.similarity_threshold = similarity_threshold
@@ -52,7 +50,7 @@ class VectorRetriever:
         self.extractor = EntityExtractor()
         self.resolver = AliasResolver()
 
-    def _get_note(self, note_id: str) -> Optional[MemoryNote]:
+    def _get_note(self, note_id: str) -> MemoryNote | None:
         """Look up a note, preferring the cross-backend lookup if available."""
         if self._note_lookup:
             result = self._note_lookup(note_id)
@@ -60,7 +58,7 @@ class VectorRetriever:
                 return result
         return self.store.get_note_by_id(note_id)
 
-    def _is_valid_embedding(self, vector: Optional[List[float]]) -> bool:
+    def _is_valid_embedding(self, vector: list[float] | None) -> bool:
         """Check if embedding vector is valid (non-None, correct dims, non-zero)."""
         if vector is None:
             return False
@@ -75,7 +73,7 @@ class VectorRetriever:
             return False
         return True
 
-    def _ensure_note_embedding(self, note: MemoryNote) -> Optional[List[float]]:
+    def _ensure_note_embedding(self, note: MemoryNote) -> list[float] | None:
         """Ensure note has valid embedding, regenerating if necessary."""
         if self._is_valid_embedding(note.embedding.vector):
             return note.embedding.vector
@@ -94,7 +92,7 @@ class VectorRetriever:
 
         return note.embedding.vector
 
-    def _get_candidates(self, domain: Optional[str] = None) -> List[MemoryNote]:
+    def _get_candidates(self, domain: str | None = None) -> list[MemoryNote]:
         """Get candidate notes, optionally filtered by domain."""
         all_notes = list(self.store.iterate_notes())
         if domain:
@@ -104,12 +102,12 @@ class VectorRetriever:
     def retrieve(
         self,
         query: str,
-        domain: Optional[str] = None,
+        domain: str | None = None,
         k: int = 10,
         include_links: bool = True,
         use_lancedb: bool = True,
         return_scores: bool = False,
-    ) -> List[MemoryNote] | List[tuple]:
+    ) -> list[MemoryNote] | list[tuple]:
         """
         Retrieve notes relevant to query using LanceDB vector search.
         Falls back to in-memory search if LanceDB unavailable.
@@ -137,8 +135,8 @@ class VectorRetriever:
         return [note for note, _ in results]
 
     def _retrieve_via_lancedb(
-        self, query: str, domain: Optional[str], k: int, include_links: bool
-    ) -> List[MemoryNote]:
+        self, query: str, domain: str | None, k: int, include_links: bool
+    ) -> list[MemoryNote]:
         """Retrieve using LanceDB vector similarity search."""
 
         query_vector = get_embedding(query)
@@ -204,7 +202,7 @@ class VectorRetriever:
 
         return results  # List[Tuple[MemoryNote, float]]
 
-    def _apply_entity_boost_scored(self, results: List[tuple], query: str) -> List[tuple]:
+    def _apply_entity_boost_scored(self, results: list[tuple], query: str) -> list[tuple]:
         """Apply entity boost to (note, score) tuples, multiplying score by boost factor."""
         raw_query_entities = self.extractor.extract_all(query)
         query_entities = set()
@@ -232,8 +230,8 @@ class VectorRetriever:
         return boosted
 
     def _expand_via_links_scored(
-        self, initial_results: List[tuple], max_results: int
-    ) -> List[tuple]:
+        self, initial_results: list[tuple], max_results: int
+    ) -> list[tuple]:
         """Expand (note, score) results by including directly linked notes with decayed score."""
         all_ids = set(n.id for n, _ in initial_results)
         expanded = list(initial_results)
@@ -250,7 +248,7 @@ class VectorRetriever:
 
         return expanded[:max_results]
 
-    def _apply_entity_boost(self, results: List[MemoryNote], query: str) -> List[MemoryNote]:
+    def _apply_entity_boost(self, results: list[MemoryNote], query: str) -> list[MemoryNote]:
         """Apply entity boost to retrieved results."""
         raw_query_entities = self.extractor.extract_all(query)
         query_entities = set()
@@ -279,8 +277,8 @@ class VectorRetriever:
         return [note for note, _ in boosted]
 
     def _retrieve_via_memory(
-        self, query: str, domain: Optional[str], k: int, include_links: bool
-    ) -> List[tuple]:
+        self, query: str, domain: str | None, k: int, include_links: bool
+    ) -> list[tuple]:
         """Fallback: In-memory cosine similarity. Returns List[Tuple[MemoryNote, float]]."""
         query_vector = get_embedding(query)
         candidates = self._get_candidates(domain)
@@ -338,8 +336,8 @@ class VectorRetriever:
         return results  # List[Tuple[MemoryNote, float]]
 
     def _expand_via_links(
-        self, initial_results: List[MemoryNote], max_results: int
-    ) -> List[MemoryNote]:
+        self, initial_results: list[MemoryNote], max_results: int
+    ) -> list[MemoryNote]:
         """Expand results by including directly linked notes"""
         all_ids = set(n.id for n in initial_results)
         expanded = list(initial_results)
@@ -356,7 +354,7 @@ class VectorRetriever:
         return expanded[:max_results]
 
     def get_memory_context(
-        self, query: str, domain: Optional[str] = None, k: int = 10, token_budget: int = 4000
+        self, query: str, domain: str | None = None, k: int = 10, token_budget: int = 4000
     ) -> str:
         """
         Format retrieved notes for injection into agent prompt.

--- a/src/zettelforge/yara/entities.py
+++ b/src/zettelforge/yara/entities.py
@@ -20,7 +20,7 @@ from __future__ import annotations
 
 import hashlib
 from dataclasses import dataclass, field
-from typing import Any, Optional
+from typing import Any
 
 from zettelforge.detection.base import DetectionRule
 from zettelforge.yara.cccs_metadata import ValidationResult, validate_metadata
@@ -31,17 +31,17 @@ from zettelforge.yara.tags import resolve_yara_tag
 class YaraRule(DetectionRule):
     """``DetectionRule`` specialisation for YARA format."""
 
-    cccs_id: Optional[str] = None
-    fingerprint: Optional[str] = None  # SHA-256 over strings + condition
-    category: Optional[str] = None  # INFO | EXPLOIT | TECHNIQUE | TOOL | MALWARE
-    technique_tag: Optional[str] = None  # MITRE technique carried in CCCS meta
-    cccs_version: Optional[str] = None
+    cccs_id: str | None = None
+    fingerprint: str | None = None  # SHA-256 over strings + condition
+    category: str | None = None  # INFO | EXPLOIT | TECHNIQUE | TOOL | MALWARE
+    technique_tag: str | None = None  # MITRE technique carried in CCCS meta
+    cccs_version: str | None = None
     hash_of_sample: list[str] = field(default_factory=list)
-    rule_name: Optional[str] = None
+    rule_name: str | None = None
     is_private: bool = False
     is_global: bool = False
     imports: list[str] = field(default_factory=list)
-    condition: Optional[str] = None
+    condition: str | None = None
 
 
 # ---------------------------------------------------------------------------

--- a/src/zettelforge/yara/ingest.py
+++ b/src/zettelforge/yara/ingest.py
@@ -71,11 +71,11 @@ def _build_note_content(
 
 def ingest_rule(
     rule_source: str | Path | dict[str, Any],
-    mm: "MemoryManager | None" = None,
+    mm: MemoryManager | None = None,
     *,
     domain: str = "detection",
     tier: str = "warn",
-) -> tuple["MemoryNote | None", list[dict[str, Any]]]:
+) -> tuple[MemoryNote | None, list[dict[str, Any]]]:
     """Ingest a single YARA rule (file, text, or pre-parsed dict).
 
     Args:
@@ -108,7 +108,7 @@ def ingest_rule(
 
 def ingest_rules_dir(
     path: str | Path,
-    mm: "MemoryManager | None" = None,
+    mm: MemoryManager | None = None,
     *,
     glob: str = "**/*.yar",
     tier: str = "warn",
@@ -225,12 +225,12 @@ def _normalize_source(src: str | Path | dict[str, Any]) -> list[dict[str, Any]]:
 
 def _ingest_single(
     rule_dict: dict[str, Any],
-    mm: "MemoryManager",
+    mm: MemoryManager,
     *,
     domain: str,
     tier: str,
     source_path: str | None = None,
-) -> tuple["MemoryNote | None", list[dict[str, Any]], bool]:
+) -> tuple[MemoryNote | None, list[dict[str, Any]], bool]:
     """Ingest one rule. Returns ``(note_or_None, relations, is_new)``.
 
     ``is_new`` is ``False`` when the rule was already present and we hit
@@ -278,9 +278,7 @@ def _ingest_single(
     return note, relations, True
 
 
-def _persist_relations(
-    mm: "MemoryManager", relations: list[dict[str, Any]], *, note_id: str
-) -> None:
+def _persist_relations(mm: MemoryManager, relations: list[dict[str, Any]], *, note_id: str) -> None:
     """Write each canonical-shape relation into the KG via the storage backend.
 
     Mirrors ``zettelforge.sigma.ingest._persist_relations``: same defensive


### PR DESCRIPTION
## Summary

Adds **`UP` (pyupgrade)** to the ruff `select` list, advancing the GOV-003 §"Tooling and Automation" mandated rule set: `{E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}`. T20 + B landed in #106/#107; this PR adds UP.

700 findings surfaced, 633 auto-fixed, 67 manual cleanup of unused `typing.Dict`/`typing.List`/`typing.Union`/`typing.Optional` imports left over after autofix.

## Findings breakdown

| Code | Description | Count | Disposition |
|------|-------------|-------|-------------|
| UP006 | `List[X]` → `list[X]` (PEP 585) | 397 | autofix |
| UP045 | `Optional[X]` → `X \| None` (PEP 604) | 205 | autofix |
| UP035 | `typing.Dict` → `dict` import | 73 | manual cleanup of orphaned imports |
| UP037 | Quoted annotation removal | 15 | autofix |
| UP015 | Unnecessary `open` mode args | 8 | autofix |
| UP007 | `Union[X, Y]` → `X \| Y` | 2 | 1 autofix + 1 manual (sigma/ingest.py `RuleSource`) |

## Why this is safe

`pyproject.toml` requires Python `>=3.10`; PEP 585 (`list[X]`, `dict[K, V]`) and PEP 604 (`X | Y`) are fully supported. No semantic changes — purely syntactic modernization.

## Pre-existing test failures (not caused by this PR)

Two tests in `tests/test_llm_providers.py` (added by RFC-012, #108) fail on master independently of this change:
- `TestLLMConfigRepr::test_api_key_is_redacted` — contradictory assertions (`assert "***" not in text` immediately followed by `assert "***" in text`); when `api_key="***"` the redaction sentinel matches the literal value
- `TestLiteLLMProvider::test_import_error_raised_when_sdk_missing` — mock fails because `litellm` is actually installed in the dev env

Filed as separate follow-up; this PR is rebased on current master and does not introduce them.

## Test plan

- [x] `ruff check src/` clean with `E, F, I, W, N, T20, B, UP` enabled
- [x] 144/147 tests pass locally (3 pre-existing failures: 1 env-dependent typedb test + the 2 RFC-012 tests above)
- [ ] CI green (lint + governance + test 3.12/3.13 + pip-audit + snyk + codeql)

🤖 Generated with [Claude Code](https://claude.com/claude-code)