### PR TITLE
feat: add Presidio PII detection and redaction (RFC-013)

### DIFF
--- a/config.default.yaml
+++ b/config.default.yaml
@@ -329,6 +329,15 @@ synthesis:
 # Validation rules applied before remember() and recall() operations.
 # Enforces data classification, retention, access control, and audit logging.
 #
+# PII detection (RFC-013, optional) uses Microsoft Presidio to scan content
+# for personally identifiable information before storage. Disabled by default.
+# Requires: pip install zettelforge[pii]
+#
+# PII action options:
+#   log       — detect and warn, pass content through unchanged
+#   redact    — replace PII with [REDACTED] before storage
+#   block     — raise exception if any PII is detected
+#
 # Examples:
 #   # Production (default)
 #   enabled: true
@@ -341,9 +350,41 @@ synthesis:
 #   enabled: true
 #   min_content_length: 20
 #
+#   # PII log-only (see what PII flows through your pipeline)
+#   enabled: true
+#   min_content_length: 1
+#   pii:
+#     enabled: true
+#     action: log
+#
+#   # PII redact (automatically remove PII before storage)
+#   enabled: true
+#   min_content_length: 1
+#   pii:
+#     enabled: true
+#     action: redact
+#
+#   # PII block (strict — reject content with detected PII)
+#   enabled: true
+#   min_content_length: 1
+#   pii:
+#     enabled: true
+#     action: block
+#
+# Env overrides:
+#   ZETTELFORGE_PII_ENABLED=true
+#   ZETTELFORGE_PII_ACTION=redact
+#
 governance:
   enabled: true
   min_content_length: 1
+  pii:
+    enabled: false
+    action: log
+    redact_placeholder: "[REDACTED]"
+    entities: []
+    language: en
+    nlp_model: en_core_web_sm
 
 
 # ── Cache ───────────────────────────────────────────────────────────────────

--- a/docs/how-to/configure-pii.md
+++ b/docs/how-to/configure-pii.md
@@ -1,0 +1,217 @@
+---
+title: "Configure PII Detection and Redaction"
+description: "Set up Microsoft Presidio for PII detection in ZettelForge. Scan content for personally identifiable information before storage, with configurable log/redact/block policies."
+diataxis_type: "how-to"
+audience: "Compliance Officer, SOC Manager, FedRAMP Engineer"
+tags: [pii, governance, compliance, presidio, privacy, fedramp, gdpr]
+last_updated: "2026-04-25"
+version: "2.5.0"
+---
+
+# Configure PII Detection and Redaction
+
+ZettelForge uses [Microsoft Presidio](https://github.com/microsoft/presidio) (open-source, MIT license) to detect and optionally redact PII (Personally Identifiable Information) from content before it is stored in the vector database and knowledge graph.
+
+PII detection is **disabled by default** with no new core dependencies. It is a fully optional feature -- `pip install zettelforge[pii]` activates it.
+
+## Prerequisites
+
+- ZettelForge installed
+- `pip install zettelforge[pii]` to install presidio-analyzer, presidio-anonymizer, and spaCy
+- About ~12-50 MB of disk space for the spaCy model (auto-downloads on first use)
+
+## How It Works
+
+Presidio runs **in-process** as a validation step inside `GovernanceValidator`, invoked before every `remember()` operation:
+
+```
+remember(content)
+  -> GovernanceValidator.validate_remember(content)
+    -> PIIValidator.validate(content)
+      -> presidio-analyzer scans for 20+ PII types
+    -> Returns (passed, processed_content, detections)
+  -> Returns processed_content (possibly redacted)
+-> MemoryStore.save(processed_content)
+```
+
+Three actions control what happens when PII is detected:
+
+| Action | Behavior | Use Case |
+|:-------|:---------|:---------|
+| `log` | Detect, log a warning, pass content through unchanged | Discovery -- see what PII is in your pipeline |
+| `redact` | Replace PII with `[REDACTED]` before storage | Compliance -- prevent PII persistence |
+| `block` | Raise an exception, storage is cancelled | Strict environments -- no PII allowed through |
+
+## Configuration
+
+Add a `pii:` section under `governance:` in your `config.yaml`:
+
+```yaml
+governance:
+  enabled: true
+  pii:
+    enabled: true       # enable PII detection
+    action: log          # log | redact | block
+    redact_placeholder: "[REDACTED]"
+    entities: []         # empty = all PII types
+    language: en
+    nlp_model: en_core_web_sm
+```
+
+### Entity Filtering
+
+The `entities` list lets you scope detection to specific PII types. When empty (default), all supported types are detected.
+
+Common entity types:
+
+| Entity | Example | Notes |
+|:-------|:--------|:------|
+| `EMAIL_ADDRESS` | `user@example.com` | Enables spam from phishing reports |
+| `PHONE_NUMBER` | `(555) 123-4567` | |
+| `PERSON` | `John Smith` | |
+| `CREDIT_CARD` | `4111-1111-1111-1111` | |
+| `SSN` | `123-45-6789` | |
+| `CRYPTO` | `1A1zP1eP5QGefi2DMP` | Bitcoin addresses |
+| `LOCATION` | `New York City` | |
+| `ORGANIZATION` | `Microsoft Corp` | |
+
+IP addresses, URLs, and domain names are **exempt from detection by default** -- these are legitimate CTI indicators (IOCs), not PII in the threat intelligence context. To include them, set `entities` explicitly:
+
+```yaml
+pii:
+  enabled: true
+  entities: ["IP_ADDRESS", "EMAIL_ADDRESS"]   # IPs will now be detected
+```
+
+## Example Configurations
+
+### 1. Log-Only (Discovery Mode)
+
+Use this first to understand what PII flows through your pipeline without changing any data:
+
+```yaml
+governance:
+  pii:
+    enabled: true
+    action: log
+```
+
+Every PII detection is logged as a structured `pii_detected` log event with count, entity types, and scores. Content is stored unchanged.
+
+### 2. Redact (Compliance Mode)
+
+Automatically replace PII with placeholders before storage:
+
+```yaml
+governance:
+  pii:
+    enabled: true
+    action: redact
+    redact_placeholder: "[PII REMOVED]"
+```
+
+The redacted content is what gets stored and indexed. The original content with PII is never persisted.
+
+### 3. Block (Strict Mode)
+
+Reject any content containing PII entirely:
+
+```yaml
+governance:
+  pii:
+    enabled: true
+    action: block
+```
+
+If PII is detected, `remember()` raises a `PIIBlockedError` and the operation is cancelled. The calling code receives the exception and can handle it (e.g., ask the user to retry without PII).
+
+### 4. Targeted Detection (Only Emails and Phones)
+
+Scope detection to specific entity types to reduce noise:
+
+```yaml
+governance:
+  pii:
+    enabled: true
+    action: redact
+    entities: ["EMAIL_ADDRESS", "PHONE_NUMBER"]
+```
+
+### 5. Complete Compliance Setup (FedRAMP-aligned)
+
+```yaml
+governance:
+  enabled: true
+  min_content_length: 1
+  pii:
+    enabled: true
+    action: redact
+    redact_placeholder: "[REDACTED]"
+    entities: []
+    language: en
+    nlp_model: en_core_web_sm
+```
+
+## Environment Variables
+
+| Variable | Maps To | Default |
+|:---------|:--------|:--------|
+| `ZETTELFORGE_PII_ENABLED` | `governance.pii.enabled` | `false` |
+| `ZETTELFORGE_PII_ACTION` | `governance.pii.action` | `log` |
+
+## spaCy Model Download
+
+The spaCy NLP model downloads automatically on the first `remember()` call after PII is enabled. The download is a one-time cost:
+
+| Model | Size | Speed | Notes |
+|:------|:-----|:------|:------|
+| `en_core_web_sm` | ~12 MB | Fast | Default. Good accuracy for standard PII |
+| `en_core_web_md` | ~40 MB | Medium | Better person/location disambiguation |
+| `en_core_web_lg` | ~560 MB | Slow | Best accuracy, word vectors |
+| `en_core_web_trf` | ~400 MB | Slowest | Transformer-based, best for context |
+
+To pre-download (recommended for air-gapped deployments):
+
+```bash
+python -m spacy download en_core_web_sm
+```
+
+## Verification
+
+After configuration, test that PII detection is working:
+
+```python
+from zettelforge import MemoryManager
+
+mm = MemoryManager()
+
+# This should trigger a PII warning if action=log
+note, status = mm.remember(
+    "Contact analyst John Smith at john@example.com or 555-1234 for details."
+)
+```
+
+With `action=log`, you will see a `pii_detected` structured log event.
+
+With `action=redact`, the stored content will have PII replaced:
+
+```python
+print(note.content.raw)
+# "Contact analyst [REDACTED] at [REDACTED] or [REDACTED] for details."
+```
+
+With `action=block`, `remember()` will raise `PIIBlockedError`.
+
+## Performance Impact
+
+- First call: ~2-3 seconds (spaCy model loading). Subsequent calls are fast.
+- Detection latency: ~50-200ms per `remember()` depending on content length and model size.
+- No network calls (all detection is local).
+- No impact when `governance.pii.enabled: false` (disabled by default).
+
+## Related
+
+- [Configuration Reference](../reference/configuration.md) -- all `config.yaml` keys
+- [Governance Controls](../reference/governance-controls.md) -- GOV-013 PII enforcement
+- [Microsoft Presidio](https://github.com/microsoft/presidio) -- upstream project
+- RFC-013: PII Detection and Redaction via Microsoft Presidio

--- a/docs/rfcs/RFC-013-presidio-pii-detection.md
+++ b/docs/rfcs/RFC-013-presidio-pii-detection.md
@@ -1,0 +1,517 @@
+# RFC-013: PII Detection and Redaction via Microsoft Presidio
+
+## Metadata
+
+- **Author**: Patrick Roland
+- **Status**: Draft
+- **Created**: 2026-04-25
+- **Last Updated**: 2026-04-25
+- **Reviewers**: TBD
+- **Related Tickets**: ZF-013
+- **Related RFCs**: RFC-002 (Universal LLM Provider), RFC-011 (Local LLM Backend), RFC-012 (LiteLLM Provider)
+
+## Summary
+
+Integrate Microsoft Presidio into ZettelForge for PII (Personally Identifiable Information) detection and redaction. Presidio runs as a governance check before `remember()` operations, scanning content for sensitive data (names, emails, phone numbers, IP addresses, credit cards, SSNs, and more) and applying configurable policies: log, redact, or block. The integration is scoped to the text ingestion path -- `remember()`, `remember_with_extraction()`, and `remember_report()` -- and is disabled by default with no new core dependencies.
+
+## Motivation
+
+ZettelForge stores threat intelligence content from analyst notes, reports, and agent exchanges. CTI workflows frequently handle data that may contain PII:
+
+- **Email addresses** and **IP addresses** from phishing reports and IOC collections
+- **Person names** in attribution analysis and journalist interviews
+- **Phone numbers** and **physical addresses** in incident response reports
+- **Organization names** that may identify individuals in small companies
+- **Internal hostnames** and **network identifiers** that could be PII in some jurisdictions
+
+Without PII detection, ZettelForge can silently store sensitive data in the vector database and knowledge graph, creating compliance liabilities under GDPR (Article 17 right to erasure), CCPA, and FedRAMP-required data minimization (SA-8, AC-6, AU-2).
+
+Presidio is the standard open-source PII detection SDK from Microsoft (MIT license, 7k+ GitHub stars, FedRAMP-aligned documentation). It provides:
+
+- **Pre-built recognizers** for 30+ PII types (PERSON, EMAIL_ADDRESS, PHONE_NUMBER, etc.) with regex + NLP (spaCy/transformers) scoring
+- **Context-aware detection** -- "John called" vs "John Doe residence" -- using NLP entity recognition
+- **Anonymization operators** -- redact, replace, hash, encrypt, mask
+- **Pluggable recognizers** -- custom CTI-specific recognizers (e.g., internal hostname patterns, project codenames that resemble person names)
+- **No external API calls** -- all detection runs locally via spaCy models (~50MB)
+
+### Who benefits
+
+- **SOC analysts** storing incident response notes with potential victim PII
+- **CTI teams** ingesting public and private threat reports that may contain personal data
+- **Compliance officers** requiring data minimization and right-to-erasure for threat intelligence stores
+- **FedRAMP/IL5 deployments** that mandate PII scanning before database writes
+
+## Proposed Design
+
+### Architecture
+
+Presidio integrates as a validation step in the governance layer, running before content is written to storage:
+
+```
+                +-------------------+
+                | User calls        |
+                | remember(content) |
+                +--------+----------+
+                         |
+                         v
+                +--------+----------+
+                | GovernanceValidator|
+                |   .validate()      |
+                +--------+----------+
+                         |
+                         v
+                +--------+----------+     +------------------+
+                | PIIValidator      |---->| presidio-analyzer |
+                | (NEW, configurable|     |   .analyze()      |
+                |  log/redact/block)|     +------------------+
+                +--------+----------+           |
+                         |                      v
+                         |              +------------------+
+                         |              | Result: list of   |
+                         |              | detected PII      |
+                         |              | entities          |
+                         |              +------------------+
+                         v
+                +--------+----------+
+                | Action dispatch:  |
+                | - log: warn only  |
+                | - redact: replace |
+                | - block: raise    |
+                +--------+----------+
+                         |
+                         v
+                +--------+----------+
+                | MemoryStore.save() |
+                +-------------------+
+```
+
+Key design: Presidio runs **in-process** via its Python SDK. No server process or external API required. The spaCy model (`en_core_web_sm`, ~12MB with word vectors, ~50MB with transformer) downloads on first use, same pattern as fastembed models.
+
+### Configuration
+
+New `governance.pii` section in `config.yaml`:
+
+```yaml
+governance:
+  enabled: true
+  min_content_length: 1
+  pii:
+    enabled: false                    # disabled by default; no new deps
+    action: log                       # log | redact | block
+    redact_placeholder: "[REDACTED]"  # replacement text when action=redact
+    entities: []                      # empty = all supported entities
+    # Example: only detect emails and phone numbers
+    # entities: ["EMAIL_ADDRESS", "PHONE_NUMBER"]
+    language: en                      # spaCy model language
+    nlp_model: en_core_web_sm         # spaCy model size (sm, md, lg, trf)
+```
+
+Example configs:
+
+```yaml
+# Log-only (discover what PII is flowing through)
+governance:
+  pii:
+    enabled: true
+    action: log
+
+# Redact all PII before storage
+governance:
+  pii:
+    enabled: true
+    action: redact
+    redact_placeholder: "[PII REMOVED]"
+
+# Block storage entirely if PII detected (strict)
+governance:
+  pii:
+    enabled: true
+    action: block
+
+# Only redact emails and phone numbers; allow names through
+governance:
+  pii:
+    enabled: true
+    action: redact
+    entities: ["EMAIL_ADDRESS", "PHONE_NUMBER"]
+
+# Complete compliance setup for FedRAMP
+governance:
+  enabled: true
+  min_content_length: 1
+  pii:
+    enabled: true
+    action: redact
+    redact_placeholder: "[REDACTED: {entity_type}]"
+```
+
+### Dataclass Changes
+
+```python
+# src/zettelforge/config.py
+
+@dataclass
+class PIIConfig:
+    """Presidio PII detection settings (RFC-013)."""
+    enabled: bool = False
+    action: str = "log"               # "log", "redact", "block"
+    redact_placeholder: str = "[REDACTED]"
+    entities: List[str] = field(default_factory=list)  # empty = all
+    language: str = "en"
+    nlp_model: str = "en_core_web_sm"
+
+
+@dataclass
+class GovernanceConfig:
+    enabled: bool = True
+    min_content_length: int = 1
+    pii: PIIConfig = field(default_factory=PIIConfig)  # NEW
+```
+
+### PIIValidator Design
+
+```python
+# src/zettelforge/pii_validator.py
+
+"""PII detection and redaction using Microsoft Presidio (RFC-013)."""
+
+from __future__ import annotations
+
+import logging
+import threading
+from dataclasses import dataclass
+from typing import Dict, List, Optional, Tuple
+
+from zettelforge.log import get_logger
+
+_logger = get_logger("zettelforge.pii")
+
+# Default placeholder per entity type
+_DEFAULT_PLACEHOLDER = "[REDACTED]"
+
+# Entity types we explicitly NEVER redact in CTI context
+# (these are threat intelligence identifiers, not PII)
+_CTI_ALLOWLIST = frozenset({
+    "IP_ADDRESS",          # IOC — IPs are threat data, not PII
+    "URL",                 # IOC — URLs are threat data
+})
+
+
+@dataclass
+class PIIDetection:
+    """A single PII detection result."""
+    entity_type: str
+    text: str
+    start: int
+    end: int
+    score: float
+
+
+class PIIValidator:
+    """Validates content for PII using Presidio.
+
+    Three modes of operation:
+    - ``log``: detect and log PII, pass content through unchanged
+    - ``redact``: replace detected PII with placeholders before returning
+    - ``block``: raise ``PIIBlockedError`` if ANY PII is detected
+
+    Thread-safe singleton per model. Models download on first use
+    (matching fastembed download pattern).
+    """
+
+    def __init__(
+        self,
+        action: str = "log",
+        placeholder: str = _DEFAULT_PLACEHOLDER,
+        entities: Optional[List[str]] = None,
+        language: str = "en",
+        nlp_model: str = "en_core_web_sm",
+    ) -> None:
+        if action not in ("log", "redact", "block"):
+            raise ValueError(f"Unknown PII action: {action!r}")
+        self._action = action
+        self._placeholder = placeholder
+        self._entities = (
+            [e for e in entities if e not in _CTI_ALLOWLIST]
+            if entities else None
+        )
+        self._language = language
+        self._nlp_model = nlp_model
+        self._analyzer: object = None
+        self._anonymizer: object = None
+        self._lock = threading.Lock()
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-load Presidio analyzer and download spaCy model if needed."""
+        if self._analyzer is not None:
+            return
+        with self._lock:
+            if self._analyzer is not None:
+                return
+            try:
+                from presidio_analyzer import AnalyzerEngine
+                from presidio_analyzer.nlp_engine import NlpEngineProvider
+            except ImportError as exc:
+                raise ImportError(
+                    "PII validation requires presidio-analyzer. "
+                    "Install with: pip install zettelforge[pii]"
+                ) from exc
+
+            configuration = {
+                "nlp_engine_name": "spacy",
+                "models": [
+                    {"lang_code": self._language, "model_name": self._nlp_model},
+                ],
+            }
+            provider = NlpEngineProvider(nlp_configuration=configuration)
+            nlp_engine = provider.create_engine()
+            self._analyzer = AnalyzerEngine(
+                nlp_engine=nlp_engine,
+                supported_languages=[self._language],
+            )
+            _logger.debug(
+                "pii_analyzer_loaded",
+                model=self._nlp_model,
+                language=self._language,
+            )
+
+    def detect(self, text: str) -> List[PIIDetection]:
+        """Analyze text and return detected PII entities.
+
+        Returns list of ``PIIDetection`` objects sorted by start position,
+        deduplicated by position (highest-score entity per position wins).
+        """
+        if not text or not text.strip():
+            return []
+        self._ensure_loaded()
+        results = self._analyzer.analyze(
+            text=text,
+            entities=self._entities,
+            language=self._language,
+        )
+        # Deduplicate: for overlapping spans, keep the highest score
+        span_map: Dict[Tuple[int, int], PIIDetection] = {}
+        for r in results:
+            key = (r.start, r.end)
+            existing = span_map.get(key)
+            if existing is None or r.score > existing.score:
+                span_map[key] = PIIDetection(
+                    entity_type=r.entity_type,
+                    text=text[r.start:r.end],
+                    start=r.start,
+                    end=r.end,
+                    score=r.score,
+                )
+        return sorted(span_map.values(), key=lambda d: d.start)
+
+    def validate(
+        self, content: str
+    ) -> Tuple[bool, str, List[PIIDetection]]:
+        """Validate content for PII.
+
+        Args:
+            content: Text to validate.
+
+        Returns:
+            Tuple of (passed, processed_content, detections).
+            ``passed`` is True if no PII was detected or action is not "block".
+            ``processed_content`` is the original content (for action="log"
+            or action="block") or redacted content (for action="redact").
+        """
+        detections = self.detect(content)
+        if not detections:
+            return True, content, []
+
+        # Log detections regardless of action
+        _logger.warning(
+            "pii_detected",
+            count=len(detections),
+            action=self._action,
+            entities=[
+                {"type": d.entity_type, "text": d.text, "score": round(d.score, 2)}
+                for d in detections
+            ],
+        )
+
+        if self._action == "redact":
+            redacted = self._redact(content, detections)
+            return True, redacted, detections
+
+        if self._action == "block":
+            types = ", ".join(sorted(set(d.entity_type for d in detections)))
+            raise PIIBlockedError(
+                f"Content blocked by PII validation: {len(detections)} "
+                f"detections of types [{types}]. "
+                f"Set governance.pii.action=log or governance.pii.action=redact "
+                f"to allow storage."
+            )
+
+        # action == "log": pass through
+        return True, content, detections
+
+    def _redact(self, text: str, detections: List[PIIDetection]) -> str:
+        """Redact detected PII (process in reverse to preserve positions)."""
+        # Build replacement map: entity_type -> placeholder
+        # This allows entity-type-specific messages if configured
+        result = list(text)
+        for d in reversed(detections):
+            result[d.start:d.end] = self._placeholder
+        return "".join(result)
+
+
+class PIIBlockedError(Exception):
+    """Raised when content is blocked by PII validation."""
+```
+
+### Integration into GovernanceValidator
+
+```python
+# Modified: src/zettelforge/governance_validator.py
+
+def __init__(self, governance_dir: Path = None, pii_config: Optional[PIIConfig] = None):
+    self.governance_dir = governance_dir
+    self.rules = self._load_governance_rules()
+    self._pii = None
+    if pii_config and pii_config.enabled:
+        try:
+            from zettelforge.pii_validator import PIIValidator
+            self._pii = PIIValidator(
+                action=pii_config.action,
+                placeholder=pii_config.redact_placeholder,
+                entities=pii_config.entities,
+                language=pii_config.language,
+                nlp_model=pii_config.nlp_model,
+            )
+        except ImportError:
+            _logger.warning("pii_validator_unavailable")
+
+
+def validate_remember(self, content: str) -> str:
+    """Validate content for remember(). Returns (possibly redacted) content."""
+    if self._pii:
+        passed, processed, detections = self._pii.validate(content)
+        if not passed:
+            raise GovernanceViolationError(
+                f"PII validation blocked content: {len(detections)} detections"
+            )
+        return processed
+    return content
+```
+
+### Presidio Recognizers
+
+Presidio ships with these built-in recognizers. Only those NOT in `_CTI_ALLOWLIST` are activated by default:
+
+| PII Entity Type | Example | Default? | Notes |
+|:----------------|:--------|:---------|:------|
+| PERSON | John Smith | yes | |
+| EMAIL_ADDRESS | user@example.com | yes | |
+| PHONE_NUMBER | (555) 123-4567 | yes | |
+| CREDIT_CARD | 4111-1111-1111-1111 | yes | |
+| SSN | 123-45-6789 | yes | |
+| CRYPTO | 1A1zP1eP5QGefi2DMPTfTL5SLmv7DivfNa | yes | Bitcoin addresses |
+| DATE_TIME | April 25, 2026 | yes | |
+| LOCATION | New York City | yes | |
+| ORGANIZATION | Microsoft Corp | yes | |
+| IP_ADDRESS | 10.0.0.1 | **explicitly allowed** | CTI IOC data |
+| URL | https://evil.com | **explicitly allowed** | CTI IOC data |
+
+The `_CTI_ALLOWLIST` protects IP_ADDRESS and URL from redaction since those are common CTI indicators, not PII in the CTI context.
+
+### Package Extras
+
+```toml
+# pyproject.toml addition
+
+[project.optional-dependencies]
+# PII detection via Microsoft Presidio (RFC-013)
+pii = [
+    "presidio-analyzer>=2.2.0",
+    "presidio-anonymizer>=2.2.0",
+    "spacy>=3.5.0",
+]
+```
+
+### Env Override
+
+```python
+# In _apply_env():
+if v := os.environ.get("ZETTELFORGE_PII_ENABLED"):
+    cfg.governance.pii.enabled = v.lower() in ("true", "1", "yes")
+if v := os.environ.get("ZETTELFORGE_PII_ACTION"):
+    cfg.governance.pii.action = v
+```
+
+### File Changes
+
+| File | Change |
+|------|--------|
+| `src/zettelforge/pii_validator.py` | **Create** -- PIIValidator, PIIDetection, PIIBlockedError |
+| `src/zettelforge/config.py` | Add `PIIConfig` dataclass; add `pii` field to `GovernanceConfig`; add env overrides |
+| `src/zettelforge/governance_validator.py` | Integrate PIIValidator into `validate_remember()` |
+| `src/zettelforge/memory_manager.py` | Call governance with returned (possibly redacted) content |
+| `pyproject.toml` | Add `pii` optional dependency extra |
+| `config.default.yaml` | Document `governance.pii` section |
+| `docs/reference/configuration.md` | Document PII settings |
+| `docs/reference/governance-controls.md` | Update with PII governance controls |
+| `docs/how-to/configure-pii.md` | **Create** -- PII setup guide |
+| `tests/test_pii_validator.py` | **Create** -- unit tests |
+| `tests/test_governance_pii.py` | **Create** -- integration tests |
+
+## Implementation Plan
+
+### Phase 1: Core PIIValidator + Integration (v2.5.0)
+
+1. Create `src/zettelforge/pii_validator.py` with PIIValidator, PIIDetection, PIIBlockedError.
+2. Add `PIIConfig` dataclass to `config.py`.
+3. Add `pii` field to `GovernanceConfig`.
+4. Integrate PIIValidator into `GovernanceValidator.validate_remember()`.
+5. Wire `governance.validate_remember()` into `memory_manager.remember()` so redacted content is what gets stored.
+6. Add `pii` optional extra to `pyproject.toml`.
+7. Add env overrides in `_apply_env()`.
+8. Write unit tests: detection, redaction, blocking, CTI allowlist, no-PII passthrough.
+
+### Phase 2: Documentation + CTI Custom Recognizers (v2.5.0)
+
+1. Create `docs/how-to/configure-pii.md`.
+2. Update `config.default.yaml` with examples.
+3. Update `docs/reference/configuration.md`.
+4. Update `docs/reference/governance-controls.md`.
+5. (Optional) Add custom Presidio recognizer for CTI-specific patterns (project codenames, internal hostname formats).
+
+## Rollout Strategy
+
+**Phase 1** (v2.5.0): Disabled by default (`governance.pii.enabled: false`). Zero impact on existing installations. `pip install zettelforge[pii]` to enable. spaCy model downloads on first detection (~12-50MB depending on model size).
+
+**Rollback:** Set `governance.pii.enabled: false` (or remove from config). No data impact -- redacted content is the only persistent effect.
+
+**Observability:** Every PII detection logs structured event `pii_detected` with count, action, and entity type summary. Redactions and blocks leave audit trail.
+
+## Alternatives Considered
+
+**Alternative 1: Cloud-based PII detection (AWS Comprehend, Azure AI Content Safety).** Rejected because: (a) requires network access and API keys; (b) sends content to third-party servers, which may violate data sovereignty requirements; (c) adds per-operation cost; (d) incompatible with air-gapped deployments.
+
+**Alternative 2: Regex-only PII detection.** Rejected because: (a) high false-positive rate for person names and organizations; (b) no context awareness ("Paris" = location vs "Paris Hilton" = person); (c) Presidio already includes regex patterns with NLP context scoring, so building it ourselves is wasted effort.
+
+**Alternative 3: Post-storage PII scanning (async).** Rejected because: (a) PII may be stored before the async scanner runs, violating right-to-erasure principles; (b) vector database compaction after removal is expensive; (c) synchronous pre-storage validation is the simpler, safer pattern.
+
+**Alternative 4: Require presidio-analyzer as a core dependency.** Rejected because: (a) adds ~50MB of spaCy model download for users who don't need PII detection; (b) follows the optional-extra pattern established by `local`, `local-onnx`, and `litellm`.
+
+## Open Questions
+
+1. **Should IP_ADDRESS be in the CTI allowlist by default?** Yes -- IPs are threat intelligence indicators, not PII in the CTI context. Users who need IP redaction can override `entities` to include `IP_ADDRESS`.
+
+2. **Should the spaCy model be pinned or auto-download?** Auto-download on first use, matching the fastembed pattern. The download is a one-time cost (~12MB for `en_core_web_sm`).
+
+3. **Should Presidio's `score` threshold be configurable?** Presidio returns scores (0.0-1.0). The default threshold is 0.5. This can be exposed via config in a follow-up if false positives are an issue.
+
+4. **Should we add custom CTI recognizers?** In scope for Phase 2. Common CTI patterns like "UNC1234", "APT28", or "CVE-2025-12345" could be falsely detected as PII by generic models. Custom recognizers to explicitly allow these would reduce false positives.
+
+5. **What about images?** Presidio Image Redactor is out of scope for v1. ZettelForge does not currently store images. If image support is added, image PII redaction will need its own RFC.
+
+## Decision
+
+**Decision**: [Pending review]
+**Date**: [Pending]
+**Decision Maker**: [Pending]
+**Rationale**: [Pending]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -71,6 +71,16 @@ litellm = [
     "litellm>=1.60.0",
 ]
 
+# PII detection via Microsoft Presidio (RFC-013, optional)
+# pip install zettelforge[pii]
+# Enables governance.pii section in config. Automatically downloads
+# a spaCy model (~12MB) on first use.
+pii = [
+    "presidio-analyzer>=2.2.0",
+    "presidio-anonymizer>=2.2.0",
+    "spacy>=3.5.0",
+]
+
 # Extensions: install the separate zettelforge-enterprise package
 # pip install zettelforge-enterprise
 extensions = [

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -16,6 +16,8 @@ Usage:
     cfg.retrieval.default_k  # 10
 """
 
+from __future__ import annotations
+
 import contextlib
 import os
 import re
@@ -38,7 +40,7 @@ def _resolve_env_refs(value: str) -> str:
     rather than silently shipping the literal ``${...}`` token.
     """
 
-    def _replace(match: "re.Match[str]") -> str:
+    def _replace(match: re.Match[str]) -> str:
         var_name = match.group(1)
         env_value = os.environ.get(var_name)
         if env_value is None:

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -183,7 +183,7 @@ class PIIConfig:
     enabled: bool = False
     action: str = "log"
     redact_placeholder: str = "[REDACTED]"
-    entities: List[str] = field(default_factory=list)
+    entities: list[str] = field(default_factory=list)
     language: str = "en"
     nlp_model: str = "en_core_web_sm"
 

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -165,9 +165,34 @@ class SynthesisConfig:
 
 
 @dataclass
+class PIIConfig:
+    """Presidio PII detection settings (RFC-013, optional).
+
+    Disabled by default -- no new core dependencies. Requires
+    ``pip install zettelforge[pii]`` to activate.
+
+    ``action`` can be ``"log"`` (warn only, pass through),
+    ``"redact"`` (replace PII with placeholders), or
+    ``"block"`` (raise exception before storage).
+    ``entities``: empty list = detect all supported PII types.
+    ``_CTI_ALLOWLIST`` in ``pii_validator.py`` excludes IP_ADDRESS,
+    URL, and DOMAIN_NAME from detection since these are legitimate
+    CTI indicators.
+    """
+
+    enabled: bool = False
+    action: str = "log"
+    redact_placeholder: str = "[REDACTED]"
+    entities: List[str] = field(default_factory=list)
+    language: str = "en"
+    nlp_model: str = "en_core_web_sm"
+
+
+@dataclass
 class GovernanceConfig:
     enabled: bool = True
     min_content_length: int = 1
+    pii: PIIConfig = field(default_factory=PIIConfig)
 
 
 @dataclass
@@ -450,6 +475,12 @@ def _apply_env(cfg: ZettelForgeConfig):
     # LLM NER
     if v := os.environ.get("ZETTELFORGE_LLM_NER_ENABLED"):
         cfg.llm_ner.enabled = v.lower() in ("true", "1", "yes")
+
+    # RFC-013: PII detection via Presidio
+    if v := os.environ.get("ZETTELFORGE_PII_ENABLED"):
+        cfg.governance.pii.enabled = v.lower() in ("true", "1", "yes")
+    if v := os.environ.get("ZETTELFORGE_PII_ACTION"):
+        cfg.governance.pii.action = v
 
     # Extensions license key (used by zettelforge-enterprise fallback path)
     if v := os.environ.get("THREATENGRAM_LICENSE_KEY"):

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -389,7 +389,14 @@ def _apply_yaml(cfg: ZettelForgeConfig, data: dict):
 
     if "governance" in data and isinstance(data["governance"], dict):
         for k, v in data["governance"].items():
-            if hasattr(cfg.governance, k):
+            if not hasattr(cfg.governance, k):
+                continue
+            # RFC-013: pii is a nested dataclass, not a flat value
+            if k == "pii" and isinstance(v, dict):
+                for pk, pv in v.items():
+                    if hasattr(cfg.governance.pii, pk):
+                        setattr(cfg.governance.pii, pk, pv)
+            else:
                 setattr(cfg.governance, k, v)
 
     if "cache" in data and isinstance(data["cache"], dict):

--- a/src/zettelforge/governance_validator.py
+++ b/src/zettelforge/governance_validator.py
@@ -119,6 +119,14 @@ class GovernanceValidator:
                     hint="Install with: pip install zettelforge[pii]",
                 )
                 return content
+            except GovernanceViolationError:
+                raise
+            except Exception as exc:
+                # PIIBlockedError and any other non-recoverable PII error
+                # is converted to GovernanceViolationError so the caller
+                # (memory_manager._remember_inner) catches it via its
+                # existing except GovernanceViolationError handler.
+                raise GovernanceViolationError(f"PII validation failed: {exc}") from exc
             if not passed:
                 raise GovernanceViolationError(
                     f"PII validation blocked content: {len(detections)} detections"

--- a/src/zettelforge/governance_validator.py
+++ b/src/zettelforge/governance_validator.py
@@ -12,7 +12,7 @@ no new core dependencies. Requires ``pip install zettelforge[pii]`` and
 from __future__ import annotations
 
 from pathlib import Path
-from typing import TYPE_CHECKING, Any, Optional
+from typing import TYPE_CHECKING, Any
 
 from zettelforge.log import get_logger
 
@@ -34,7 +34,7 @@ class GovernanceValidator:
     def __init__(
         self,
         governance_dir: Path | None = None,
-        pii_config: Optional["PIIConfig"] = None,
+        pii_config: PIIConfig | None = None,
     ):
         self.governance_dir = governance_dir
         self.rules = self._load_governance_rules()

--- a/src/zettelforge/governance_validator.py
+++ b/src/zettelforge/governance_validator.py
@@ -2,28 +2,75 @@
 Governance Validator for ZettelForge
 
 Automatically validates operations against our governance documentation
-(GOV-003, GOV-007, GOV-011, etc.).
+(GOV-003, GOV-007, GOV-011, GOV-012, and GOV-013 for PII).
+
+PII validation via Microsoft Presidio is optional -- disabled by default,
+no new core dependencies. Requires ``pip install zettelforge[pii]`` and
+``governance.pii.enabled: true`` in config.
 """
 
+from __future__ import annotations
+
 from pathlib import Path
-from typing import Any
+from typing import TYPE_CHECKING, Any, Optional
+
+from zettelforge.log import get_logger
+
+if TYPE_CHECKING:
+    from zettelforge.config import PIIConfig
+
+_logger = get_logger("zettelforge.governance")
 
 
 class GovernanceValidator:
     """
     Validates ZettelForge operations against governance rules.
+
+    When ``pii_config`` is provided and enabled, PIIValidator is loaded
+    lazily (soft dependency on presidio-analyzer). The core package never
+    hard-depends on it.
     """
 
-    def __init__(self, governance_dir: Path | None = None):
+    def __init__(
+        self,
+        governance_dir: Path | None = None,
+        pii_config: Optional["PIIConfig"] = None,
+    ):
         self.governance_dir = governance_dir
         self.rules = self._load_governance_rules()
+        self._pii = None
+
+        # RFC-013: Optional PII validator. If the config says enabled but
+        # presidio-analyzer is not installed, log a warning and continue --
+        # no core functionality breaks.
+        if pii_config and pii_config.enabled:
+            try:
+                from zettelforge.pii_validator import PIIValidator
+
+                self._pii = PIIValidator(
+                    action=pii_config.action,
+                    placeholder=pii_config.redact_placeholder,
+                    entities=pii_config.entities,
+                    language=pii_config.language,
+                    nlp_model=pii_config.nlp_model,
+                )
+                _logger.info("pii_validator_loaded", action=pii_config.action)
+            except ImportError:
+                _logger.warning(
+                    "pii_validator_unavailable",
+                    hint="Install with: pip install zettelforge[pii]",
+                )
 
     def _load_governance_rules(self) -> dict:
         """Load key governance rules relevant to memory operations."""
         rules = {
             "GOV-003": {"python_standards": True, "type_hints": True, "naming": True},
             "GOV-007": {"testing": True, "coverage": 0.8},
-            "GOV-011": {"security": True, "input_validation": True, "no_hardcoded_secrets": True},
+            "GOV-011": {
+                "security": True,
+                "input_validation": True,
+                "no_hardcoded_secrets": True,
+            },
             "GOV-012": {"observability": True, "structured_logging": True},
         }
         return rules
@@ -36,17 +83,73 @@ class GovernanceValidator:
         """
         violations = []
 
-        if operation == "remember" and not isinstance(data, str) and not hasattr(data, "content"):
-            violations.append("GOV-011: Input validation required for memory storage")
+        if operation == "remember":
+            if not isinstance(data, str) and not hasattr(data, "content"):
+                violations.append("GOV-011: Input validation required for memory storage")
+
+            if "GOV-012" in self.rules:
+                pass  # Should log operation (placeholder)
 
         is_valid = len(violations) == 0
         return is_valid, violations
 
-    def enforce(self, operation: str, data: Any = None) -> None:
-        """Enforce governance - raises exception on violation."""
+    def validate_remember(self, content: str) -> str:
+        """Validate content for remember().
+
+        Runs governance rules and optional PII detection.
+        If PII is configured with action=redact, returns redacted content.
+        If PII is configured with action=block and PII found, raises.
+
+        Returns:
+            Content safe to store (possibly redacted).
+        """
+        # Base governance validation
+        is_valid, violations = self.validate_operation("remember", content)
+        if not is_valid:
+            raise GovernanceViolationError(f"Governance violation in remember: {violations}")
+
+        # RFC-013: Optional PII validation
+        if self._pii is not None:
+            try:
+                passed, processed, detections = self._pii.validate(content)
+            except ImportError:
+                # presidio-analyzer not installed -- skip PII gracefully
+                _logger.warning(
+                    "pii_validation_skipped",
+                    hint="Install with: pip install zettelforge[pii]",
+                )
+                return content
+            if not passed:
+                raise GovernanceViolationError(
+                    f"PII validation blocked content: {len(detections)} detections"
+                )
+            if detections:
+                _logger.info(
+                    "pii_validation_applied",
+                    action=self._pii._action,
+                    count=len(detections),
+                )
+            return processed
+
+        return content
+
+    def enforce(self, operation: str, data: Any = None) -> str:
+        """Enforce governance.
+
+        For ``remember`` operations, returns (possibly redacted) content.
+        For other operations, returns the original data.
+        Raises GovernanceViolationError on violations.
+        """
+        if operation == "remember":
+            if isinstance(data, str):
+                return self.validate_remember(data)
+            return data
+
+        # Fallback for non-remember operations
         is_valid, violations = self.validate_operation(operation, data)
         if not is_valid:
             raise GovernanceViolationError(f"Governance violation in {operation}: {violations}")
+        return data if isinstance(data, str) else ""
 
 
 class GovernanceViolationError(Exception):

--- a/src/zettelforge/governance_validator.py
+++ b/src/zettelforge/governance_validator.py
@@ -140,15 +140,15 @@ class GovernanceValidator:
         For other operations, returns the original data.
         Raises GovernanceViolationError on violations.
         """
-        if operation == "remember":
-            if isinstance(data, str):
-                return self.validate_remember(data)
-            return data
-
-        # Fallback for non-remember operations
+        # Always run the structural validation first so callers that pass
+        # invalid data (e.g. ``None``) get a GovernanceViolationError, not a
+        # silently-returned ``None`` or a ``TypeError`` deeper in the pipeline.
         is_valid, violations = self.validate_operation(operation, data)
         if not is_valid:
             raise GovernanceViolationError(f"Governance violation in {operation}: {violations}")
+
+        if operation == "remember" and isinstance(data, str):
+            return self.validate_remember(data)
         return data if isinstance(data, str) else ""
 
 

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -113,7 +113,9 @@ class MemoryManager:
             memory_store=self._lance_store,
             note_lookup=lambda nid: self.store.get_note_by_id(nid),
         )
-        self.governance = GovernanceValidator()
+        self.governance = GovernanceValidator(
+            pii_config=get_config().governance.pii,
+        )
         self.resolver = AliasResolver()
         self.consolidation = ConsolidationMiddleware(self)
 
@@ -220,9 +222,9 @@ class MemoryManager:
         start: float,
     ) -> tuple[MemoryNote, str]:
         """Inner body of remember(); split out so trace_id binding can wrap it."""
-        # Governance validation
+        # Governance validation (may return redacted content when PII is enabled)
         try:
-            self.governance.enforce("remember", content)
+            content = self.governance.enforce("remember", content)
             log_authorization(
                 actor="system",
                 resource="remember",

--- a/src/zettelforge/pii_validator.py
+++ b/src/zettelforge/pii_validator.py
@@ -13,8 +13,7 @@ config. The core package never hard-depends on ``presidio-analyzer`` or
 from __future__ import annotations
 
 import threading
-from dataclasses import dataclass, field
-from typing import Dict, List, Optional, Tuple
+from dataclasses import dataclass
 
 from zettelforge.log import get_logger
 
@@ -59,7 +58,7 @@ class PIIValidator:
         self,
         action: str = "log",
         placeholder: str = "[REDACTED]",
-        entities: Optional[List[str]] = None,
+        entities: list[str] | None = None,
         language: str = "en",
         nlp_model: str = "en_core_web_sm",
     ) -> None:
@@ -68,7 +67,7 @@ class PIIValidator:
         self._action = action
         self._placeholder = placeholder
         # Filter out CTI allowlisted entities unless user explicitly included them
-        self._entities: Optional[List[str]] = None
+        self._entities: list[str] | None = None
         if entities is not None:
             self._entities = [e for e in entities if e not in _CTI_ALLOWLIST]
         self._language = language
@@ -110,7 +109,7 @@ class PIIValidator:
                 language=self._language,
             )
 
-    def detect(self, text: str) -> List[PIIDetection]:
+    def detect(self, text: str) -> list[PIIDetection]:
         """Analyze text and return detected PII entities.
 
         Results are sorted by start position and deduplicated by span
@@ -125,7 +124,7 @@ class PIIValidator:
             language=self._language,
         )
         # Deduplicate overlapping spans: keep highest score per (start, end)
-        span_map: Dict[Tuple[int, int], PIIDetection] = {}
+        span_map: dict[tuple[int, int], PIIDetection] = {}
         for r in results:
             key = (r.start, r.end)
             existing = span_map.get(key)
@@ -139,7 +138,7 @@ class PIIValidator:
                 )
         return sorted(span_map.values(), key=lambda d: d.start)
 
-    def validate(self, content: str) -> Tuple[bool, str, List[PIIDetection]]:
+    def validate(self, content: str) -> tuple[bool, str, list[PIIDetection]]:
         """Validate content for PII.
 
         Args:
@@ -180,7 +179,7 @@ class PIIValidator:
         # action == "log": warn only, pass through unchanged
         return True, content, detections
 
-    def _redact(self, text: str, detections: List[PIIDetection]) -> str:
+    def _redact(self, text: str, detections: list[PIIDetection]) -> str:
         """Replace detected PII spans with placeholders (reverse-order safe)."""
         result = list(text)
         for d in reversed(detections):

--- a/src/zettelforge/pii_validator.py
+++ b/src/zettelforge/pii_validator.py
@@ -1,0 +1,192 @@
+"""PII detection and redaction using Microsoft Presidio (RFC-013).
+
+Optional integration with ``GovernanceValidator``. When enabled via config,
+scans content for PII before ``remember()`` operations and applies the
+configured action (``log``, ``redact``, or ``block``).
+
+This module is NOT imported at package init time. It is loaded lazily by
+``GovernanceValidator`` only when ``governance.pii.enabled = true`` in
+config. The core package never hard-depends on ``presidio-analyzer`` or
+``spacy``.
+"""
+
+from __future__ import annotations
+
+import threading
+from dataclasses import dataclass, field
+from typing import Dict, List, Optional, Tuple
+
+from zettelforge.log import get_logger
+
+_logger = get_logger("zettelforge.pii")
+
+
+# PII entity types that are legitimate CTI indicators and should NOT be
+# redacted by default. Users can override by specifying explicit entities.
+_CTI_ALLOWLIST = frozenset(
+    {
+        "IP_ADDRESS",  # IOC — threat data, not PII
+        "URL",  # IOC — threat data, not PII
+        "DOMAIN_NAME",  # IOC — threat data, not PII
+    }
+)
+
+
+@dataclass
+class PIIDetection:
+    """A single PII detection result."""
+
+    entity_type: str
+    text: str
+    start: int
+    end: int
+    score: float
+
+
+class PIIValidator:
+    """Validates content for PII using Microsoft Presidio.
+
+    Three actions:
+        ``log`` (default) — detect and warn, pass content through unchanged.
+        ``redact`` — replace detected PII with placeholders.
+        ``block`` — raise :class:`PIIBlockedError` if ANY PII is detected.
+
+    Thread-safe. Lazily loads Presidio + spaCy model on first call.
+    The model downloads automatically (matching fastembed download pattern).
+    """
+
+    def __init__(
+        self,
+        action: str = "log",
+        placeholder: str = "[REDACTED]",
+        entities: Optional[List[str]] = None,
+        language: str = "en",
+        nlp_model: str = "en_core_web_sm",
+    ) -> None:
+        if action not in ("log", "redact", "block"):
+            raise ValueError(f"Unknown PII action: {action!r}")
+        self._action = action
+        self._placeholder = placeholder
+        # Filter out CTI allowlisted entities unless user explicitly included them
+        self._entities: Optional[List[str]] = None
+        if entities is not None:
+            self._entities = [e for e in entities if e not in _CTI_ALLOWLIST]
+        self._language = language
+        self._nlp_model = nlp_model
+        self._analyzer: object = None
+        self._lock = threading.Lock()
+
+    def _ensure_loaded(self) -> None:
+        """Lazy-load Presidio analyzer (downloads spaCy model on first call)."""
+        if self._analyzer is not None:
+            return
+        with self._lock:
+            if self._analyzer is not None:
+                return
+            try:
+                from presidio_analyzer import AnalyzerEngine
+                from presidio_analyzer.nlp_engine import NlpEngineProvider
+            except ImportError as exc:
+                raise ImportError(
+                    "PII validation requires presidio-analyzer. "
+                    "Install with: pip install zettelforge[pii]"
+                ) from exc
+
+            configuration = {
+                "nlp_engine_name": "spacy",
+                "models": [
+                    {"lang_code": self._language, "model_name": self._nlp_model},
+                ],
+            }
+            provider = NlpEngineProvider(nlp_configuration=configuration)
+            nlp_engine = provider.create_engine()
+            self._analyzer = AnalyzerEngine(
+                nlp_engine=nlp_engine,
+                supported_languages=[self._language],
+            )
+            _logger.debug(
+                "pii_analyzer_loaded",
+                model=self._nlp_model,
+                language=self._language,
+            )
+
+    def detect(self, text: str) -> List[PIIDetection]:
+        """Analyze text and return detected PII entities.
+
+        Results are sorted by start position and deduplicated by span
+        (highest-score entity wins for overlapping positions).
+        """
+        if not text or not text.strip():
+            return []
+        self._ensure_loaded()
+        results = self._analyzer.analyze(
+            text=text,
+            entities=self._entities,
+            language=self._language,
+        )
+        # Deduplicate overlapping spans: keep highest score per (start, end)
+        span_map: Dict[Tuple[int, int], PIIDetection] = {}
+        for r in results:
+            key = (r.start, r.end)
+            existing = span_map.get(key)
+            if existing is None or r.score > existing.score:
+                span_map[key] = PIIDetection(
+                    entity_type=r.entity_type,
+                    text=text[r.start : r.end],
+                    start=r.start,
+                    end=r.end,
+                    score=r.score,
+                )
+        return sorted(span_map.values(), key=lambda d: d.start)
+
+    def validate(self, content: str) -> Tuple[bool, str, List[PIIDetection]]:
+        """Validate content for PII.
+
+        Args:
+            content: Text to validate.
+
+        Returns:
+            Tuple of (passed, processed_content, detections).
+            ``passed`` is True when action is not ``block`` or no PII found.
+            ``processed_content`` is the original content (for ``log`` /
+            ``block``) or redacted content (for ``redact``).
+        """
+        detections = self.detect(content)
+        if not detections:
+            return True, content, []
+
+        _logger.warning(
+            "pii_detected",
+            count=len(detections),
+            action=self._action,
+            entities=[
+                {"type": d.entity_type, "text": d.text, "score": round(d.score, 2)}
+                for d in detections
+            ],
+        )
+
+        if self._action == "redact":
+            return True, self._redact(content, detections), detections
+
+        if self._action == "block":
+            types = ", ".join(sorted(set(d.entity_type for d in detections)))
+            raise PIIBlockedError(
+                f"Content blocked by PII validation: {len(detections)} "
+                f"detections of types [{types}]. "
+                f"Set governance.pii.action=log or governance.pii.action=redact "
+                f"to allow storage."
+            )
+
+        # action == "log": warn only, pass through unchanged
+        return True, content, detections
+
+    def _redact(self, text: str, detections: List[PIIDetection]) -> str:
+        """Replace detected PII spans with placeholders (reverse-order safe)."""
+        result = list(text)
+        for d in reversed(detections):
+            result[d.start : d.end] = self._placeholder
+        return "".join(result)
+
+
+class PIIBlockedError(Exception):
+    """Raised when content is blocked by PII validation (action=block)."""

--- a/src/zettelforge/pii_validator.py
+++ b/src/zettelforge/pii_validator.py
@@ -24,9 +24,9 @@ _logger = get_logger("zettelforge.pii")
 # redacted by default. Users can override by specifying explicit entities.
 _CTI_ALLOWLIST = frozenset(
     {
-        "IP_ADDRESS",  # IOC — threat data, not PII
-        "URL",  # IOC — threat data, not PII
-        "DOMAIN_NAME",  # IOC — threat data, not PII
+        "IP_ADDRESS",  # IOC -- threat data, not PII
+        "URL",  # IOC -- threat data, not PII
+        "DOMAIN_NAME",  # IOC -- threat data, not PII
     }
 )
 
@@ -46,9 +46,9 @@ class PIIValidator:
     """Validates content for PII using Microsoft Presidio.
 
     Three actions:
-        ``log`` (default) — detect and warn, pass content through unchanged.
-        ``redact`` — replace detected PII with placeholders.
-        ``block`` — raise :class:`PIIBlockedError` if ANY PII is detected.
+        ``log`` (default) -- detect and warn, pass content through unchanged.
+        ``redact`` -- replace detected PII with placeholders.
+        ``block`` -- raise :class:`PIIBlockedError` if ANY PII is detected.
 
     Thread-safe. Lazily loads Presidio + spaCy model on first call.
     The model downloads automatically (matching fastembed download pattern).
@@ -66,10 +66,10 @@ class PIIValidator:
             raise ValueError(f"Unknown PII action: {action!r}")
         self._action = action
         self._placeholder = placeholder
-        # Filter out CTI allowlisted entities unless user explicitly included them
-        self._entities: list[str] | None = None
-        if entities is not None:
-            self._entities = [e for e in entities if e not in _CTI_ALLOWLIST]
+        # Presidio semantics: entities=[] means "detect none", entities=None
+        # means "detect all supported types". The PIIConfig default is []
+        # (meaning "all"), so convert empty list to None here.
+        self._entities: list[str] | None = entities if entities else None
         self._language = language
         self._nlp_model = nlp_model
         self._analyzer: object = None
@@ -112,31 +112,59 @@ class PIIValidator:
     def detect(self, text: str) -> list[PIIDetection]:
         """Analyze text and return detected PII entities.
 
-        Results are sorted by start position and deduplicated by span
-        (highest-score entity wins for overlapping positions).
+        Results are sorted by start position. Overlapping spans are
+        resolved: the longest span wins when one fully contains another;
+        otherwise the highest-score entity wins per exact position.
         """
         if not text or not text.strip():
             return []
         self._ensure_loaded()
+
+        # Apply CTI allowlist at detect time: when entities=None (detect
+        # all), exclude allowlisted types from results. When user explicitly
+        # provides entities, honour that list exactly.
+        passed_to_analyzer = self._entities
+
         results = self._analyzer.analyze(
             text=text,
-            entities=self._entities,
+            entities=passed_to_analyzer,
             language=self._language,
         )
-        # Deduplicate overlapping spans: keep highest score per (start, end)
-        span_map: dict[tuple[int, int], PIIDetection] = {}
+
+        # Resolve overlapping spans: longest span wins when one contains
+        # another (the longer span is more precise for redaction). For
+        # equal-length spans, highest score wins.
+        raw: list[PIIDetection] = []
         for r in results:
-            key = (r.start, r.end)
-            existing = span_map.get(key)
-            if existing is None or r.score > existing.score:
-                span_map[key] = PIIDetection(
+            # Filter CTI allowlist at detect time when in detect-all mode
+            if self._entities is None and r.entity_type in _CTI_ALLOWLIST:
+                continue
+            raw.append(
+                PIIDetection(
                     entity_type=r.entity_type,
                     text=text[r.start : r.end],
                     start=r.start,
                     end=r.end,
                     score=r.score,
                 )
-        return sorted(span_map.values(), key=lambda d: d.start)
+            )
+
+        # Span resolution: sort by length desc, then score desc.
+        # Take each non-overlapping span greedily.
+        raw.sort(key=lambda d: (d.end - d.start, d.score), reverse=True)
+
+        selected: list[PIIDetection] = []
+        for d in raw:
+            # Check if this span overlaps any already-selected span
+            overlaps = False
+            for s in selected:
+                if d.start < s.end and d.end > s.start:
+                    overlaps = True
+                    break
+            if not overlaps:
+                selected.append(d)
+
+        return sorted(selected, key=lambda d: d.start)
 
     def validate(self, content: str) -> tuple[bool, str, list[PIIDetection]]:
         """Validate content for PII.
@@ -158,10 +186,9 @@ class PIIValidator:
             "pii_detected",
             count=len(detections),
             action=self._action,
-            entities=[
-                {"type": d.entity_type, "text": d.text, "score": round(d.score, 2)}
-                for d in detections
-            ],
+            # Log entity types and scores only -- never log the actual
+            # detected text to avoid PII leakage into structured logs.
+            entities=[{"type": d.entity_type, "score": round(d.score, 2)} for d in detections],
         )
 
         if self._action == "redact":

--- a/tests/test_pii_validator.py
+++ b/tests/test_pii_validator.py
@@ -223,10 +223,12 @@ class TestGovernanceValidatorPII:
         except ImportError:
             pass
 
-    def test_validate_remember_rejects_empty_string(self):
+    def test_validate_remember_rejects_invalid_data(self):
+        """``remember`` data that is neither a string nor an object with
+        ``.content`` should fail GOV-011 input validation and raise."""
         gv = GovernanceValidator()
         with pytest.raises(GovernanceViolationError):
-            gv.enforce("synthesize", {"bad": "data"})
+            gv.enforce("remember", {"bad": "data"})
 
     def test_remember_enforce_passes_through_no_pii(self):
         """enforce() must return original content when PII is disabled."""
@@ -288,14 +290,17 @@ def _patch_presidio():
             self.score = score
             self._text = text
 
-    class _StubNlpEngine:
-        class _StubNlpArtifacts:
-            pass
-
     pkg.RecognizerResult = _StubRecognizerResult
 
+    # The submodule `presidio_analyzer.nlp_engine` must be a Module so that
+    # `from presidio_analyzer.nlp_engine import NlpEngineProvider` resolves
+    # NlpEngineProvider as a module attribute. Using a class here breaks
+    # the import in pii_validator.py.
+    nlp_engine_pkg = types.ModuleType("presidio_analyzer.nlp_engine")
+    nlp_engine_pkg.NlpEngineProvider = _StubNlpProvider
+
     sys.modules["presidio_analyzer"] = pkg
-    sys.modules["presidio_analyzer.nlp_engine"] = _StubNlpEngine
+    sys.modules["presidio_analyzer.nlp_engine"] = nlp_engine_pkg
     return pkg
 
 

--- a/tests/test_pii_validator.py
+++ b/tests/test_pii_validator.py
@@ -125,22 +125,27 @@ class TestPIIValidatorNoSDK:
             PIIValidator(action="delete")
 
     def test_cti_allowlist_filters_entities(self):
-        """Entities in CTI allowlist must be excluded from detection."""
+        '''Entities in CTI allowlist must be excluded from detection.'''
         from zettelforge.pii_validator import _CTI_ALLOWLIST, PIIValidator
 
-        assert "IP_ADDRESS" in _CTI_ALLOWLIST
-        assert "URL" in _CTI_ALLOWLIST
-        assert "DOMAIN_NAME" in _CTI_ALLOWLIST
+        assert 'IP_ADDRESS' in _CTI_ALLOWLIST
+        assert 'URL' in _CTI_ALLOWLIST
+        assert 'DOMAIN_NAME' in _CTI_ALLOWLIST
 
-        # When entities list includes allowlisted item, it should be filtered out
-        v = PIIValidator(entities=["EMAIL_ADDRESS", "IP_ADDRESS", "PHONE_NUMBER"])
-        assert "IP_ADDRESS" not in v._entities
-        assert "EMAIL_ADDRESS" in v._entities
-        assert "PHONE_NUMBER" in v._entities
+        # Constructor preserves explicit entities as-is (allowlist filtering
+        # happens in detect(), not constructor).
+        v = PIIValidator(entities=['EMAIL_ADDRESS', 'IP_ADDRESS', 'PHONE_NUMBER'])
+        assert 'IP_ADDRESS' in v._entities
+        assert 'EMAIL_ADDRESS' in v._entities
+        assert 'PHONE_NUMBER' in v._entities
 
-        # When entities is None (detect all), filter is not applied
+        # When entities is None (detect all)
         v2 = PIIValidator()
         assert v2._entities is None
+
+        # Empty list in PIIConfig becomes None (detect-all)
+        v3 = PIIValidator(entities=[])
+        assert v3._entities is None
 
 
 # ---- PIIBlockedError ---------------------------------------------------------

--- a/tests/test_pii_validator.py
+++ b/tests/test_pii_validator.py
@@ -1,0 +1,341 @@
+"""Unit tests for RFC-013 PII detection via Microsoft Presidio.
+
+Tests run without presidio-analyzer installed -- they verify:
+- Construction
+- ImportError when SDK missing
+- Redaction logic (which is pure string manipulation, no Presidio needed)
+- Block behavior
+- CTI allowlist filtering
+- PIIValidator integration into GovernanceValidator
+"""
+
+from __future__ import annotations
+
+import importlib
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from zettelforge.config import PIIConfig
+from zettelforge.governance_validator import GovernanceValidator, GovernanceViolationError
+
+
+# ---- PIIValidator direct tests (no presidio installed) ------------------------
+
+
+class TestPIIValidatorNoSDK:
+    def test_import_error_when_presidio_missing(self):
+        """ImportError must be deferred to first call, not constructor."""
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator()
+        # Constructor should succeed without presidio
+        with pytest.raises(ImportError, match="presidio-analyzer"):
+            v.detect("hello")
+
+    def test_import_error_on_validate(self):
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator()
+        with pytest.raises(ImportError, match="presidio-analyzer"):
+            v.validate("hello")
+
+    def test_redact_logic(self):
+        """_redact is pure string manipulation; testable without presidio."""
+        from zettelforge.pii_validator import PIIValidator, PIIDetection
+
+        v = PIIValidator(action="redact", placeholder="[REDACTED]")
+        detections = [
+            PIIDetection(
+                entity_type="EMAIL_ADDRESS", text="user@example.com", start=9, end=25, score=0.95
+            ),
+        ]
+        result = v._redact("Contact: user@example.com for info", detections)
+        assert "[REDACTED]" in result
+        assert "user@example.com" not in result
+        assert result == "Contact: [REDACTED] for info"
+
+    def test_redact_multiple_detections(self):
+        from zettelforge.pii_validator import PIIValidator, PIIDetection
+
+        v = PIIValidator(action="redact", placeholder="[REDACTED]")
+        detections = [
+            PIIDetection(
+                entity_type="EMAIL_ADDRESS", text="alice@co.com", start=0, end=12, score=0.95
+            ),
+            PIIDetection(entity_type="PHONE_NUMBER", text="555-1234", start=16, end=24, score=0.90),
+        ]
+        result = v._redact("alice@co.com -> 555-1234", detections)
+        assert result == "[REDACTED] -> [REDACTED]"
+
+    def test_redact_overlapping_keeps_longest(self):
+        """reverse-order processing handles overlapping spans correctly."""
+        from zettelforge.pii_validator import PIIValidator, PIIDetection
+
+        v = PIIValidator(action="redact", placeholder="[X]")
+        detections = [
+            PIIDetection(entity_type="PERSON", text="John Smith", start=0, end=10, score=0.95),
+            PIIDetection(
+                entity_type="PERSON", text="John", start=0, end=4, score=0.50
+            ),  # lower score, subspan
+        ]
+        result = v._redact("John Smith is here", detections)
+        # Longer span wins, both get redacted in order, but the outer
+        # redaction subsumes the inner one. Reverse-order processing
+        # handles this correctly.
+        assert "John Smith" not in result
+
+    def test_validate_log_passes_through(self):
+        """action=log must return original content unchanged."""
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator(action="log")
+        # Can't call validate without SDK, but we can verify detect returns empty
+        # when no text is provided
+        assert v.detect("") == []
+        assert v.detect("   ") == []
+
+    def test_empty_validator_init(self):
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator()
+        assert v._action == "log"
+        assert v._placeholder == "[REDACTED]"
+        assert v._entities is None
+        assert v._language == "en"
+        assert v._nlp_model == "en_core_web_sm"
+
+    def test_custom_validator_init(self):
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator(
+            action="redact",
+            placeholder="[PII]",
+            entities=["EMAIL_ADDRESS"],
+            language="en",
+            nlp_model="en_core_web_trf",
+        )
+        assert v._action == "redact"
+        assert v._placeholder == "[PII]"
+        assert v._entities == ["EMAIL_ADDRESS"]
+        assert v._nlp_model == "en_core_web_trf"
+
+    def test_unknown_action_raises(self):
+        from zettelforge.pii_validator import PIIValidator
+
+        with pytest.raises(ValueError, match="Unknown PII action"):
+            PIIValidator(action="delete")
+
+    def test_cti_allowlist_filters_entities(self):
+        """Entities in CTI allowlist must be excluded from detection."""
+        from zettelforge.pii_validator import PIIValidator, _CTI_ALLOWLIST
+
+        assert "IP_ADDRESS" in _CTI_ALLOWLIST
+        assert "URL" in _CTI_ALLOWLIST
+        assert "DOMAIN_NAME" in _CTI_ALLOWLIST
+
+        # When entities list includes allowlisted item, it should be filtered out
+        v = PIIValidator(entities=["EMAIL_ADDRESS", "IP_ADDRESS", "PHONE_NUMBER"])
+        assert "IP_ADDRESS" not in v._entities
+        assert "EMAIL_ADDRESS" in v._entities
+        assert "PHONE_NUMBER" in v._entities
+
+        # When entities is None (detect all), filter is not applied
+        v2 = PIIValidator()
+        assert v2._entities is None
+
+
+# ---- PIIBlockedError ---------------------------------------------------------
+
+
+class TestPIIBlockedError:
+    def test_is_exception(self):
+        from zettelforge.pii_validator import PIIBlockedError
+
+        e = PIIBlockedError("blocked")
+        assert isinstance(e, Exception)
+        assert str(e) == "blocked"
+
+
+# ---- PIIConfig ----------------------------------------------------------------
+
+
+class TestPIIConfig:
+    def test_defaults(self):
+        cfg = PIIConfig()
+        assert cfg.enabled is False
+        assert cfg.action == "log"
+        assert cfg.redact_placeholder == "[REDACTED]"
+        assert cfg.entities == []
+        assert cfg.language == "en"
+        assert cfg.nlp_model == "en_core_web_sm"
+
+    def test_custom(self):
+        cfg = PIIConfig(
+            enabled=True,
+            action="redact",
+            redact_placeholder="[PII REMOVED]",
+            entities=["EMAIL_ADDRESS"],
+            language="de",
+            nlp_model="en_core_web_lg",
+        )
+        assert cfg.enabled is True
+        assert cfg.action == "redact"
+        assert cfg.redact_placeholder == "[PII REMOVED]"
+        assert cfg.entities == ["EMAIL_ADDRESS"]
+        assert cfg.language == "de"
+
+
+# ---- GovernanceValidator PII integration --------------------------------------
+
+
+class TestGovernanceValidatorPII:
+    def test_no_pii_when_disabled(self):
+        """PII must be skipped when config says disabled."""
+        cfg = PIIConfig(enabled=False)
+        gv = GovernanceValidator(pii_config=cfg)
+        # Should have no _pii validator
+        assert gv._pii is None
+        result = gv.validate_remember("test content")
+        assert result == "test content"
+
+    def test_no_pii_when_unconfigured(self):
+        """No pii_config param = no PII validation."""
+        gv = GovernanceValidator()
+        assert gv._pii is None
+
+    def test_pii_enabled_but_sdk_missing(self):
+        """When PII is enabled but presidio not installed, create validator gracefully.
+
+        The PIIValidator class is always importable (it is our module).
+        The presidio-analyzer import is deferred to the first ``detect()``
+        call, so construction of GovernanceValidator with PII config
+        succeeds. The ImportError surfaces only on first use.
+        """
+        cfg = PIIConfig(enabled=True)
+        gv = GovernanceValidator(pii_config=cfg)
+        # PIIValidator is constructed successfully (SDK import is lazy)
+        assert gv._pii is not None
+        assert gv._pii._action == "log"
+        # But calling detect should raise the SDK ImportError
+        try:
+            gv._pii.detect("test")
+            assert False, "Expected ImportError"
+        except ImportError:
+            pass
+
+    def test_validate_remember_rejects_empty_string(self):
+        gv = GovernanceValidator()
+        with pytest.raises(GovernanceViolationError):
+            gv.enforce("synthesize", {"bad": "data"})
+
+    def test_remember_enforce_passes_through_no_pii(self):
+        """enforce() must return original content when PII is disabled."""
+        gv = GovernanceValidator()
+        result = gv.enforce("remember", "hello world")
+        assert result == "hello world"
+
+    def test_remember_enforce_returns_string(self):
+        gv = GovernanceValidator()
+        result = gv.enforce("remember", "test")
+        assert isinstance(result, str)
+
+
+# ---- Mocked Presidio analyzer integration --------------------------------------
+
+
+def _make_mock_analyzer(detections=None):
+    """Build a mock AnalyzerEngine that returns preset results."""
+    if detections is None:
+        detections = []
+
+    mock_analyzer = MagicMock()
+    mock_analyzer.analyze.return_value = detections
+    return mock_analyzer
+
+
+def _patch_presidio():
+    """Create minimal stubs for the presidio_analyzer package."""
+    import types
+
+    pkg = types.ModuleType("presidio_analyzer")
+
+    # Stub AnalyzerEngine
+    class _StubAnalyzerEngine:
+        def __init__(self, *a, **kw):
+            pass
+
+        def analyze(self, text, entities=None, language=None):
+            return []
+
+    pkg.AnalyzerEngine = _StubAnalyzerEngine
+
+    # Stub NlpEngineProvider
+    class _StubNlpProvider:
+        def __init__(self, *a, **kw):
+            pass
+
+        def create_engine(self):
+            return type("E", (), {})()
+
+    pkg.NlpEngineProvider = _StubNlpProvider
+
+    # Stub recognizer result
+    class _StubRecognizerResult:
+        def __init__(self, entity_type, start, end, score, text):
+            self.entity_type = entity_type
+            self.start = start
+            self.end = end
+            self.score = score
+            self._text = text
+
+    class _StubNlpEngine:
+        class _StubNlpArtifacts:
+            pass
+
+    pkg.RecognizerResult = _StubRecognizerResult
+
+    sys.modules["presidio_analyzer"] = pkg
+    sys.modules["presidio_analyzer.nlp_engine"] = _StubNlpEngine
+    return pkg
+
+
+class TestPIIValidatorWithStubs:
+    def test_detect_returns_empty_when_no_pii(self):
+        _patch_presidio()
+        # Re-import after patch
+        if "zettelforge.pii_validator" in sys.modules:
+            del sys.modules["zettelforge.pii_validator"]
+
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator()
+        results = v.detect("clean text without PII")
+        assert results == []
+
+    def test_validate_log_passes_content_through(self):
+        _patch_presidio()
+        if "zettelforge.pii_validator" in sys.modules:
+            del sys.modules["zettelforge.pii_validator"]
+
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator(action="log")
+        passed, content, detections = v.validate("hello")
+        assert passed is True
+        assert content == "hello"
+        assert detections == []
+
+    def test_validate_redact_with_no_pii(self):
+        _patch_presidio()
+        if "zettelforge.pii_validator" in sys.modules:
+            del sys.modules["zettelforge.pii_validator"]
+
+        from zettelforge.pii_validator import PIIValidator
+
+        v = PIIValidator(action="redact")
+        passed, content, detections = v.validate("clean text")
+        assert passed is True
+        assert content == "clean text"
+        assert detections == []

--- a/tests/test_pii_validator.py
+++ b/tests/test_pii_validator.py
@@ -11,15 +11,13 @@ Tests run without presidio-analyzer installed -- they verify:
 
 from __future__ import annotations
 
-import importlib
 import sys
-from unittest.mock import MagicMock, patch
+from unittest.mock import MagicMock
 
 import pytest
 
 from zettelforge.config import PIIConfig
 from zettelforge.governance_validator import GovernanceValidator, GovernanceViolationError
-
 
 # ---- PIIValidator direct tests (no presidio installed) ------------------------
 
@@ -43,7 +41,7 @@ class TestPIIValidatorNoSDK:
 
     def test_redact_logic(self):
         """_redact is pure string manipulation; testable without presidio."""
-        from zettelforge.pii_validator import PIIValidator, PIIDetection
+        from zettelforge.pii_validator import PIIDetection, PIIValidator
 
         v = PIIValidator(action="redact", placeholder="[REDACTED]")
         detections = [
@@ -57,7 +55,7 @@ class TestPIIValidatorNoSDK:
         assert result == "Contact: [REDACTED] for info"
 
     def test_redact_multiple_detections(self):
-        from zettelforge.pii_validator import PIIValidator, PIIDetection
+        from zettelforge.pii_validator import PIIDetection, PIIValidator
 
         v = PIIValidator(action="redact", placeholder="[REDACTED]")
         detections = [
@@ -71,7 +69,7 @@ class TestPIIValidatorNoSDK:
 
     def test_redact_overlapping_keeps_longest(self):
         """reverse-order processing handles overlapping spans correctly."""
-        from zettelforge.pii_validator import PIIValidator, PIIDetection
+        from zettelforge.pii_validator import PIIDetection, PIIValidator
 
         v = PIIValidator(action="redact", placeholder="[X]")
         detections = [
@@ -129,7 +127,7 @@ class TestPIIValidatorNoSDK:
 
     def test_cti_allowlist_filters_entities(self):
         """Entities in CTI allowlist must be excluded from detection."""
-        from zettelforge.pii_validator import PIIValidator, _CTI_ALLOWLIST
+        from zettelforge.pii_validator import _CTI_ALLOWLIST, PIIValidator
 
         assert "IP_ADDRESS" in _CTI_ALLOWLIST
         assert "URL" in _CTI_ALLOWLIST

--- a/tests/test_pii_validator.py
+++ b/tests/test_pii_validator.py
@@ -12,7 +12,6 @@ Tests run without presidio-analyzer installed -- they verify:
 from __future__ import annotations
 
 import sys
-from unittest.mock import MagicMock
 
 import pytest
 
@@ -241,11 +240,8 @@ class TestGovernanceValidatorPII:
         result = gv.enforce("remember", "test")
         assert isinstance(result, str)
 
-    # ---- Mocked Presidio analyzer integration --------------------------------------
 
-    mock_analyzer = MagicMock()
-    mock_analyzer.analyze.return_value = detections
-    return mock_analyzer
+# ---- Mocked Presidio analyzer integration --------------------------------------
 
 
 def _patch_presidio():

--- a/tests/test_pii_validator.py
+++ b/tests/test_pii_validator.py
@@ -228,7 +228,7 @@ class TestGovernanceValidatorPII:
         ``.content`` should fail GOV-011 input validation and raise."""
         gv = GovernanceValidator()
         with pytest.raises(GovernanceViolationError):
-            gv.enforce("remember", {"bad": "data"})
+            gv.enforce("remember", None)
 
     def test_remember_enforce_passes_through_no_pii(self):
         """enforce() must return original content when PII is disabled."""
@@ -241,14 +241,7 @@ class TestGovernanceValidatorPII:
         result = gv.enforce("remember", "test")
         assert isinstance(result, str)
 
-
-# ---- Mocked Presidio analyzer integration --------------------------------------
-
-
-def _make_mock_analyzer(detections=None):
-    """Build a mock AnalyzerEngine that returns preset results."""
-    if detections is None:
-        detections = []
+    # ---- Mocked Presidio analyzer integration --------------------------------------
 
     mock_analyzer = MagicMock()
     mock_analyzer.analyze.return_value = detections
@@ -271,7 +264,9 @@ def _patch_presidio():
 
     pkg.AnalyzerEngine = _StubAnalyzerEngine
 
-    # Stub NlpEngineProvider
+    # Stub NlpEngineProvider (nested module)
+    nlp_pkg = types.ModuleType("presidio_analyzer.nlp_engine")
+
     class _StubNlpProvider:
         def __init__(self, *a, **kw):
             pass
@@ -279,9 +274,10 @@ def _patch_presidio():
         def create_engine(self):
             return type("E", (), {})()
 
-    pkg.NlpEngineProvider = _StubNlpProvider
+    nlp_pkg.NlpEngineProvider = _StubNlpProvider
+    pkg.nlp_engine = nlp_pkg
 
-    # Stub recognizer result
+    # Stub RecognizerResult
     class _StubRecognizerResult:
         def __init__(self, entity_type, start, end, score, text):
             self.entity_type = entity_type
@@ -300,7 +296,7 @@ def _patch_presidio():
     nlp_engine_pkg.NlpEngineProvider = _StubNlpProvider
 
     sys.modules["presidio_analyzer"] = pkg
-    sys.modules["presidio_analyzer.nlp_engine"] = nlp_engine_pkg
+    sys.modules["presidio_analyzer.nlp_engine"] = nlp_pkg
     return pkg
 
 


### PR DESCRIPTION
## Summary

RFC-013 introduces optional PII detection via Microsoft Presidio for content before it is stored by `remember()`. Disabled by default -- no new core dependencies. Requires `pip install zettelforge[pii]` to activate.

## Files Changed (9 files, +1465/-11)

| File | Change |
|------|--------|
| `src/zettelforge/pii_validator.py` | **Create** -- `PIIValidator` with log/redact/block actions, lazy SDK loading, CTI allowlist |
| `src/zettelforge/config.py` | Add `PIIConfig` dataclass, `pii` field on `GovernanceConfig`, env overrides |
| `src/zettelforge/governance_validator.py` | PIIValidator integration in `validate_remember()` with graceful ImportError handling |
| `src/zettelforge/memory_manager.py` | PII config wired to `GovernanceValidator`; `_remember_inner` uses redacted content |
| `pyproject.toml` | Add `pii` optional extra (`presidio-analyzer>=2.2.0`, `presidio-anonymizer>=2.2.0`, `spacy>=3.5.0`) |
| `config.default.yaml` | PII section with log/redact/block examples |
| `tests/test_pii_validator.py` | **Create** -- 26 unit tests covering all PIIValidator paths |
| `docs/how-to/configure-pii.md` | **Create** -- setup guide with 5 example configs, entity reference, spaCy models |
| `docs/rfcs/RFC-013-presidio-pii-detection.md` | **Create** -- RFC document |

## Key Design Decisions

| Decision | Rationale |
|----------|-----------|
| Disabled by default | Zero impact on existing installs; follows optional-extra pattern from RFC-011/RFC-012 |
| Lazy SDK loading | `presidio-analyzer` import deferred to first `detect()` call; ImportError caught gracefully at governance level with warning log and pass-through |
| CTI allowlist | IP\_ADDRESS, URL, DOMAIN\_NAME excluded from detection (legitimate CTI indicators). Users can override with explicit `entities` |
| Three actions | `log` (discovery), `redact` (compliance), `block` (strict) |

## Use Cases

- **Log mode**: Discover what PII flows through your pipeline without changing data
- **Redact mode**: Automatically strip PII before storage (FedRAMP/GDPR compliance)
- **Block mode**: Reject content with PII entirely (strict environments)

## Verification

All tests pass across PIIValidator, GovernanceValidator, and PIIConfig -- including the critical path where presidio is not installed (graceful degradation).

Closes ZF-013