### PR TITLE
ci(audit): L-4 — fix shell precedence in CI pip-install fallback

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -79,7 +79,11 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]" || pip install -e "." && pip install pytest pytest-cov pytest-asyncio
+        # If [dev] install fails, fall back to bare install + manually
+        # add the pytest deps. Parenthesizing the fallback prevents shell
+        # precedence from running the "pytest pytest-cov pytest-asyncio"
+        # step when [dev] already succeeded (audit L-4).
+        pip install -e ".[dev]" || (pip install -e "." && pip install pytest pytest-cov pytest-asyncio)
 
     - name: Pre-download fastembed model
       run: |
@@ -117,7 +121,8 @@ jobs:
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip
-        pip install -e ".[dev]" || pip install -e "." && pip install pytest pytest-cov
+        # See "Install dependencies" comment above (audit L-4).
+        pip install -e ".[dev]" || (pip install -e "." && pip install pytest pytest-cov)
 
     - name: GOV-012 — Logging compliance tests
       env:


### PR DESCRIPTION
## Summary

Closes audit finding **L-4** from \`tasks/compliance-audit-2026-04-25.md\`.

\`pip install -e \".[dev]\" || pip install -e \".\" && pip install pytest pytest-cov pytest-asyncio\` parses as \`(A || B) && C\` because \`||\` and \`&&\` have the same precedence in bash and associate left-to-right. The pytest install runs whenever the chain returns success — including when \`[dev]\` already installed it. Worse, if both \`[dev]\` AND the bare install fail, the pytest install is skipped.

Fix: wrap the fallback in parentheses so the pytest install runs **only** when the fallback path is taken — the original intent.

Applied to the test matrix job and the governance job.

## Test plan

- [ ] CI green on this PR (the fix is in CI itself)
- [x] Manual semantics check: \`(A || (B && C))\` no, \`A || (B && C)\` — pytest installs only when A fails AND B succeeds. Matches the original docstring intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)