### PR TITLE
ci: H-1 batch 5 — Ruff S (security/bandit) closes the H-1 ratchet for src/

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -124,10 +124,12 @@ line-length = 100
 [tool.ruff.lint]
 # GOV-003 §"Tooling and Automation" mandates the full set
 # {E, F, I, S, B, UP, SIM, RUF, N, ANN, T20}. We ratchet incrementally:
-# T20 + B + UP added 2026-04-25; SIM + RUF added 2026-04-25 (audit H-1
-# partial). The remaining rules (S, ANN) will be added in subsequent
-# batches once the surfaced findings are triaged.
-select = ["E", "F", "I", "W", "N", "T20", "B", "UP", "SIM", "RUF"]
+# T20 + B + UP + SIM + RUF added earlier 2026-04-25; S (bandit-ish
+# security) added in this batch. Per-line `# noqa: SXXX` annotations
+# document each accepted exception (best-effort fallbacks, non-crypto
+# RNG, ?-bound SQL with constant column lists). Only ANN remains; it
+# will be ratcheted per-module to avoid a 1000+ finding flood.
+select = ["E", "F", "I", "W", "N", "T20", "B", "UP", "SIM", "RUF", "S"]
 ignore = [
     "E501",   # line too long — handled by formatter
     "E402",   # module-level import not at top — needed for conditional imports

--- a/src/zettelforge/knowledge_graph.py
+++ b/src/zettelforge/knowledge_graph.py
@@ -120,10 +120,10 @@ class KnowledgeGraph:
         if not ts_string:
             return None
 
-        # ISO format
+        # ISO format — try first, fall through to fmt list on parse failure
         try:
             return datetime.fromisoformat(ts_string.replace("Z", "+00:00"))
-        except Exception:
+        except Exception:  # noqa: S110 — best-effort parse; fall through to alt fmts
             pass
 
         # Common formats
@@ -131,7 +131,7 @@ class KnowledgeGraph:
         for fmt in formats:
             try:
                 return datetime.strptime(ts_string, fmt)
-            except Exception:
+            except Exception:  # noqa: S112 — best-effort parse; try next fmt
                 continue
         return None
 

--- a/src/zettelforge/memory_store.py
+++ b/src/zettelforge/memory_store.py
@@ -141,7 +141,9 @@ class MemoryStore:
         ts = datetime.now().strftime("%Y%m%d_%H%M%S")
         import random
 
-        suffix = str(random.randint(0, 9999)).zfill(4)
+        # Note IDs are not security-sensitive; collisions are tolerated
+        # (timestamp-prefixed → vanishing collision probability per second).
+        suffix = str(random.randint(0, 9999)).zfill(4)  # noqa: S311
         return f"note_{ts}_{suffix}"
 
     def _ensure_cache(self):
@@ -367,7 +369,7 @@ class MemoryStore:
                                 updated = True
                             else:
                                 notes.append(data)
-                        except Exception:
+                        except Exception:  # noqa: S110 — corrupt JSONL lines are dropped
                             pass
 
                 if not updated:

--- a/src/zettelforge/ocsf.py
+++ b/src/zettelforge/ocsf.py
@@ -45,7 +45,7 @@ def _resolve_product_version() -> str:
                 stripped = line.strip()
                 if stripped.startswith("version") and "=" in stripped:
                     return stripped.split("=", 1)[1].strip().strip('"').strip("'")
-    except Exception:  # pragma: no cover — defensive; fall through to metadata
+    except Exception:  # pragma: no cover  # noqa: S110 — defensive; fall through to metadata
         pass
 
     try:

--- a/src/zettelforge/retry.py
+++ b/src/zettelforge/retry.py
@@ -56,7 +56,8 @@ def with_retry(config: RetryConfig = None, observability: Observability = None):
                 except Exception as e:
                     last_exception = e
                     delay = min(config.base_delay * (2 ** (attempt - 1)), config.max_delay)
-                    jitter = random.uniform(0, 0.1 * delay)
+                    # Backoff jitter — non-cryptographic.
+                    jitter = random.uniform(0, 0.1 * delay)  # noqa: S311
                     sleep_time = delay + jitter
 
                     observability.log_operation(

--- a/src/zettelforge/scripts/compact_lance.py
+++ b/src/zettelforge/scripts/compact_lance.py
@@ -154,15 +154,15 @@ def _serialize_lance_metrics(metrics: Any) -> dict[str, Any]:
     if dataclasses.is_dataclass(metrics) and not isinstance(metrics, type):
         try:
             return dataclasses.asdict(metrics)
-        except Exception:
-            pass  # fall through to attribute enumeration
+        except Exception:  # noqa: S110 — fall through to attribute enumeration
+            pass
     out: dict[str, Any] = {}
     for k in dir(metrics):
         if k.startswith("_"):
             continue
         try:
             v = getattr(metrics, k)
-        except Exception:
+        except Exception:  # noqa: S112 — skip attrs that error on getattr
             continue
         if callable(v):
             continue

--- a/src/zettelforge/sqlite_backend.py
+++ b/src/zettelforge/sqlite_backend.py
@@ -268,8 +268,9 @@ _NOTE_COLUMNS = [
     "vuln_meta",
 ]
 
+# _NOTE_COLUMNS is a module-level constant; row values are ?-bound. Safe.
 _INSERT_NOTE_SQL = (
-    f"INSERT OR REPLACE INTO notes ({', '.join(_NOTE_COLUMNS)}) "
+    f"INSERT OR REPLACE INTO notes ({', '.join(_NOTE_COLUMNS)}) "  # noqa: S608
     f"VALUES ({', '.join('?' for _ in _NOTE_COLUMNS)})"
 )
 

--- a/src/zettelforge/synthesis_generator.py
+++ b/src/zettelforge/synthesis_generator.py
@@ -80,7 +80,7 @@ class SynthesisGenerator:
             "format": format,
             "synthesis": synthesis,
             "metadata": {
-                "query_id": hashlib.md5(query.encode()).hexdigest()[:12],
+                "query_id": hashlib.md5(query.encode(), usedforsecurity=False).hexdigest()[:12],
                 "model_used": self.llm_model,
                 "tokens_used": tokens_used,
                 "latency_ms": latency_ms,

--- a/src/zettelforge/vector_memory.py
+++ b/src/zettelforge/vector_memory.py
@@ -129,15 +129,15 @@ def get_embedding(text: str, model: str | None = None) -> list[float]:
     except Exception:
         _logger.warning("http_embedding_failed", exc_info=True)
 
-    # Last resort: deterministic mock embedding
-    h = int(hashlib.md5(text.encode()).hexdigest(), 16)
+    # Last resort: deterministic mock embedding (non-cryptographic).
+    h = int(hashlib.md5(text.encode(), usedforsecurity=False).hexdigest(), 16)
     import random
 
     random.seed(h)
     from zettelforge.config import get_config
 
     dim = get_config().embedding.dimensions
-    return [random.random() for _ in range(dim)]
+    return [random.random() for _ in range(dim)]  # noqa: S311
 
 
 def get_embedding_batch(texts: list[str], model: str | None = None) -> list[list[float]]:


### PR DESCRIPTION
## Summary

Adds **\`S\` (flake8-bandit)** to the ruff \`select\` list. Closes the GOV-003 §"Tooling and Automation" rule set for \`src/\` — only \`ANN\` remains and it will be ratcheted per-module.

Active \`select\` list now: \`{E, F, I, W, N, T20, B, UP, SIM, RUF, S}\`.

## Findings + disposition (14 in src/)

| Code | Description | Count | Disposition |
|------|-------------|-------|-------------|
| S110/S112 | try-except-pass / -continue | 6 | per-line \`# noqa\` with intent (best-effort parsers, defensive fallbacks) |
| S311 | random for non-cryptographic uses | 3 | per-line \`# noqa\` (note ID suffix, retry jitter, mock embedding) |
| S324 | hashlib.md5 | 2 | switched to \`usedforsecurity=False\` (PEP 587, 3.9+) |
| S608 | f-string SQL | 1 | per-line \`# noqa\` (column list is module constant; values \`?\`-bound) |

CI lints \`src/\` only, so the 1095 \`assert\` statements in \`tests/\` are not in scope.

## Stack

This is the last of 5 H-1 batches:
- #106 batch 1 (T20)
- #107 batch 2 (B)
- #109 batch 3 (UP)
- #111 batch 4 (SIM + RUF)
- **#113 batch 5 (S)** ← this PR

## Test plan

- [x] \`ruff check src/\` clean with full select list
- [x] \`ruff format --check src/\` clean
- [x] 69/70 critical tests pass (1 pre-existing env-dependent: \`test_ingest_relationship\`)
- [ ] CI green

🤖 Generated with [Claude Code](https://claude.com/claude-code)