### PR TITLE
ci: H-1 batch 4 — Ruff SIM + RUF

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,14 +124,15 @@ line-length = 100
 [tool.ruff.lint]
 # GOV-003 §"Tooling and Automation" mandates the full set
 # {E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}. We ratchet incrementally:
-# T20 + B added 2026-04-25; UP (pyupgrade — PEP 585/604 modernization)
-# added 2026-04-25 (audit H-1 partial). The remaining rules (S, SIM,
-# RUF, ANN) will be added in subsequent batches once the surfaced
-# findings are triaged.
-select = ["E", "F", "I", "W", "N", "T20", "B", "UP"]
+# T20 + B + UP added 2026-04-25; SIM + RUF added 2026-04-25 (audit H-1
+# partial). The remaining rules (S, ANN) will be added in subsequent
+# batches once the surfaced findings are triaged.
+select = ["E", "F", "I", "W", "N", "T20", "B", "UP", "SIM", "RUF"]
 ignore = [
     "E501",   # line too long — handled by formatter
     "E402",   # module-level import not at top — needed for conditional imports
+    "RUF002", # ambiguous unicode in docstrings — en-dash and × are intentional
+    "RUF003", # ambiguous unicode in comments — en-dash and × are intentional
 ]
 
 [tool.ruff.lint.per-file-ignores]

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -59,45 +59,45 @@ from zettelforge.vector_retriever import VectorRetriever
 
 __version__ = "2.4.3"
 __all__ = [
-    # Edition
-    "Edition",
-    "get_edition",
-    "is_enterprise",
-    "is_community",
-    "edition_name",
-    "EditionError",
-    # Core
-    "MemoryManager",
-    "get_memory_manager",
-    "MemoryNote",
-    "VectorRetriever",
-    "SynthesisGenerator",
-    "get_synthesis_generator",
-    "SynthesisValidator",
-    "get_synthesis_validator",
-    # Knowledge Graph
-    "KnowledgeGraph",
-    "get_knowledge_graph",
-    # Retrieval
-    "GraphRetriever",
-    "ScoredResult",
-    "BlendedRetriever",
     # Ontology reference tables (TypedEntityStore / OntologyValidator are
     # importable from zettelforge.ontology but are not part of the public API
     # — see the module comment above for details).
     "ENTITY_TYPES",
     "RELATION_TYPES",
-    # Intent Classification
-    "IntentClassifier",
-    "get_intent_classifier",
-    "QueryIntent",
-    # Note Constructor
-    "NoteConstructor",
+    "BlendedRetriever",
+    # Edition
+    "Edition",
+    "EditionError",
+    "ExtractedFact",
     # Two-Phase Pipeline
     "FactExtractor",
-    "ExtractedFact",
+    # Retrieval
+    "GraphRetriever",
+    # Intent Classification
+    "IntentClassifier",
+    # Knowledge Graph
+    "KnowledgeGraph",
+    # Core
+    "MemoryManager",
+    "MemoryNote",
     "MemoryUpdater",
+    # Note Constructor
+    "NoteConstructor",
+    "QueryIntent",
+    "ScoredResult",
+    "SynthesisGenerator",
+    "SynthesisValidator",
     "UpdateOperation",
+    "VectorRetriever",
+    "edition_name",
+    "get_edition",
+    "get_intent_classifier",
+    "get_knowledge_graph",
+    "get_memory_manager",
+    "get_synthesis_generator",
+    "get_synthesis_validator",
+    "is_community",
+    "is_enterprise",
 ]
 
 # ── Enterprise-only imports (conditional) ───────────────────────────────────

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -16,6 +16,7 @@ Usage:
     cfg.retrieval.default_k  # 10
 """
 
+import contextlib
 import os
 import re
 from dataclasses import dataclass, field
@@ -295,10 +296,8 @@ def _parse_simple_yaml(path: Path) -> dict:
                     try:
                         value = int(value)
                     except ValueError:
-                        try:
+                        with contextlib.suppress(ValueError):
                             value = float(value)
-                        except ValueError:
-                            pass
                 result[current_section][key] = value
             elif ":" in stripped and current_section is None:
                 key, _, value = stripped.partition(":")

--- a/src/zettelforge/demo.py
+++ b/src/zettelforge/demo.py
@@ -88,7 +88,7 @@ def run_demo():
     print()
     for i, report in enumerate(SAMPLE_REPORTS, 1):
         start = time.perf_counter()
-        note, status = mm.remember(report["content"], domain="security_ops")
+        note, _status = mm.remember(report["content"], domain="security_ops")
         elapsed = (time.perf_counter() - start) * 1000
 
         # Show extracted entities

--- a/src/zettelforge/entity_indexer.py
+++ b/src/zettelforge/entity_indexer.py
@@ -10,6 +10,7 @@ Conversational Entity Extension (RFC-001):
 """
 
 import atexit
+import contextlib
 import fcntl
 import json
 import os
@@ -17,6 +18,7 @@ import re
 import tempfile
 import threading
 from pathlib import Path
+from typing import ClassVar
 
 from zettelforge.json_parse import extract_json
 from zettelforge.log import get_logger
@@ -28,7 +30,7 @@ class EntityExtractor:
     """Extract entities from text using regex (CTI) and LLM (conversational) patterns."""
 
     # Regex fast-path for CTI entities — deterministic, zero-latency
-    REGEX_PATTERNS: dict[str, re.Pattern] = {
+    REGEX_PATTERNS: ClassVar[dict[str, re.Pattern]] = {
         "cve": re.compile(r"(CVE-\d{4}-\d{4,})", re.IGNORECASE),
         "intrusion_set": re.compile(
             r"\b((?:apt|unc|ta|fin|temp)\s*-?\s*\d+)\b",
@@ -67,7 +69,7 @@ class EntityExtractor:
     }
 
     # All entity types the system recognizes
-    ENTITY_TYPES: list[str] = [
+    ENTITY_TYPES: ClassVar[list[str]] = [
         # CTI (regex)
         "cve",
         "intrusion_set",
@@ -127,7 +129,7 @@ class EntityExtractor:
     _PERSON_PATTERN = re.compile(r"(?:^|\n)\s*([A-Z][a-z]{2,15}):", re.MULTILINE)
 
     # Common words that match the person pattern but aren't names
-    _NAME_STOPWORDS = {
+    _NAME_STOPWORDS: ClassVar[set[str]] = {
         "the",
         "and",
         "but",
@@ -436,10 +438,8 @@ class EntityIndexer:
         except Exception:
             # Best-effort cleanup; raise so caller observes the failure.
             if os.path.exists(tmp_path):
-                try:
+                with contextlib.suppress(OSError):
                     os.unlink(tmp_path)
-                except OSError:
-                    pass
             raise
 
     def add_note(self, note_id: str, entities: dict[str, list[str]]) -> None:
@@ -523,7 +523,7 @@ class EntityIndexer:
         query_lower = query.lower()
         results: dict[str, list[str]] = {}
         for etype, entities in self.index.items():
-            matches = [ev for ev in entities.keys() if ev.startswith(query_lower)][:limit]
+            matches = [ev for ev in entities if ev.startswith(query_lower)][:limit]
             if matches:
                 results[etype] = matches
         return results

--- a/src/zettelforge/governance_validator.py
+++ b/src/zettelforge/governance_validator.py
@@ -14,7 +14,7 @@ class GovernanceValidator:
     Validates ZettelForge operations against governance rules.
     """
 
-    def __init__(self, governance_dir: Path = None):
+    def __init__(self, governance_dir: Path | None = None):
         self.governance_dir = governance_dir
         self.rules = self._load_governance_rules()
 
@@ -36,14 +36,8 @@ class GovernanceValidator:
         """
         violations = []
 
-        if operation == "remember":
-            if not isinstance(data, str) and not hasattr(data, "content"):
-                violations.append("GOV-011: Input validation required for memory storage")
-
-        if operation in ("remember", "synthesize"):
-            if "GOV-012" in self.rules:
-                # Should log operation
-                pass
+        if operation == "remember" and not isinstance(data, str) and not hasattr(data, "content"):
+            violations.append("GOV-011: Input validation required for memory storage")
 
         is_valid = len(violations) == 0
         return is_valid, violations

--- a/src/zettelforge/graph_retriever.py
+++ b/src/zettelforge/graph_retriever.py
@@ -90,4 +90,4 @@ class GraphRetriever:
                 to_node = self.kg.get_node_by_id(to_id)
                 if to_node and to_id not in visited:
                     step_label = f"{to_node['entity_type']}:{to_node['entity_value']}"
-                    queue.append((to_id, depth + 1, path + [step_label]))
+                    queue.append((to_id, depth + 1, [*path, step_label]))

--- a/src/zettelforge/knowledge_graph.py
+++ b/src/zettelforge/knowledge_graph.py
@@ -373,7 +373,7 @@ class KnowledgeGraph:
                     "to_type": to_node["entity_type"],
                     "to_value": to_node["entity_value"],
                 }
-                new_path = path + [step]
+                new_path = [*path, step]
                 results.append(new_path)
                 _dfs(to_id, depth + 1, new_path)
 

--- a/src/zettelforge/llm_providers/__init__.py
+++ b/src/zettelforge/llm_providers/__init__.py
@@ -15,6 +15,8 @@ Third-party packages can register additional providers via the
 
 from __future__ import annotations
 
+import contextlib
+
 from zettelforge.llm_providers.base import LLMProvider, LLMProviderConfigurationError
 from zettelforge.llm_providers.local_provider import LocalProvider
 from zettelforge.llm_providers.mock_provider import MockProvider
@@ -44,11 +46,9 @@ def _register_builtins() -> None:
         ("ollama", OllamaProvider),
         ("mock", MockProvider),
     ):
-        try:
+        # Already registered (re-import / test runtime); silently skip.
+        with contextlib.suppress(ValueError):
             register(name, cls)
-        except ValueError:
-            # Already registered (re-import / test runtime); silently skip.
-            pass
 
     # RFC-012: LiteLLM is an optional provider — installed via
     # pip install zettelforge[litellm]. Registration is conditional

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -567,7 +567,7 @@ class MemoryManager:
         from zettelforge.intent_classifier import get_intent_classifier
 
         classifier = get_intent_classifier()
-        intent, intent_meta = classifier.classify(query)
+        intent, _intent_meta = classifier.classify(query)
         policy = classifier.get_traversal_policy(intent)
 
         # Extract entities from query for graph traversal
@@ -592,11 +592,10 @@ class MemoryManager:
 
         # Temporal boost: for temporal queries, prioritize notes containing dates from the query
         if intent.value == "temporal":
-            try:
-                import re as _re
+            import importlib.util
+            import re as _re
 
-                import dateparser  # noqa: F401 — probe-import; raises ImportError when unavailable
-
+            if importlib.util.find_spec("dateparser") is not None:
                 # Extract date-like strings from query
                 date_patterns = _re.findall(
                     r"\b(?:january|february|march|april|may|june|july|august|september|"
@@ -617,8 +616,6 @@ class MemoryManager:
                         else:
                             rest.append((note, score))
                     vector_scored = boosted + rest
-            except ImportError:
-                pass
 
         # Blended retrieval: combine vector similarity with graph traversal
         from zettelforge.blended_retriever import BlendedRetriever
@@ -1388,7 +1385,7 @@ class MemoryManager:
         query: str,
         format: str = "direct_answer",
         k: int = 10,
-        tier_filter: list[str] = None,
+        tier_filter: list[str] | None = None,
         actor: str | None = None,
     ) -> dict[str, Any]:
         """

--- a/src/zettelforge/memory_store.py
+++ b/src/zettelforge/memory_store.py
@@ -4,6 +4,7 @@ A-MEM Agentic Memory Architecture V1.0
 """
 
 import atexit
+import contextlib
 import fcntl
 import glob
 import hashlib
@@ -247,11 +248,10 @@ class MemoryStore:
                 activity = "Create"
             else:
                 tbl = self.lancedb.open_table(table_name)
-                # Remove existing row if present (prevents ghost duplicates)
-                try:
+                # Remove existing row if present (prevents ghost duplicates).
+                # Table may be empty or ID may not exist — both are fine.
+                with contextlib.suppress(Exception):
                     tbl.delete(f"id = '{note.id}'")
-                except Exception:
-                    pass  # Table may be empty or ID may not exist
                 tbl.add([note_data])
                 activity = "Update"
 

--- a/src/zettelforge/note_constructor.py
+++ b/src/zettelforge/note_constructor.py
@@ -10,6 +10,7 @@ Causal Triple Extension (2026-04-06):
 
 import re
 from datetime import datetime
+from typing import ClassVar
 
 from zettelforge.alias_resolver import AliasResolver
 from zettelforge.json_parse import extract_json
@@ -92,7 +93,7 @@ class NoteConstructor:
 
     # ===== Causal Triple Extraction (MAGMA-style) =====
 
-    CAUSAL_RELATIONS = [
+    CAUSAL_RELATIONS: ClassVar[list[str]] = [
         "causes",
         "enables",
         "targets",

--- a/src/zettelforge/ontology.py
+++ b/src/zettelforge/ontology.py
@@ -417,9 +417,8 @@ class OntologyValidator:
                     "end >= start" in validate_expr
                     and "end" in properties
                     and "start" in properties
-                ):
-                    if properties["end"] < properties["start"]:
-                        errors.append("End time must be >= start time")
+                ) and properties["end"] < properties["start"]:
+                    errors.append("End time must be >= start time")
             except Exception as e:
                 errors.append(f"Validation error: {e}")
 
@@ -551,9 +550,8 @@ class TypedEntityStore:
 
         # Check acyclic if required
         rel_def = RELATION_TYPES.get(relation_type, {})
-        if rel_def.get("acyclic"):
-            if self._would_create_cycle(from_id, relation_type, to_id):
-                return False, [f"Relation {relation_type} would create cycle (acyclic constraint)"]
+        if rel_def.get("acyclic") and self._would_create_cycle(from_id, relation_type, to_id):
+            return False, [f"Relation {relation_type} would create cycle (acyclic constraint)"]
 
         relation = {
             "from": from_id,
@@ -601,26 +599,24 @@ class TypedEntityStore:
         """Query entities by property value."""
         results = []
         for entity in self._entities.values():
-            if entity["type"] == entity_type:
-                if entity["properties"].get(property_name) == value:
-                    results.append(entity)
+            if entity["type"] == entity_type and entity["properties"].get(property_name) == value:
+                results.append(entity)
         return results
 
     def get_related(self, entity_id: str, relation_type: str | None = None) -> list[dict]:
         """Get related entities."""
         results = []
         for rel in self._relations:
-            if rel["from"] == entity_id:
-                if relation_type is None or rel["rel"] == relation_type:
-                    target = self._entities.get(rel["to"])
-                    if target:
-                        results.append(
-                            {
-                                "relation": rel["rel"],
-                                "entity": target,
-                                "properties": rel.get("properties", {}),
-                            }
-                        )
+            if rel["from"] == entity_id and (relation_type is None or rel["rel"] == relation_type):
+                target = self._entities.get(rel["to"])
+                if target:
+                    results.append(
+                        {
+                            "relation": rel["rel"],
+                            "entity": target,
+                            "properties": rel.get("properties", {}),
+                        }
+                    )
         return results
 
     def list_types(self) -> list[str]:

--- a/src/zettelforge/scripts/compact_lance.py
+++ b/src/zettelforge/scripts/compact_lance.py
@@ -128,10 +128,7 @@ def _process_one(
 
     t0 = time.perf_counter()
     try:
-        if mode == "optimize":
-            metrics = table.optimize()
-        else:  # "compact"
-            metrics = table.compact_files()
+        metrics = table.optimize() if mode == "optimize" else table.compact_files()
         report.elapsed_seconds = round(time.perf_counter() - t0, 2)
         report.lance_metrics = _serialize_lance_metrics(metrics)
     except Exception as exc:

--- a/src/zettelforge/sqlite_backend.py
+++ b/src/zettelforge/sqlite_backend.py
@@ -9,6 +9,7 @@ WARNING-3: synchronous=NORMAL means the last transaction before an OS crash
 (power failure, kernel panic) may be lost.  Application-level crashes are safe.
 """
 
+import contextlib
 import json
 import sqlite3
 import threading
@@ -323,10 +324,8 @@ class SQLiteBackend(StorageBackend):
             if conn is None:
                 return
             self._conn = None
-            try:
+            with contextlib.suppress(Exception):
                 conn.execute("PRAGMA wal_checkpoint(TRUNCATE)")
-            except Exception:
-                pass
             conn.close()
 
     def health_check(self) -> dict[str, Any]:
@@ -689,7 +688,7 @@ class SQLiteBackend(StorageBackend):
                     "to_type": erow["to_type"],
                     "to_value": erow["to_value"],
                 }
-                new_path = path + [step]
+                new_path = [*path, step]
                 results.append(new_path)
                 _dfs(erow["to_node_id"], depth + 1, new_path)
 

--- a/src/zettelforge/synthesis_generator.py
+++ b/src/zettelforge/synthesis_generator.py
@@ -44,7 +44,7 @@ class SynthesisGenerator:
         memory_manager=None,
         format: str = "direct_answer",
         k: int = 10,
-        tier_filter: list[str] = None,
+        tier_filter: list[str] | None = None,
     ) -> dict:
         """
         Synthesize an answer from retrieved notes.

--- a/src/zettelforge/vector_memory.py
+++ b/src/zettelforge/vector_memory.py
@@ -265,10 +265,7 @@ class VectorMemory:
             if existing:
                 return []
 
-        if chunk and len(text) > 2000:
-            chunks = self._chunk_text(text)
-        else:
-            chunks = [text]
+        chunks = self._chunk_text(text) if chunk and len(text) > 2000 else [text]
 
         ids = []
         for chunk_text in chunks:

--- a/src/zettelforge/vector_retriever.py
+++ b/src/zettelforge/vector_retriever.py
@@ -67,11 +67,10 @@ class VectorRetriever:
         # Check if all zeros or all identical (deterministic mock)
         if all(v == 0.0 for v in vector):
             return False
-        # Check variance - real embeddings have variance
+        # Check variance — real embeddings have variance.
+        # Suspiciously low variance ⇒ likely zero/mock vector.
         var = np.var(vector)
-        if var < 0.001:  # Suspiciously low variance
-            return False
-        return True
+        return var >= 0.001
 
     def _ensure_note_embedding(self, note: MemoryNote) -> list[float] | None:
         """Ensure note has valid embedding, regenerating if necessary."""


### PR DESCRIPTION
## Summary

Adds **`SIM` (flake8-simplify)** and **`RUF` (ruff-specific)** to the ruff `select` list. Surfaced 37 findings; 17 auto/unsafe-fixed, 16 manual fixes, plus RUF002/RUF003 ignored globally for stylistic unicode (en-dash `–` and `×`).

## Manual fixes

- **RUF012** mutable default class attr (4) — annotated `ClassVar[...]` on `EntityExtractor.REGEX_PATTERNS / ENTITY_TYPES / _NAME_STOPWORDS`, `NoteConstructor.CAUSAL_RELATIONS`
- **SIM102** nested if (4) — flattened to `and`-combined in ontology + governance_validator
- **SIM105** try-except-pass (2) — `contextlib.suppress` in llm_providers + lance row delete
- **SIM108** if-else → ternary (1) — compact_lance mode dispatch
- **SIM103** return negated (1) — vector_retriever variance check
- **F401** orphan probe-import (1) — `dateparser` → `importlib.util.find_spec`

## Why ignore RUF002/RUF003

Codebase consistently uses `–` (EN DASH) as typographic separator in comments and docstrings, and `×` in performance docs ("32× improvement"). Stylistic, not bugs.

## Test plan

- [x] `ruff check src/` clean
- [x] `ruff format --check src/` clean
- [x] 87/89 critical tests pass (2 pre-existing env-dependent: `test_ingest_relationship`, `test_intent_classification`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)