### PR TITLE
ci(audit): spec-drift validator walks all workflow files + GOV-009 declares Snyk rules

### DIFF
--- a/governance/controls.yaml
+++ b/governance/controls.yaml
@@ -43,13 +43,14 @@ controls:
         description: "Audit dependencies for known vulnerabilities on every PR"
         ci_step: "Audit dependencies (any reported vuln blocks)"
         tool: "pip-audit --strict --vulnerability-service=osv"
-      # Snyk Open Source / Code (SCA / SAST) live in a separate workflow
-      # (.github/workflows/snyk-security.yml) and are part of GOV-009
-      # in spirit. The spec-drift validator currently inspects ci.yml
-      # only, so they are not declared as ci_step rules here to avoid
-      # tripping test_ci_step_references_exist_in_workflow. Broadening
-      # the validator to walk all workflows is tracked as a separate
-      # follow-up.
+      - id: snyk_sca
+        description: "SCA (Software Composition Analysis) scan; HIGH/CRITICAL fails the gate"
+        ci_step: "Snyk Open Source test (SCA)"
+        tool: "snyk test --severity-threshold=high"
+      - id: snyk_sast
+        description: "SAST (Static Application Security Testing); HIGH/CRITICAL fails the gate"
+        ci_step: "Snyk Code test (SAST)"
+        tool: "snyk code test --severity-threshold=high"
 
   GOV-011:
     name: Access Control & Input Validation

--- a/tests/test_governance_spec_drift.py
+++ b/tests/test_governance_spec_drift.py
@@ -16,7 +16,12 @@ import yaml
 
 
 GOVERNANCE_MANIFEST = Path(__file__).parent.parent / "governance" / "controls.yaml"
-CI_WORKFLOW = Path(__file__).parent.parent / ".github" / "workflows" / "ci.yml"
+WORKFLOWS_DIR = Path(__file__).parent.parent / ".github" / "workflows"
+# CI_WORKFLOW retained for backwards compat with any external callers,
+# but the validator now walks every *.yml under WORKFLOWS_DIR so a CI
+# step in a non-ci.yml workflow (e.g. snyk-security.yml) can also satisfy
+# a control's `ci_step` reference.
+CI_WORKFLOW = WORKFLOWS_DIR / "ci.yml"
 
 
 def _load_manifest():
@@ -28,12 +33,19 @@ def _load_manifest():
         return yaml.safe_load(f)
 
 
+def _read_all_workflow_text() -> str:
+    """Concatenate every .yml/.yaml file under .github/workflows/."""
+    assert WORKFLOWS_DIR.is_dir(), f"Workflows dir not found: {WORKFLOWS_DIR}"
+    chunks: list[str] = []
+    for path in sorted(WORKFLOWS_DIR.iterdir()):
+        if path.suffix in (".yml", ".yaml") and path.is_file():
+            chunks.append(path.read_text())
+    return "\n".join(chunks)
+
+
 def _extract_gov_labels_from_ci():
-    """Extract all GOV-XXX labels from CI workflow step names."""
-    assert CI_WORKFLOW.exists(), f"CI workflow not found: {CI_WORKFLOW}"
-    ci_text = CI_WORKFLOW.read_text()
-    # Match step names like "GOV-003 — ..." or "GOV-012 — ..."
-    return set(re.findall(r"GOV-\d{3}", ci_text))
+    """Extract all GOV-XXX labels from any workflow step name."""
+    return set(re.findall(r"GOV-\d{3}", _read_all_workflow_text()))
 
 
 class TestGovernanceSpecDrift:
@@ -103,16 +115,19 @@ class TestGovernanceSpecDrift:
                 )
 
     def test_ci_step_references_exist_in_workflow(self):
-        """Every ci_step referenced in the manifest must exist in ci.yml."""
+        """Every ci_step referenced in the manifest must exist in some workflow."""
         manifest = _load_manifest()
-        ci_text = CI_WORKFLOW.read_text()
+        all_workflows = _read_all_workflow_text()
 
         missing = []
         for control_id, control in manifest["controls"].items():
             for rule in control["rules"]:
                 ci_step = rule.get("ci_step")
-                if ci_step and ci_step not in ci_text:
-                    missing.append(f"{control_id}/{rule['id']}: ci_step '{ci_step}' not found in ci.yml")
+                if ci_step and ci_step not in all_workflows:
+                    missing.append(
+                        f"{control_id}/{rule['id']}: ci_step '{ci_step}' "
+                        f"not found in any .github/workflows/*.yml"
+                    )
 
         assert missing == [], (
             f"Manifest references CI steps that don't exist:\n" +


### PR DESCRIPTION
## Summary

Closes the validator-broadening follow-up flagged in PR #102 and \`tasks/compliance-audit-2026-04-25.md\` under H-5.

The spec-drift validator only inspected \`.github/workflows/ci.yml\`. Snyk's SCA + SAST gates live in \`.github/workflows/snyk-security.yml\` (correctly — Snyk gets its own workflow with its own permission scope and SARIF upload), so the corresponding GOV-009 rules had to be left as comments to avoid breaking \`test_ci_step_references_exist_in_workflow\`.

## Changes

- **\`tests/test_governance_spec_drift.py\`** — \`_extract_gov_labels_from_ci()\` and the \`ci_step\` membership check now read every \`*.yml\`/\`*.yaml\` under \`.github/workflows/\`.
- **\`governance/controls.yaml\`** GOV-009 — adds two declared rules:
  - \`snyk_sca\` → step name \`"Snyk Open Source test (SCA)"\`
  - \`snyk_sast\` → step name \`"Snyk Code test (SAST)"\`

## Test plan

- [x] All 7 \`test_governance_spec_drift\` tests pass
- [ ] CI green (the broadened validator runs as part of CI)

🤖 Generated with [Claude Code](https://claude.com/claude-code)