### PR TITLE
docs(contributing): replace black with ruff format; document CI rule set

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,15 @@ No external services (Ollama, TypeDB, Docker) are required for development. Zett
 2. Make your changes
 3. Run tests: `pytest tests/ -v`
 4. Run linting: `ruff check src/zettelforge/`
-5. Run formatting: `black src/zettelforge/`
-6. Commit with clear messages
+5. Run formatting: `ruff format src/zettelforge/`
+6. Commit with a Conventional Commits message (see "Commit Messages" below)
 7. Push and create a pull request
+
+CI enforces the same `ruff check` and `ruff format --check` invocations
+plus `pytest --cov-fail-under=67`, `pip-audit`, governance spec-drift,
+and Snyk SCA/SAST. The full active rule set is `{E, F, I, W, N, T20,
+B, UP, SIM, RUF, S}` per GOV-003 §"Tooling and Automation"; only ANN
+remains and is being ratcheted per-module.
 
 ## Where to contribute
 


### PR DESCRIPTION
## Summary

Two small accuracy fixes to \`CONTRIBUTING.md\`:

1. The "Run formatting" step said \`black src/zettelforge/\` but black isn't in \`[dev]\` extras. The project uses \`ruff format\`. Replaced.
2. Added a one-paragraph note on what CI actually enforces — ruff rule families \`{E, F, I, W, N, T20, B, UP, SIM, RUF, S}\` per GOV-003, coverage gate (\`--cov-fail-under=67\`), pip-audit, governance spec-drift, and Snyk SCA/SAST. New contributors otherwise have to read every workflow file to know what will fail their PR.

Also tweaked the "Commit with clear messages" line to point at the existing "Commit Messages" section that already documents Conventional Commits.

## Test plan

- [x] No code changes; pure docs
- [ ] CI green (treat as a smoke test of the PR template)

🤖 Generated with [Claude Code](https://claude.com/claude-code)