### PR TITLE
fix(kg): tolerate legacy edge schema in kg_edges.jsonl (v2.5.1 hotfix)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,29 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.5.1] - 2026-04-25
+
+Hotfix release. Surfaced during the v2.5.0 perf benchmark run.
+
+### Fixed
+
+- **`KnowledgeGraph._cache_edge` crashed on legacy-schema edges**.
+  Long-running deployments accumulated `kg_edges.jsonl` entries written
+  by a now-removed pre-v2.5.x writer that used
+  `{source_id, target_id, relation_type}` instead of the canonical
+  `{from_node_id, to_node_id, relationship}` keys. The loader hard-failed
+  with `KeyError: 'from_node_id'` on the first such row, taking down
+  every `recall()` and `synthesize()` that touches the KG. Affects any
+  workspace with mixed-schema edge history; observed locally with 189k
+  edges where ~80k were the legacy shape.
+  `_normalize_edge_schema()` now remaps legacy keys to canonical on load
+  and silently drops entries that are still un-normalizable, with a
+  count logged at WARNING so operators can see the skip volume.
+  Six new regression tests in `tests/test_kg_edge_schema.py` cover
+  pass-through, remap, missing-fields, non-dict, mixed-batch, and
+  corrupt-JSON cases. The previously-broken environment-dependent
+  `test_basic.py::test_ingest_relationship` now passes deterministically.
+
 ## [2.5.0] - 2026-04-25
 
 Compliance-driven minor release. Closes every CRITICAL and HIGH audit

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zettelforge"
-version = "2.5.0"
+version = "2.5.1"
 description = "ZettelForge: Agentic Memory System with vector search, knowledge graph, and synthesis"
 readme = "README.md"
 license = "MIT"

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -57,7 +57,7 @@ from zettelforge.vector_retriever import VectorRetriever
 # importable for advanced use but are not part of the advertised public API
 # and are therefore excluded from __all__ below.
 
-__version__ = "2.4.3"
+__version__ = "2.5.1"
 __all__ = [
     # Ontology reference tables (TypedEntityStore / OntologyValidator are
     # importable from zettelforge.ontology but are not part of the public API

--- a/src/zettelforge/knowledge_graph.py
+++ b/src/zettelforge/knowledge_graph.py
@@ -22,6 +22,34 @@ from collections import deque
 from datetime import datetime
 from pathlib import Path
 
+# Pre-v2.5.1 writers (now removed from the codebase, but persisted on disk
+# in older deployments) used {source_id, target_id, relation_type} instead of
+# {from_node_id, to_node_id, relationship}. _normalize_edge_schema() rewrites
+# legacy entries on load so both shapes are tolerated. Missing edge_id is
+# treated as terminal — we cannot index without one.
+_LEGACY_EDGE_KEY_MAP = {
+    "source_id": "from_node_id",
+    "target_id": "to_node_id",
+    "relation_type": "relationship",
+}
+
+
+def _normalize_edge_schema(edge: dict) -> dict | None:
+    """Return a copy of ``edge`` with legacy keys remapped, or ``None`` if
+    the entry is missing fields the cache requires.
+
+    Idempotent: edges already in the canonical shape pass through unchanged.
+    """
+    if not isinstance(edge, dict) or not edge.get("edge_id"):
+        return None
+    out = dict(edge)
+    for legacy, canonical in _LEGACY_EDGE_KEY_MAP.items():
+        if canonical not in out and legacy in out:
+            out[canonical] = out[legacy]
+    if "from_node_id" not in out or "to_node_id" not in out:
+        return None
+    return out
+
 
 class KnowledgeGraph:
     """
@@ -64,20 +92,41 @@ class KnowledgeGraph:
                             continue
 
         if self.edges_file.exists():
+            skipped_malformed = 0
             with open(self.edges_file) as f:
                 for line in f:
-                    if line.strip():
-                        try:
-                            edge = json.loads(line)
-                            self._cache_edge(edge)
-                            # Index temporal edges
-                            if (
-                                edge.get("relationship", "").startswith("TEMPORAL_")
-                                or edge.get("relationship") == "SUPERSEDES"
-                            ):
-                                self._index_temporal_edge(edge)
-                        except json.JSONDecodeError:
-                            continue
+                    if not line.strip():
+                        continue
+                    try:
+                        edge = json.loads(line)
+                    except json.JSONDecodeError:
+                        skipped_malformed += 1
+                        continue
+                    edge = _normalize_edge_schema(edge)
+                    if edge is None:
+                        skipped_malformed += 1
+                        continue
+                    self._cache_edge(edge)
+                    # Index temporal edges
+                    if (
+                        edge.get("relationship", "").startswith("TEMPORAL_")
+                        or edge.get("relationship") == "SUPERSEDES"
+                    ):
+                        self._index_temporal_edge(edge)
+            if skipped_malformed:
+                # Pre-v2.5.1 deployments wrote edges under both
+                # {from_node_id, to_node_id, relationship} and
+                # {source_id, target_id, relation_type}; the loader now
+                # normalizes the latter to the former. Anything still
+                # un-normalizable is silently dropped here. Logged at
+                # warning so operators can see the count without crashing.
+                import logging as _logging
+
+                _logging.getLogger("zettelforge.knowledge_graph").warning(
+                    "kg_edges_skipped_malformed count=%d file=%s",
+                    skipped_malformed,
+                    self.edges_file,
+                )
 
     def _cache_node(self, node: dict):
         self._nodes[node["node_id"]] = node

--- a/src/zettelforge/knowledge_graph.py
+++ b/src/zettelforge/knowledge_graph.py
@@ -22,6 +22,11 @@ from collections import deque
 from datetime import datetime
 from pathlib import Path
 
+from zettelforge.log import get_logger
+
+_logger = get_logger("zettelforge.knowledge_graph")
+
+
 # Pre-v2.5.1 writers (now removed from the codebase, but persisted on disk
 # in older deployments) used {source_id, target_id, relation_type} instead of
 # {from_node_id, to_node_id, relationship}. _normalize_edge_schema() rewrites
@@ -39,6 +44,11 @@ def _normalize_edge_schema(edge: dict) -> dict | None:
     the entry is missing fields the cache requires.
 
     Idempotent: edges already in the canonical shape pass through unchanged.
+
+    ``relationship`` is required because downstream code (``add_edge`` dedup
+    scan, ``get_neighbors``, traversal) does direct subscripting on it; a
+    legacy row without ``relation_type`` would otherwise survive load and
+    trigger a deferred KeyError on first read.
     """
     if not isinstance(edge, dict) or not edge.get("edge_id"):
         return None
@@ -46,7 +56,7 @@ def _normalize_edge_schema(edge: dict) -> dict | None:
     for legacy, canonical in _LEGACY_EDGE_KEY_MAP.items():
         if canonical not in out and legacy in out:
             out[canonical] = out[legacy]
-    if "from_node_id" not in out or "to_node_id" not in out:
+    if "from_node_id" not in out or "to_node_id" not in out or "relationship" not in out:
         return None
     return out
 
@@ -120,12 +130,10 @@ class KnowledgeGraph:
                 # normalizes the latter to the former. Anything still
                 # un-normalizable is silently dropped here. Logged at
                 # warning so operators can see the count without crashing.
-                import logging as _logging
-
-                _logging.getLogger("zettelforge.knowledge_graph").warning(
-                    "kg_edges_skipped_malformed count=%d file=%s",
-                    skipped_malformed,
-                    self.edges_file,
+                _logger.warning(
+                    "kg_edges_skipped_malformed",
+                    count=skipped_malformed,
+                    file=str(self.edges_file),
                 )
 
     def _cache_node(self, node: dict):

--- a/tests/test_kg_edge_schema.py
+++ b/tests/test_kg_edge_schema.py
@@ -51,6 +51,15 @@ def test_normalize_edge_schema_returns_none_when_unrecoverable():
         _normalize_edge_schema({"from_node_id": "a", "to_node_id": "b", "relationship": "R"})
         is None
     )
+    # Missing relationship (and no legacy relation_type to remap from).
+    # Downstream code does direct subscripting on edge["relationship"], so
+    # entries without it must be rejected at load time, not deferred.
+    assert (
+        _normalize_edge_schema(
+            {"edge_id": "edge_4", "from_node_id": "a", "to_node_id": "b"}
+        )
+        is None
+    )
 
 
 def test_normalize_edge_schema_handles_non_dict():

--- a/tests/test_kg_edge_schema.py
+++ b/tests/test_kg_edge_schema.py
@@ -1,0 +1,126 @@
+"""Regression test for v2.5.1 hotfix: KnowledgeGraph._cache_edge crashed
+with KeyError on legacy edges that used {source_id, target_id, relation_type}
+instead of {from_node_id, to_node_id, relationship}.
+
+Tickled in production by long-running deployments where pre-v2.5.x writers
+left ~80k+ legacy entries in kg_edges.jsonl alongside canonical-shape rows.
+"""
+
+from __future__ import annotations
+
+import json
+import tempfile
+from pathlib import Path
+
+from zettelforge.knowledge_graph import KnowledgeGraph, _normalize_edge_schema
+
+
+def test_normalize_edge_schema_passes_canonical_shape_through():
+    edge = {
+        "edge_id": "edge_1",
+        "from_node_id": "node_a",
+        "to_node_id": "node_b",
+        "relationship": "MENTIONED_IN",
+    }
+    normalized = _normalize_edge_schema(edge)
+    assert normalized == edge
+
+
+def test_normalize_edge_schema_remaps_legacy_keys():
+    legacy = {
+        "edge_id": "edge_2",
+        "source_id": "node_a",
+        "target_id": "node_b",
+        "relation_type": "MENTIONED_IN",
+    }
+    normalized = _normalize_edge_schema(legacy)
+    assert normalized is not None
+    assert normalized["from_node_id"] == "node_a"
+    assert normalized["to_node_id"] == "node_b"
+    assert normalized["relationship"] == "MENTIONED_IN"
+    # Legacy keys preserved alongside the canonical ones (we don't drop them
+    # on load — write path will overwrite if needed).
+    assert normalized["source_id"] == "node_a"
+
+
+def test_normalize_edge_schema_returns_none_when_unrecoverable():
+    # Missing both legacy and canonical id keys — cannot cache without them.
+    assert _normalize_edge_schema({"edge_id": "edge_3"}) is None
+    # Missing edge_id — cannot index even if we had the rest.
+    assert (
+        _normalize_edge_schema({"from_node_id": "a", "to_node_id": "b", "relationship": "R"})
+        is None
+    )
+
+
+def test_normalize_edge_schema_handles_non_dict():
+    assert _normalize_edge_schema("not a dict") is None
+    assert _normalize_edge_schema(None) is None
+
+
+def test_load_all_tolerates_mixed_schema_kg_edges():
+    """KnowledgeGraph._load_all() must not crash when kg_edges.jsonl contains
+    both canonical and legacy edge entries."""
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        # Two canonical edges + one legacy + one totally broken.
+        edges = [
+            {
+                "edge_id": "edge_1",
+                "from_node_id": "node_a",
+                "to_node_id": "node_b",
+                "relationship": "MENTIONED_IN",
+                "properties": {},
+            },
+            {
+                "edge_id": "edge_2",
+                "source_id": "node_c",
+                "target_id": "node_d",
+                "relation_type": "MENTIONED_IN",
+                "properties": {},
+            },
+            {"edge_id": "edge_3"},  # malformed — no nodes
+            {
+                "edge_id": "edge_4",
+                "from_node_id": "node_e",
+                "to_node_id": "node_f",
+                "relationship": "TEMPORAL_BEFORE",
+                "properties": {"timestamp": "2026-04-25T00:00:00Z"},
+            },
+        ]
+        edges_file = data_dir / "kg_edges.jsonl"
+        with open(edges_file, "w") as f:
+            for edge in edges:
+                f.write(json.dumps(edge) + "\n")
+
+        # Even with a broken entry mixed in, construction must succeed and the
+        # cache must contain the three salvageable edges.
+        kg = KnowledgeGraph(data_dir=str(data_dir))
+        assert "edge_1" in kg._edges
+        assert "edge_2" in kg._edges  # legacy schema normalized in
+        assert "edge_4" in kg._edges
+        assert "edge_3" not in kg._edges  # dropped — no node ids
+
+        # The legacy entry's normalized from_node_id wires into the index.
+        assert "node_c" in kg._edges_from
+        assert "node_d" in kg._edges_to
+
+
+def test_load_all_skips_corrupt_json_lines():
+    """Pre-existing tolerance for malformed JSON should still hold."""
+    with tempfile.TemporaryDirectory() as tmp:
+        data_dir = Path(tmp)
+        edges_file = data_dir / "kg_edges.jsonl"
+        with open(edges_file, "w") as f:
+            f.write(
+                '{"edge_id": "ok", "from_node_id": "a", "to_node_id": "b", "relationship": "R"}\n'
+            )
+            f.write("{not valid json\n")
+            f.write(
+                '{"edge_id": "ok2", "from_node_id": "c", "to_node_id": "d", "relationship": "R"}\n'
+            )
+
+        kg = KnowledgeGraph(data_dir=str(data_dir))
+        assert "ok" in kg._edges
+        assert "ok2" in kg._edges
+        assert len(kg._edges) == 2


### PR DESCRIPTION
## Summary

Hotfix for a regression surfaced during the v2.5.0 perf benchmark.

\`KnowledgeGraph._cache_edge\` hard-failed with \`KeyError: 'from_node_id'\` on legacy-schema edges left in \`kg_edges.jsonl\` by a pre-v2.5.x writer that used \`{source_id, target_id, relation_type}\` instead of \`{from_node_id, to_node_id, relationship}\`. Affects any deployment with mixed-schema edge history. Observed locally on a 189k-edge file where ~80k were legacy shape; every \`recall()\` and \`synthesize()\` aborted at construction.

This was also the root cause of the long-standing \`test_basic.py::test_ingest_relationship\` failure (previously attributed to "TYPEDB env-dependent"). With the fix, that test passes deterministically.

## Fix

- New \`_normalize_edge_schema()\` helper remaps legacy keys to canonical on load. Returns \`None\` for un-normalizable entries (missing \`edge_id\` or both source/target ids).
- \`_load_all()\` now skips un-normalizable entries with a WARNING log (count + file path) instead of crashing.

## Tests

\`tests/test_kg_edge_schema.py\` — 6 new tests:
- canonical pass-through
- legacy key remap
- unrecoverable detection (missing edge_id, missing nodes)
- non-dict input
- mixed-schema fixture end-to-end
- corrupt JSON line tolerance

**31/31 pass** in \`test_kg_edge_schema.py + test_basic.py\` (including the previously-broken \`test_ingest_relationship\`).

## Version

\`pyproject.toml\` 2.5.0 → 2.5.1, CHANGELOG entry added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)