### PR TITLE
ci(audit): H-4 — declare GOV-006 solo-maintainer compensating controls

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,4 +1,13 @@
 # ZettelForge Code Owners
 # These users are automatically requested for review on PRs.
+#
+# Solo-maintainer mode (see governance/controls.yaml GOV-006): the
+# project currently has one human maintainer, so the GOV-006 §"Approval
+# Requirements" two-person rule cannot be physically satisfied. Until a
+# second maintainer is added, the compensating controls declared under
+# GOV-006 in controls.yaml (CI-green required, lint, governance
+# spec-drift, plus GOV-009 SCA/SAST gates) substitute for a second set
+# of human eyes. The audit trail of compensating controls is recoverable
+# from CI logs and branch-protection settings.
 
 * @rolandpg

--- a/governance/controls.yaml
+++ b/governance/controls.yaml
@@ -81,3 +81,37 @@ controls:
       - id: operation_coverage
         description: "remember, recall, synthesize operations are logged"
         test: "tests/test_logging_compliance.py"
+
+  GOV-006:
+    # The 2026-04-25 audit (H-4) flagged that GOV-006 §"Approval
+    # Requirements" requires "the reviewer must not be the PR author,"
+    # which is physically impossible in a solo-maintainer project.
+    # Until a second human maintainer is added to CODEOWNERS, the
+    # compensating controls below are the project's good-faith
+    # equivalent of the two-person rule. They are listed here so an
+    # external auditor can see what's enforcing this control today
+    # and so the project's spec-drift validator records each as a
+    # tracked CI gate. The accompanying GOV-006 doc amendment lives
+    # in the separate `rolandpg/governance` repo.
+    name: Code Review (Solo-Maintainer Compensating Controls)
+    category: Change Control
+    enforcement: ci
+    rules:
+      - id: ci_green_required
+        description: "Every PR must pass the CI gate (lint, tests, governance, build, pip-audit) before merge"
+        ci_step: "Test with pytest"
+        tool: "GitHub branch protection on master (required status checks)"
+      - id: lint_gate
+        description: "Static analysis catches what a human reviewer would otherwise catch"
+        ci_step: "Lint with ruff"
+        tool: "ruff (full GOV-003 rule set)"
+      - id: governance_drift_gate
+        description: "Governance spec-drift check enforces controls.yaml ↔ workflows alignment"
+        ci_step: "Governance spec-drift check"
+        tool: "tests/test_governance_spec_drift.py"
+      # Secret scanning is provided by GitGuardian (GitHub App, named
+      # "GitGuardian Security Checks" in branch-protection required
+      # status checks) and is part of the GOV-006 compensating control
+      # set in spirit. It is not declared here because the spec-drift
+      # validator only inspects workflow YAML; GitGuardian runs as a
+      # GitHub-native check, not as a workflow step. See L-3 follow-up.


### PR DESCRIPTION
## Summary

Closes the **zettelforge-side** scope of audit finding **H-4** (GOV-006 §"Approval Requirements" cannot be satisfied in a solo-maintainer project; the audit asked for an exception clause + compensating controls to be documented).

## Changes

### \`governance/controls.yaml\` — new GOV-006 entry

\`enforcement: ci\` with three rules cross-referencing existing CI steps:

| rule | ci_step it pins to | substitutes for |
|---|---|---|
| \`ci_green_required\` | "Test with pytest" | the "PR must pass review" gate |
| \`lint_gate\` | "Lint with ruff" | static analysis a human reviewer would run |
| \`governance_drift_gate\` | "Governance spec-drift check" | the "controls match what's enforced" verification |

GitGuardian secret-scan is part of the compensating set in spirit but runs as a GitHub-native app, not a workflow step, so it's documented in a comment rather than declared as a \`ci_step\`. The GOV-009 rules (\`vulnerability_scanning\`, \`snyk_sca\`, \`snyk_sast\`) declared earlier this session also gate every PR — GOV-006 references them by intent.

### \`CODEOWNERS\` — explanatory header

Adds a comment block above the wildcard line so a future contributor or auditor sees the policy context without having to cross-reference the controls manifest.

## Out of scope

The **GOV-006 markdown amendment** itself lives in the separate \`rolandpg/governance\` repo (the doc that says "the reviewer must not be the PR author"). That edit is a separate commit; this PR only covers the zettelforge-side controls manifest + CODEOWNERS reference.

## Test plan

- [x] \`pytest tests/test_governance_spec_drift.py\` — 7/7 pass with the new GOV-006 entry
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)