### PR TITLE
chore(release): v2.6.0 — RFC-014, RFC-015, recall timeout

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,44 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.6.0] - 2026-04-25
+
+Feature release. Adds configurable content-size limits for DoS mitigation
+(RFC-014) and moves per-call-site LLM token budgets out of hardcoded
+literals into `LLMConfig`, making them overridable at deploy time.
+
+### Added
+
+- **Configurable content size limits** (`GovernanceConfig.limits.max_content_length`,
+  default 50 MB). `remember()` calls with content exceeding the limit are
+  rejected with a clear error message. Set to `0` to disable the check.
+  Environment override: `ZETTELFORGE_LIMITS_MAX_CONTENT_LENGTH`.
+  (RFC-014, PR #123)
+- **Per-call-site `max_tokens` budgets configurable via `LLMConfig`**.
+  Five new fields: `max_tokens_causal` (8000), `max_tokens_synthesis` (2500),
+  `max_tokens_fact` (2500), `max_tokens_ner` (2500), `max_tokens_evolution` (2500).
+  Defaults match v2.5.2 values. No behavioral change for existing configs.
+  (PR #126, issue #125)
+
+### Changed
+
+- **Docs: config reconciliation for v2.5.2** — `config.default.yaml` gained
+  the `lance:` section (RFC-009 Phase 1.5), `docs/reference/configuration.md`
+  now covers all v2.5.2 knobs (`lance`, `pii`, per-call-site budgets), and
+  `docs/explanation/llm-budgets-and-timeouts.md` explains the reasoning-model
+  token-budget tradeoffs. (PR #126)
+- **`_apply_yaml()` now handles `lance:` section** — previously the
+  `lance.cleanup_interval_minutes` and `lance.cleanup_older_than_seconds` YAML
+  knobs were silently ignored (regression from RFC-009 Phase 1.5 landing in
+  v2.4.x without the `_apply_yaml` branch). (PR #126, code review finding)
+
+### Internal
+
+- **Removed `docs/superpowers/` from version control**. The directory holds
+  workspace scratch — internal research and notes with unredacted incident
+  detail. 18 files (7319 lines) untracked. No published content lost.
+  (PR #128)
+
 ## [2.5.2] - 2026-04-25
 
 Hotfix release. Restores end-to-end functionality of synthesis, causal

--- a/docs/explanation/llm-budgets-and-timeouts.md
+++ b/docs/explanation/llm-budgets-and-timeouts.md
@@ -5,7 +5,7 @@ diataxis_type: explanation
 audience: "Operator / Developer"
 tags: [llm, configuration, performance, reasoning-models, ollama]
 last_updated: "2026-04-25"
-version: "2.5.2"
+version: "2.6.0"
 ---
 
 # LLM budgets, timeouts, and what they cost you
@@ -61,7 +61,7 @@ You can lower `llm.timeout` to e.g. 60 s without losing correctness, since each 
 
 ### You're on a non-reasoning model (gemma4, llama-3.x base, qwen2.5)
 
-These don't emit `<think>` tokens. Your budgets only need to cover the actual answer length, not reasoning + answer. You can set `max_tokens` literals to ~25% of the v2.5.2 defaults if you patch the source (today the values are hardcoded; v2.6.0 — [issue #125](https://github.com/rolandpg/zettelforge/issues/125) — moves them to config). `llm.timeout: 60` is then enough.
+These don't emit `<think>` tokens. Your budgets only need to cover the actual answer length, not reasoning + answer. You can set `max_tokens` literals to ~25% of the v2.5.2 defaults if you patch the source (today the values are hardcoded; v2.6.0 — [issue #125](https://github.com/rolandpg/zettelforge/issues/125) — moved them to config). `llm.timeout: 60` is then enough.
 
 ### You're on a much larger model (70B, 120B, cloud)
 

--- a/docs/explanation/llm-budgets-and-timeouts.md
+++ b/docs/explanation/llm-budgets-and-timeouts.md
@@ -61,7 +61,7 @@ You can lower `llm.timeout` to e.g. 60 s without losing correctness, since each 
 
 ### You're on a non-reasoning model (gemma4, llama-3.x base, qwen2.5)
 
-These don't emit `<think>` tokens. Your budgets only need to cover the actual answer length, not reasoning + answer. You can set `max_tokens` literals to ~25% of the v2.5.2 defaults if you patch the source (today the values are hardcoded; v2.6.0 — [issue #125](https://github.com/rolandpg/zettelforge/issues/125) — moved them to config). `llm.timeout: 60` is then enough.
+These don't emit ` thinking` tokens. Your budgets only need to cover the actual answer length, not reasoning + answer. You can set `max_tokens` values to ~25% of the v2.5.2 defaults in config (v2.6.0 moved them to `LLMConfig` — see [issue #125](https://github.com/rolandpg/zettelforge/issues/125)). `llm.timeout: 60` is then enough.
 
 ### You're on a much larger model (70B, 120B, cloud)
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -5,7 +5,7 @@ diataxis_type: "how-to"
 audience: "Operator / Developer"
 tags: [troubleshooting, debugging, errors, performance]
 last_updated: "2026-04-25"
-version: "2.5.2"
+version: "2.6.0"
 ---
 
 # Troubleshoot ZettelForge
@@ -59,7 +59,7 @@ ollama pull qwen2.5:3b             # or whatever ZETTELFORGE_LLM_MODEL points to
 **2. Reasoning-model token starvation.** If you're on a reasoning model (qwen3.5+, qwen3.6, nemotron-3) and the OCSF log shows
 `event=llm_call_empty_response done_reason=length eval_count=<num_predict>`, the model used its entire token budget on hidden `<think>...</think>` tokens before emitting a final answer.
 
-Pre-2.5.2 budgets were too low (300–1024 tokens depending on call site) and silently failed every causal-extraction, synthesis, fact-extraction, and LLM-NER call. **Upgrade to 2.5.2+**; the per-call-site caps are now 2500–8000 tokens. See the [Configuration Reference §Per-call-site `max_tokens` budgets](../reference/configuration.md#per-call-site-max_tokens-budgets-hardcoded-v252) for the exact values and the v2.6.0 plan to make them config-overridable.
+Pre-2.5.2 budgets were too low (300–1024 tokens depending on call site) and silently failed every causal-extraction, synthesis, fact-extraction, and LLM-NER call. **Upgrade to 2.5.2+**; the per-call-site caps are now 2500–8000 tokens. See the [Configuration Reference §Per-call-site `max_tokens` budgets](../reference/configuration.md#per-call-site-max_tokens-budgets-hardcoded-v252) for the exact values and now config-overridable in v2.6.0.
 
 If you can't upgrade and you're stuck on a reasoning model, switch to a non-reasoning model (e.g. `gemma4:e4b`, `qwen2.5:3b`) which doesn't emit `<think>` tokens.
 

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -59,7 +59,7 @@ ollama pull qwen2.5:3b             # or whatever ZETTELFORGE_LLM_MODEL points to
 **2. Reasoning-model token starvation.** If you're on a reasoning model (qwen3.5+, qwen3.6, nemotron-3) and the OCSF log shows
 `event=llm_call_empty_response done_reason=length eval_count=<num_predict>`, the model used its entire token budget on hidden `<think>...</think>` tokens before emitting a final answer.
 
-Pre-2.5.2 budgets were too low (300–1024 tokens depending on call site) and silently failed every causal-extraction, synthesis, fact-extraction, and LLM-NER call. **Upgrade to 2.5.2+**; the per-call-site caps are now 2500–8000 tokens. See the [Configuration Reference §Per-call-site `max_tokens` budgets](../reference/configuration.md#per-call-site-max_tokens-budgets-hardcoded-v252) for the exact values and now config-overridable in v2.6.0.
+Pre-2.5.2 budgets were too low (300–1024 tokens depending on call site) and silently failed every causal-extraction, synthesis, fact-extraction, and LLM-NER call. **Upgrade to 2.5.2+**; the per-call-site caps are now 2500–8000 tokens. See the [Configuration Reference §Per-call-site `max_tokens` budgets](../reference/configuration.md#per-call-site-max_tokens-budgets-v260-config-driven) for the exact values and now config-overridable in v2.6.0.
 
 If you can't upgrade and you're stuck on a reasoning model, switch to a non-reasoning model (e.g. `gemma4:e4b`, `qwen2.5:3b`) which doesn't emit `<think>` tokens.
 

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -5,7 +5,7 @@ diataxis_type: "how-to"
 audience: "Operator / Maintainer"
 tags: [upgrade, migration, release, breaking-changes]
 last_updated: "2026-04-25"
-version: "2.5.2"
+version: "2.6.0"
 ---
 
 # Upgrade ZettelForge
@@ -18,12 +18,40 @@ the full list of changes per release see
 
 | From -> To | Required action | Data migration? |
 |-----------|-----------------|-----------------|
-| 2.5.0 / 2.5.1 -> 2.5.2 | `pip install -U zettelforge` (read v2.5.2 notes below) | No |
+| 2.5.0 / 2.5.1 / 2.5.2 -> 2.6.0 | `pip install -U zettelforge` (read v2.6.0 notes above) | No |
 | 2.4.x -> 2.5.x | `pip install -U zettelforge` (read v2.5.0/2.5.1/2.5.2 notes below) | No |
 | 2.2.x -> 2.4.x | `pip install -U zettelforge` | No |
 | 2.1.x -> 2.2.x | `pip install -U zettelforge` + run JSONL -> SQLite migration | **Yes** |
 | 2.0.x -> 2.2.x | Upgrade in two hops via 2.1.x is recommended but not required | **Yes** |
 | < 2.0 | Not supported -- export notes manually, fresh-install 2.2.x |
+
+## 2.5.x -> 2.6.0 (content limits + config-driven token budgets)
+
+### What's new
+
+- **Configurable content size limits** (RFC-014). `GovernanceConfig.limits.max_content_length` (default 50 MB) prevents oversized content from exhausting memory or blocking the enrichment queue. Set to `0` to disable. Environment override: `ZETTELFORGE_LIMITS_MAX_CONTENT_LENGTH`.
+- **Per-call-site `max_tokens` budgets moved to config.** `LLMConfig` now exposes `max_tokens_causal`, `max_tokens_synthesis`, `max_tokens_fact`, `max_tokens_ner`, and `max_tokens_evolution` (defaults match v2.5.2 values). No more monkey-patching.
+- **`llm.timeout` default remains 180 s** (set in v2.5.2). Now symmetrically overridable alongside per-call-site budgets.
+
+### Steps
+
+1. `pip install -U 'zettelforge>=2.6.0'`
+2. If you had a custom `config.yaml` that overrode `llm.timeout`, it still works. No YAML changes required — existing configs are backward-compatible.
+3. (Optional) Override per-call-site budgets in your `config.yaml`:
+
+   ```yaml
+   llm:
+     max_tokens_causal: 12000     # default 8000
+     max_tokens_synthesis: 4000   # default 2500
+     max_tokens_fact: 4000        # default 2500
+   ```
+
+   See the [Configuration Reference](../reference/configuration.md#per-call-site-max_tokens-budgets-hardcoded-v252) for all knobs.
+
+### Operational impact
+
+- **None if you're on v2.5.2 defaults.** Budget values are unchanged. The only difference is they are now configurable instead of hardcoded.
+- **If you had v2.5.0/v2.5.1:** this upgrade includes the v2.5.2 reasoning-model fix. Apply the same steps listed below in the v2.5.2 section.
 
 ## 2.5.x -> 2.5.2 (recommended for everyone on a reasoning model)
 
@@ -31,7 +59,7 @@ the full list of changes per release see
 
 ### What changed
 
-- **Per-call-site `max_tokens` budgets bumped** to give reasoning models headroom: causal extraction 300 → 8000, synthesis 800 → 2500, fact extraction 400 → 2500, LLM NER 300 → 2500, memory evolution 1024 → 2500. These are still hardcoded literals in source today; v2.6.0 ([issue #125](https://github.com/rolandpg/zettelforge/issues/125)) will move them to `LLMConfig`.
+- **Per-call-site `max_tokens` budgets bumped** to give reasoning models headroom: causal extraction 300 → 8000, synthesis 800 → 2500, fact extraction 400 → 2500, LLM NER 300 → 2500, memory evolution 1024 → 2500. These were hardcoded literals until v2.6.0 moved them to `LLMConfig`.
 - **`llm.timeout` default bumped 60 s -> 180 s** (`LLMConfig.timeout`, `OllamaProvider`, `config.default.yaml`). The 60 s default fired before causal extraction at 8000 tokens could complete on a 9B model.
 
 ### Operational impact you should know about

--- a/docs/how-to/upgrade.md
+++ b/docs/how-to/upgrade.md
@@ -46,7 +46,7 @@ the full list of changes per release see
      max_tokens_fact: 4000        # default 2500
    ```
 
-   See the [Configuration Reference](../reference/configuration.md#per-call-site-max_tokens-budgets-hardcoded-v252) for all knobs.
+   See the [Configuration Reference](../reference/configuration.md#per-call-site-max_tokens-budgets-v260-config-driven) for all knobs.
 
 ### Operational impact
 
@@ -59,7 +59,7 @@ the full list of changes per release see
 
 ### What changed
 
-- **Per-call-site `max_tokens` budgets bumped** to give reasoning models headroom: causal extraction 300 → 8000, synthesis 800 → 2500, fact extraction 400 → 2500, LLM NER 300 → 2500, memory evolution 1024 → 2500. These were hardcoded literals until v2.6.0 moved them to `LLMConfig`.
+- **Per-call-site `max_tokens` budgets bumped** to give reasoning models headroom: causal extraction 300 → 8000, synthesis 800 → 2500, fact extraction 400 → 2500, LLM NER 300 → 2500, memory evolution 1024 → 2500. These were hardcoded until v2.6.0 moved them to `LLMConfig`.
 - **`llm.timeout` default bumped 60 s -> 180 s** (`LLMConfig.timeout`, `OllamaProvider`, `config.default.yaml`). The 60 s default fired before causal extraction at 8000 tokens could complete on a 9B model.
 
 ### Operational impact you should know about

--- a/docs/index.md
+++ b/docs/index.md
@@ -5,7 +5,7 @@ diataxis_type: "navigation"
 audience: "all"
 tags: [overview, navigation]
 last_updated: "2026-04-25"
-version: "2.5.0"
+version: "2.6.0"
 ---
 
 # ZettelForge Documentation
@@ -148,7 +148,7 @@ Background context and design rationale for the system's architecture.
 
 ## LLM Quick Reference
 
-ZettelForge (v2.5.0, MIT license) is an agentic memory system for cyber threat intelligence. It requires Python 3.10+. By default, storage uses SQLite together with LanceDB for vector-indexed notes; TypeDB 3.x via Docker on port 1729 is an optional graph backend. Embeddings run in-process via fastembed (nomic-embed-text-v1.5-Q, 768-dim, ONNX). The default LLM provider is Ollama (`provider: ollama`, `model: qwen3.5:9b`).
+ZettelForge (v2.6.0, MIT license) is an agentic memory system for cyber threat intelligence. It requires Python 3.10+. By default, storage uses SQLite together with LanceDB for vector-indexed notes; TypeDB 3.x via Docker on port 1729 is an optional graph backend. Embeddings run in-process via fastembed (nomic-embed-text-v1.5-Q, 768-dim, ONNX). The default LLM provider is Ollama (`provider: ollama`, `model: qwen3.5:9b`).
 
 Three additional LLM providers are available as optional extras:
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -9,7 +9,7 @@ tags:
   - settings
   - deployment
 last_updated: "2026-04-25"
-version: "2.5.2"
+version: "2.6.0"
 ---
 
 # Configuration Reference
@@ -155,9 +155,9 @@ class LLMConfig:
 | `litellm` | `pip install zettelforge[litellm]` | `provider: litellm` + `model: gpt-4o` | LiteLLM model name | Routes to 100+ providers by model prefix. |
 | `mock` | core (no extra) | `provider: mock` | N/A | Deterministic canned responses for testing. |
 
-#### Per-call-site `max_tokens` budgets (hardcoded, v2.5.2)
+#### Per-call-site `max_tokens` budgets (v2.6.0: config-driven)
 
-`llm.timeout` is config-driven, but the `max_tokens` (Ollama `num_predict`) value passed to each LLM call site is currently a literal in the calling module. v2.5.2 raised these caps to give reasoning models (qwen3.5+, qwen3.6, nemotron-3) room to emit their hidden `<think>...</think>` tokens *and* a final answer; pre-2.5.2 caps were exhausted entirely by reasoning, leaving the JSON answer empty.
+`llm.timeout` is config-driven. v2.6.0 moved `max_tokens` (Ollama `num_predict`) values to `LLMConfig`, making them config-overridable per call site. v2.5.2 raised these caps to give reasoning models (qwen3.5+, qwen3.6, nemotron-3) room to emit their hidden `<think>...</think>` tokens *and* a final answer; pre-2.5.2 caps were exhausted entirely by reasoning, leaving the JSON answer empty.
 
 | Call site | File | Budget | Why |
 |:----------|:-----|:-------|:----|
@@ -169,7 +169,7 @@ class LLMConfig:
 
 **Operational impact.** Causal extraction at 8000 tokens runs 60–140 s per call on a 9B-Q4_K_M reasoning model; `remember(sync=True)` therefore blocks 1–3 minutes per note. The default async path (background enrichment queue) is unaffected — these calls happen off the write hot path. If you're triggering `sync=True` or doing bulk ingestion you'll feel the latency; switch to async or scale up the model server.
 
-If you're on faster hardware or smaller non-reasoning models you can monkey-patch lower values, but the 2.5.2 defaults trade latency for correctness on the reference qwen3.5:9b setup. v2.6.0 (tracked in [issue #125](https://github.com/rolandpg/zettelforge/issues/125)) will move these to `LLMConfig` so you can override per call site without touching code.
+If you're on faster hardware or smaller non-reasoning models you can monkey-patch lower values, but the 2.5.2 defaults trade latency for correctness on the reference qwen3.5:9b setup. v2.6.0 moves these to `LLMConfig` so you can override per call site without touching code — see [issue #125](https://github.com/rolandpg/zettelforge/issues/125).
 
 #### LiteLLM model prefix examples
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -92,6 +92,7 @@ web = [
     "fastapi>=0.100.0",
     "uvicorn>=0.20.0",
     "psutil>=5.9.0",
+    "jinja2>=3.0.0",
 ]
 
 # LangChain integration
@@ -109,6 +110,7 @@ dev = [
     "fastapi>=0.100.0",     # for test_web_api.py
     "uvicorn>=0.20.0",      # for test_web_api.py
     "psutil>=5.9.0",        # for test_web_api.py
+    "jinja2>=3.0.0",        # for test_web_api.py
 ]
 
 [project.urls]

--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -23,6 +23,7 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "web"))
 def client():
     """Create a TestClient for the ZettelForge web app."""
     os.environ.setdefault("ZETTELFORGE_BACKEND", "sqlite")
+    os.environ.setdefault("ZETTELFORGE_LLM_PROVIDER", "mock")
     from web.app import app
 
     with TestClient(app) as c:

--- a/web/app.py
+++ b/web/app.py
@@ -879,7 +879,16 @@ async def index(request: Request):
 @app.get("/config", response_class=HTMLResponse)
 async def config_page(request: Request):
     """Serve the config editor."""
-    return templates.TemplateResponse(request, "config_editor.html")
+    try:
+        cfg = get_config()
+        import yaml
+        config_yaml = yaml.dump(_to_dict(cfg), default_flow_style=False, sort_keys=False)
+    except Exception:
+        config_yaml = ""
+    return templates.TemplateResponse(
+        request, "config_editor.html",
+        {"config_yaml": config_yaml, "config_path": "config.yaml"}
+    )
 
 
 @app.get("/api/version", dependencies=[Depends(require_api_guard)])

--- a/web/app.py
+++ b/web/app.py
@@ -531,51 +531,49 @@ async def entities(
 
 
 @app.get("/api/history", dependencies=[Depends(require_api_guard)])
-async def history():
-    """Recent activity from telemetry JSONL files (last 5 days)."""
+async def history(
+    limit: int = Query(default=100, ge=1, le=500),
+    days: int = Query(default=5, ge=1, le=30),
+):
+    """Recent activity from telemetry JSONL files."""
     try:
-        from zettelforge.config import get_config as _get_cfg
-        cfg = _get_cfg()
+        cfg = get_config()
         data_dir = Path(os.path.expanduser(cfg.storage.data_dir))
         telemetry_dir = data_dir / "telemetry"
-        now = datetime.now()
+        if not telemetry_dir.exists():
+            return []
+
         entries = []
+        cutoff = datetime.now() - timedelta(days=days)
 
-        for day_offset in range(5):
-            day = datetime(now.year, now.month, now.day) - timedelta(days=day_offset)
-            fname = f"telemetry_{day.strftime('%Y-%m-%d')}.jsonl"
-            fpath = telemetry_dir / fname
-            if not fpath.exists():
-                continue
+        for telemetry_file in sorted(telemetry_dir.glob("telemetry_*.jsonl"), reverse=True):
+            if len(entries) >= limit:
+                break
             try:
-                with open(fpath) as f:
-                    for line in f:
-                        line = line.strip()
-                        if not line:
-                            continue
-                        try:
-                            ev = json.loads(line)
-                        except json.JSONDecodeError:
-                            continue
-                        entries.append({
-                            "query_id": ev.get("query_id", ""),
-                            "query": ev.get("query", "")[:200],
-                            "event_type": ev.get("event_type", ""),
-                            "timestamp": ev.get("timestamp", 0),
-                            "result_count": ev.get("result_count", 0),
-                            "duration_ms": ev.get("duration_ms", 0),
-                            "actor": ev.get("actor"),
-                            "intent": ev.get("intent", ""),
-                        })
-            except Exception:
+                file_date_str = telemetry_file.stem.split("_")[1]
+                file_date = datetime.strptime(file_date_str, "%Y-%m-%d")
+                if file_date < cutoff:
+                    continue
+            except (IndexError, ValueError):
                 continue
 
-        # Sort newest first
-        entries.sort(key=lambda e: e.get("timestamp", 0), reverse=True)
-        return {"entries": entries[:200], "total": len(entries)}
+            with open(telemetry_file) as f:
+                for line in f:
+                    if len(entries) >= limit:
+                        break
+                    line = line.strip()
+                    if not line:
+                        continue
+                    try:
+                        entry = json.loads(line)
+                        entries.append(entry)
+                    except json.JSONDecodeError:
+                        continue
+
+        return entries
     except Exception as e:
-        logger.exception("history_failed")
-        return JSONResponse(status_code=500, content={"error": str(e), "entries": [], "total": 0})
+        logger.exception("History endpoint failed")
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
 
 class BulkIngestItem(BaseModel):
@@ -875,13 +873,13 @@ async def telemetry_stream():
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     """Serve the SPA."""
-    return templates.TemplateResponse("index.html", {"request": request})
+    return templates.TemplateResponse(request, "index.html")
 
 
 @app.get("/config", response_class=HTMLResponse)
 async def config_page(request: Request):
     """Serve the config editor."""
-    return templates.TemplateResponse("config_editor.html", {"request": request})
+    return templates.TemplateResponse(request, "config_editor.html")
 
 
 @app.get("/api/version", dependencies=[Depends(require_api_guard)])

--- a/web/app.py
+++ b/web/app.py
@@ -1,4 +1,5 @@
-"""ZettelForge Web UI — FastAPI backend + SPA frontend (RFC-015).
+"""
+ZettelForge Web UI — FastAPI backend + minimal HTML frontend.
 
 A search-and-recall interface for ZettelForge's CTI memory system.
 
@@ -7,28 +8,13 @@ Usage:
     python web/app.py --port 9000        # Custom port
     uvicorn web.app:app --reload         # Dev mode
 
-Endpoints (existing):
-    GET  /                    -> Search UI (SPA HTML)
-    POST /api/recall          -> Blended recall (vector + graph)
-    POST /api/remember        -> Store a note
-    POST /api/synthesize      -> RAG synthesis
-    GET  /api/stats           -> Memory system stats
-    POST /api/sync            -> Trigger OpenCTI sync
-
-Endpoints (RFC-015, new):
-    GET  /api/health          -> System health
-    GET  /api/config          -> Current config (secrets redacted)
-    PUT  /api/config          -> Apply config changes
-    GET  /api/graph/nodes     -> KG entity nodes
-    GET  /api/graph/edges     -> KG relationship edges
-    GET  /api/entities        -> Paginated entity index
-    GET  /api/history         -> Recent activity
-    POST /api/ingest          -> Bulk ingestion
-    GET  /api/telemetry       -> Aggregated telemetry summary
-    GET  /api/storage         -> Storage stats
-    GET  /api/logs            -> Log file tailing
-    GET  /api/logs/stream     -> SSE log streaming
-    GET  /api/telemetry/stream -> SSE telemetry streaming
+Endpoints:
+    GET  /                    → Search UI (HTML)
+    POST /api/recall          → Blended recall (vector + graph)
+    POST /api/remember        → Store a note
+    POST /api/synthesize      → RAG synthesis
+    GET  /api/stats           → Memory system stats
+    POST /api/sync            → Trigger OpenCTI sync
 """
 
 # isort: skip_file
@@ -48,6 +34,8 @@ from typing import Any, List, Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
 from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.staticfiles import StaticFiles
+from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
 # Ensure zettelforge is importable
@@ -55,20 +43,30 @@ sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
 
 os.environ.setdefault("ZETTELFORGE_BACKEND", "sqlite")
 
-from zettelforge import MemoryManager, __version__
-from zettelforge.config import get_config
-from zettelforge.edition import edition_name, is_enterprise
-from web.auth import get_mm_for_request, register_auth_routes
+from zettelforge import MemoryManager, __version__  # noqa: E402
+from zettelforge.config import get_config, reload_config, _apply_yaml  # noqa: E402
+from zettelforge.edition import edition_name, is_enterprise  # noqa: E402
+from zettelforge.knowledge_graph import get_knowledge_graph  # noqa: E402
+from web.auth import get_mm_for_request, register_auth_routes  # noqa: E402
+
+# ── Jinja2 + static files ──────────────────────────────────────────────────
+_web_dir = Path(__file__).parent
+templates = Jinja2Templates(directory=str(_web_dir / "templates"))
+templates.env.globals["version"] = __version__
 
 logger = logging.getLogger(__name__)
-
-_start_time = time.monotonic()
 
 app = FastAPI(
     title="ZettelForge",
     description=edition_name(),
     version=__version__,
 )
+
+# Mount static files after app is created
+app.mount("/static", StaticFiles(directory=str(_web_dir / "static")), name="static")
+
+# Uptime tracking (monotonic clock, reset on process restart)
+_start_time = time.monotonic()
 
 # Register OAuth/JWT auth routes (Enterprise: full OAuth, Community: pass-through)
 register_auth_routes(app)
@@ -94,7 +92,36 @@ _rate_lock = threading.Lock()
 _rate_windows = defaultdict(deque)
 _write_slots = threading.BoundedSemaphore(max(1, WRITE_CONCURRENCY))
 
-# ── Helper functions ─────────────────────────────────────────────────────────
+
+# ── Pydantic models ──────────────────────────────────────────────────────────
+
+
+class RecallRequest(BaseModel):
+    query: str = Field(min_length=1, max_length=MAX_QUERY_CHARS)
+    k: int = Field(default=10, ge=1, le=MAX_K)
+    domain: Optional[str] = Field(default=None, max_length=100)
+
+
+class RememberRequest(BaseModel):
+    content: str = Field(min_length=1, max_length=MAX_CONTENT_CHARS)
+    domain: str = Field(default="cti", min_length=1, max_length=100)
+    source_type: str = Field(default="manual", min_length=1, max_length=100)
+    source_ref: str = Field(default="", max_length=500)
+    evolve: bool = True
+
+
+class SynthesizeRequest(BaseModel):
+    query: str = Field(min_length=1, max_length=MAX_QUERY_CHARS)
+    format: str = Field(default="direct_answer", max_length=50)
+    k: int = Field(default=10, ge=1, le=MAX_K)
+
+
+class SyncRequest(BaseModel):
+    limit: int = Field(default=20, ge=1, le=MAX_SYNC_LIMIT)
+    entity_types: Optional[List[str]] = None
+
+
+# ── API endpoints ────────────────────────────────────────────────────────────
 
 
 def _client_ip(request: Request) -> str:
@@ -124,8 +151,8 @@ def _check_rate_limit(key: str) -> None:
 
 async def require_api_guard(
     request: Request,
-    x_api_key: str | None = Header(default=None, alias="X-API-Key"),
-    authorization: str | None = Header(default=None),
+    x_api_key: Optional[str] = Header(default=None, alias="X-API-Key"),
+    authorization: Optional[str] = Header(default=None),
 ) -> None:
     client_ip = _client_ip(request)
     supplied_key = x_api_key
@@ -147,87 +174,6 @@ async def require_api_guard(
         )
 
     _check_rate_limit(supplied_key or client_ip)
-
-
-def _get_memory_stats() -> dict:
-    """Get stats from the default MemoryManager."""
-    try:
-        return mm.get_stats()
-    except Exception:
-        return {"total_notes": 0, "notes_created": 0, "retrievals": 0, "entity_index": {}}
-
-
-def _get_memory_mb() -> float | None:
-    """Get current memory usage in MB. Returns None if psutil not available."""
-    try:
-        import psutil
-
-        return psutil.Process().memory_info().rss / (1024 * 1024)
-    except ImportError:
-        return None
-
-
-def _get_data_dir_size_mb(data_dir: str = "~/.amem") -> float | None:
-    """Get the size of the data directory in MB."""
-    try:
-        path = Path(os.path.expanduser(data_dir))
-        if not path.exists():
-            return None
-        total_bytes = sum(f.stat().st_size for f in path.rglob("*") if f.is_file())
-        return round(total_bytes / (1024 * 1024), 1)
-    except Exception:
-        return None
-
-
-# ── Pydantic models (existing) ───────────────────────────────────────────────
-
-
-class RecallRequest(BaseModel):
-    query: str = Field(min_length=1, max_length=MAX_QUERY_CHARS)
-    k: int = Field(default=10, ge=1, le=MAX_K)
-    domain: str | None = Field(default=None, max_length=100)
-
-
-class RememberRequest(BaseModel):
-    content: str = Field(min_length=1, max_length=MAX_CONTENT_CHARS)
-    domain: str = Field(default="cti", min_length=1, max_length=100)
-    source_type: str = Field(default="manual", min_length=1, max_length=100)
-    source_ref: str = Field(default="", max_length=500)
-    evolve: bool = True
-
-
-class SynthesizeRequest(BaseModel):
-    query: str = Field(min_length=1, max_length=MAX_QUERY_CHARS)
-    format: str = Field(default="direct_answer", max_length=50)
-    k: int = Field(default=10, ge=1, le=MAX_K)
-
-
-class SyncRequest(BaseModel):
-    limit: int = Field(default=20, ge=1, le=MAX_SYNC_LIMIT)
-    entity_types: List[str] | None = None
-
-
-# ── Pydantic models (RFC-015, new) ───────────────────────────────────────────
-
-
-class IngestItem(BaseModel):
-    content: str = Field(min_length=1, max_length=MAX_CONTENT_CHARS)
-    source_type: str = Field(default="manual")
-    source_ref: str = Field(default="")
-    domain: str = Field(default="cti")
-    evolve: bool = True
-
-
-class IngestRequest(BaseModel):
-    items: list[IngestItem] = Field(default_factory=list, max_length=100)
-
-
-class ConfigUpdateRequest(BaseModel):
-    # Accept arbitrary nested dict for config updates
-    pass
-
-
-# ── Existing API endpoints ───────────────────────────────────────────────────
 
 
 @app.post("/api/recall", dependencies=[Depends(require_api_guard)])
@@ -387,591 +333,570 @@ async def sync(request: Request, req: SyncRequest):
         return JSONResponse(status_code=500, content={"error": "Internal server error"})
 
 
-# ── RFC-015: New API Endpoints ───────────────────────────────────────────────
+# ── System Endpoints ────────────────────────────────────────────────────────────
 
 
-def _redact_secrets(obj: Any, depth: int = 0) -> Any:
-    """Recursively redact sensitive config fields."""
-    _SENSITIVE_KEYS = {"api_key", "password", "token", "secret", "license_key", "credentials"}
+def _redact_secrets(data: Any, depth: int = 0) -> Any:
+    """Recursively redact sensitive values (api_key, password, token, license_key)."""
+    SENSITIVE_KEYS = {"api_key", "password", "token", "license_key"}
     if depth > 10:
-        return obj
-    if isinstance(obj, dict):
+        return data
+    if isinstance(data, dict):
         return {
-            k: ("***" if k.lower() in _SENSITIVE_KEYS and isinstance(v, str) and v else _redact_secrets(v, depth + 1))
-            for k, v in obj.items()
+            k: ("***" if k.lower() in SENSITIVE_KEYS else _redact_secrets(v, depth + 1))
+            for k, v in data.items()
         }
-    if isinstance(obj, list):
-        return [_redact_secrets(item, depth + 1) for item in obj]
-    if hasattr(obj, "__dict__"):
-        return _redact_secrets(obj.__dict__, depth)
-    return obj
-
-
-_RESTART_REQUIRED_FIELDS = {
-    "backend", "storage.data_dir", "embedding.provider",
-    "llm.provider", "logging.log_file", "logging.level",
-}
-
-# ── 1. Health ────────────────────────────────────────────────────────────────
+    if isinstance(data, list):
+        return [_redact_secrets(item, depth + 1) for item in data]
+    return data
 
 
 @app.get("/api/health", dependencies=[Depends(require_api_guard)])
-async def health(request: Request):
-    """System health information."""
+async def health():
+    """System health endpoint — version, config, queue depths, uptime."""
     try:
         cfg = get_config()
-        s = _get_memory_stats()
-
+        kg = get_knowledge_graph()
+        uptime = time.monotonic() - _start_time
         enrichment_depth = 0
         try:
             enrichment_depth = mm._enrichment_queue.qsize()
         except Exception:
             pass
-
         return {
+            "status": "ok",
             "version": __version__,
             "edition": "enterprise" if is_enterprise() else "community",
-            "storage_backend": os.environ.get("ZETTELFORGE_BACKEND", "sqlite"),
+            "edition_name": edition_name(),
+            "storage_backend": cfg.backend,
             "embedding_provider": cfg.embedding.provider,
             "embedding_model": cfg.embedding.model,
-            "embedding_dimensions": cfg.embedding.dimensions,
             "llm_provider": cfg.llm.provider,
             "llm_model": cfg.llm.model,
             "llm_local_backend": cfg.llm.local_backend,
             "enrichment_queue_depth": enrichment_depth,
             "governance_enabled": cfg.governance.enabled,
             "pii_enabled": cfg.governance.pii.enabled,
-            "uptime_seconds": round(time.monotonic() - _start_time, 1),
+            "uptime_seconds": round(uptime, 1),
             "data_dir": cfg.storage.data_dir,
-            "memory_usage_mb": _get_memory_mb(),
-            "data_size_mb": _get_data_dir_size_mb(cfg.storage.data_dir),
-            "total_notes": s.get("total_notes", 0),
-            "retrievals": s.get("retrievals", 0),
+            "graph_node_count": len(kg._nodes),
+            "graph_edge_count": len(kg._edges),
         }
     except Exception as e:
-        logger.exception("Health endpoint failed")
+        logger.exception("health_check_failed")
         return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 2. Config GET ────────────────────────────────────────────────────────────
 
 
 @app.get("/api/config", dependencies=[Depends(require_api_guard)])
 async def get_config_endpoint():
-    """Return the current configuration with secrets redacted."""
+    """Return current config as JSON with secrets redacted."""
     try:
         cfg = get_config()
-        config_dict = {}
-        for key in dir(cfg):
-            if key.startswith("_"):
-                continue
-            val = getattr(cfg, key)
-            if hasattr(val, "__dataclass_fields__"):
-                config_dict[key] = _redact_secrets(
-                    {f: getattr(val, f) for f in dir(val) if not f.startswith("_")}
-                )
-            else:
-                config_dict[key] = val
-        return config_dict
+
+        def _to_dict(obj):
+            """Convert dataclass to plain dict."""
+            if hasattr(obj, "__dataclass_fields__"):
+                return {k: _to_dict(v) for k, v in obj.__dict__.items()}
+            if isinstance(obj, dict):
+                return {k: _to_dict(v) for k, v in obj.items()}
+            if isinstance(obj, (list, tuple)):
+                return [_to_dict(item) for item in obj]
+            if isinstance(obj, (int, float, bool, str, type(None))):
+                return obj
+            return str(obj)
+
+        raw = _to_dict(cfg)
+        redacted = _redact_secrets(raw)
+        return redacted
     except Exception as e:
-        logger.exception("Config endpoint failed")
+        logger.exception("get_config_failed")
         return JSONResponse(status_code=500, content={"error": str(e)})
 
 
-# ── 3. Config PUT ────────────────────────────────────────────────────────────
+class ConfigUpdateRequest(BaseModel):
+    """Accepted fields: any config section key, value pairs."""
+    pass
 
 
 @app.put("/api/config", dependencies=[Depends(require_api_guard)])
-async def put_config_endpoint(data: dict):
-    """Apply configuration changes in-memory."""
+async def update_config(req: dict):
+    """Apply config changes in-memory. Returns applied + pending-restart fields."""
     try:
-
         cfg = get_config()
+        # Fields that require a restart to take effect
+        RESTART_REQUIRED = {"backend", "embedding.provider", "embedding.url",
+                            "llm.provider", "llm.model", "llm.url",
+                            "storage.data_dir", "logging.log_file"}
         applied = []
         pending_restart = []
 
-        def _find_changes(prefix: str, updates: dict, target: Any):
-            for k, v in updates.items():
-                full_key = f"{prefix}.{k}" if prefix else k
-                if isinstance(v, dict) and hasattr(target, k):
-                    sub = getattr(target, k)
-                    if hasattr(sub, "__dataclass_fields__"):
-                        _find_changes(full_key, v, sub)
-                        continue
-                if hasattr(target, k):
-                    setattr(target, k, v)
-                    applied.append(full_key)
-                    if full_key in _RESTART_REQUIRED_FIELDS or k in _RESTART_REQUIRED_FIELDS:
-                        pending_restart.append(full_key)
+        _apply_yaml(cfg, req)
 
-        _find_changes("", data, cfg)
+        # Determine which changes need restart
+        for key in req:
+            if key in RESTART_REQUIRED:
+                pending_restart.append(key)
+            else:
+                applied.append(key)
 
         return {
             "applied": applied,
             "pending_restart": pending_restart,
-            "message": "Configuration updated. Some changes require a restart."
-            if pending_restart
-            else "Configuration updated.",
+            "message": "Config updated in-memory. Some changes require a restart."
         }
     except Exception as e:
-        logger.exception("Config put endpoint failed")
+        logger.exception("update_config_failed")
         return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 4. Graph Nodes ───────────────────────────────────────────────────────────
 
 
 @app.get("/api/graph/nodes", dependencies=[Depends(require_api_guard)])
-async def graph_nodes(request: Request):
-    """Return all knowledge graph entity nodes."""
+async def graph_nodes():
+    """Return all knowledge graph nodes."""
     try:
-        tenant_mm = get_mm_for_request(request)
-        kg = getattr(tenant_mm, "_knowledge_graph", None)
+        kg = get_knowledge_graph()
         nodes = []
-        if kg is not None:
-            raw_nodes = getattr(kg, "_nodes", {}) or {}
-            for nid, node in raw_nodes.items():
-                nodes.append({
-                    "id": nid,
-                    "label": node.get("name", nid),
-                    "type": node.get("entity_type", "unknown"),
-                    "tier": node.get("tier", "C"),
-                    "aliases": node.get("aliases", []),
-                    "confidence": node.get("confidence", 0.5),
-                    "created_at": node.get("created_at"),
-                })
+        for node_id, node in kg._nodes.items():
+            nodes.append({
+                "id": node.get("node_id", node_id),
+                "label": node.get("entity_value", ""),
+                "type": node.get("entity_type", ""),
+                "tier": node.get("properties", {}).get("tier", ""),
+                "aliases": node.get("properties", {}).get("aliases", []),
+                "confidence": node.get("properties", {}).get("confidence", 0.0),
+                "created_at": node.get("created_at", ""),
+            })
         return {"nodes": nodes, "count": len(nodes)}
     except Exception as e:
-        logger.exception("Graph nodes endpoint failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 5. Graph Edges ───────────────────────────────────────────────────────────
+        logger.exception("graph_nodes_failed")
+        return JSONResponse(status_code=500, content={"error": str(e), "nodes": []})
 
 
 @app.get("/api/graph/edges", dependencies=[Depends(require_api_guard)])
-async def graph_edges(request: Request):
-    """Return all knowledge graph relationship edges."""
+async def graph_edges():
+    """Return all knowledge graph edges."""
     try:
-        tenant_mm = get_mm_for_request(request)
-        kg = getattr(tenant_mm, "_knowledge_graph", None)
+        kg = get_knowledge_graph()
         edges = []
-        if kg is not None:
-            raw_edges = getattr(kg, "_edges", {}) or {}
-            for eid, edge in raw_edges.items():
-                edges.append({
-                    "id": eid,
-                    "source": edge.get("source_id"),
-                    "target": edge.get("target_id"),
-                    "relationship": edge.get("relationship"),
-                    "created_at": edge.get("created_at"),
-                })
+        for edge_id, edge in kg._edges.items():
+            edges.append({
+                "id": edge.get("edge_id", edge_id),
+                "source": edge.get("from_node_id", ""),
+                "target": edge.get("to_node_id", ""),
+                "relationship": edge.get("relationship", ""),
+                "created_at": edge.get("created_at", ""),
+            })
         return {"edges": edges, "count": len(edges)}
     except Exception as e:
-        logger.exception("Graph edges endpoint failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 6. Entities ──────────────────────────────────────────────────────────────
+        logger.exception("graph_edges_failed")
+        return JSONResponse(status_code=500, content={"error": str(e), "edges": []})
 
 
 @app.get("/api/entities", dependencies=[Depends(require_api_guard)])
 async def entities(
-    request: Request,
     offset: int = Query(default=0, ge=0),
-    limit: int = Query(default=50, ge=1, le=200),
-    entity_type: str | None = Query(default=None, alias="type"),
-    tier: str | None = Query(default=None),
-    q: str | None = Query(default=None),
+    limit: int = Query(default=50, ge=1, le=500),
+    type: Optional[str] = Query(default=None),
+    tier: Optional[str] = Query(default=None),
+    q: Optional[str] = Query(default=None),
 ):
-    """Paginated entity index with filters."""
+    """Paginated entity index query."""
     try:
-        tenant_mm = get_mm_for_request(request)
-        kg = getattr(tenant_mm, "_knowledge_graph", None)
+        # Use entity indexer from memory manager if available
+        idx = getattr(mm, "indexer", None)
+        if idx is None:
+            return {"entities": [], "total": 0, "offset": offset, "limit": limit}
 
         all_entities = []
-        if kg is not None:
-            raw_nodes = getattr(kg, "_nodes", {}) or {}
-            for nid, node in raw_nodes.items():
+        for etype, entities in idx.index.items():
+            if type and etype != type:
+                continue
+            for evalue, note_ids in entities.items():
+                if q and q.lower() not in evalue.lower():
+                    continue
+                # Look up tier from earliest note if possible
+                ent_tier = tier if tier else ""
                 all_entities.append({
-                    "id": nid,
-                    "name": node.get("name", nid),
-                    "type": node.get("entity_type", "unknown"),
-                    "tier": node.get("tier", "C"),
-                    "confidence": node.get("confidence", 0.5),
-                    "aliases": node.get("aliases", []),
-                    "first_seen": node.get("created_at"),
-                    "last_seen": node.get("updated_at"),
-                    "connected_count": len(
-                        getattr(kg, "_edges_from", {}).get(nid, [])
-                    ),
+                    "entity_type": etype,
+                    "entity_value": evalue,
+                    "note_count": len(note_ids),
+                    "tier": ent_tier,
                 })
 
-        # Apply filters
-        if entity_type:
-            all_entities = [e for e in all_entities if e["type"] == entity_type]
-        if tier:
-            all_entities = [e for e in all_entities if e["tier"] == tier]
-        if q:
-            q_lower = q.lower()
-            all_entities = [
-                e
-                for e in all_entities
-                if q_lower in e["name"].lower()
-                or any(q_lower in a.lower() for a in e["aliases"])
-            ]
-
         total = len(all_entities)
-        page = all_entities[offset : offset + limit]
-
+        page = all_entities[offset:offset + limit]
         return {"entities": page, "total": total, "offset": offset, "limit": limit}
     except Exception as e:
-        logger.exception("Entities endpoint failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 7. History ───────────────────────────────────────────────────────────────
+        logger.exception("entities_failed")
+        return JSONResponse(status_code=500, content={"error": str(e), "entities": [], "total": 0, "offset": offset, "limit": limit})
 
 
 @app.get("/api/history", dependencies=[Depends(require_api_guard)])
-async def history(
-    limit: int = Query(default=100, ge=1, le=500),
-    days: int = Query(default=5, ge=1, le=30),
-):
-    """Recent activity from telemetry JSONL files."""
+async def history():
+    """Recent activity from telemetry JSONL files (last 5 days)."""
     try:
-        cfg = get_config()
+        from zettelforge.config import get_config as _get_cfg
+        cfg = _get_cfg()
         data_dir = Path(os.path.expanduser(cfg.storage.data_dir))
         telemetry_dir = data_dir / "telemetry"
-        if not telemetry_dir.exists():
-            return []
-
+        now = datetime.now()
         entries = []
-        cutoff = datetime.now() - timedelta(days=days)
 
-        for telemetry_file in sorted(telemetry_dir.glob("telemetry_*.jsonl"), reverse=True):
-            if len(entries) >= limit:
-                break
-            # Parse date from filename
+        for day_offset in range(5):
+            day = datetime(now.year, now.month, now.day) - timedelta(days=day_offset)
+            fname = f"telemetry_{day.strftime('%Y-%m-%d')}.jsonl"
+            fpath = telemetry_dir / fname
+            if not fpath.exists():
+                continue
             try:
-                file_date_str = telemetry_file.stem.split("_")[1]
-                file_date = datetime.strptime(file_date_str, "%Y-%m-%d")
-                if file_date < cutoff:
-                    continue
-            except (IndexError, ValueError):
+                with open(fpath) as f:
+                    for line in f:
+                        line = line.strip()
+                        if not line:
+                            continue
+                        try:
+                            ev = json.loads(line)
+                        except json.JSONDecodeError:
+                            continue
+                        entries.append({
+                            "query_id": ev.get("query_id", ""),
+                            "query": ev.get("query", "")[:200],
+                            "event_type": ev.get("event_type", ""),
+                            "timestamp": ev.get("timestamp", 0),
+                            "result_count": ev.get("result_count", 0),
+                            "duration_ms": ev.get("duration_ms", 0),
+                            "actor": ev.get("actor"),
+                            "intent": ev.get("intent", ""),
+                        })
+            except Exception:
                 continue
 
-            with open(telemetry_file) as f:
-                for line in f:
-                    if len(entries) >= limit:
-                        break
-                    line = line.strip()
-                    if not line:
-                        continue
-                    try:
-                        entry = json.loads(line)
-                        entries.append(entry)
-                    except json.JSONDecodeError:
-                        continue
-
-        return entries
+        # Sort newest first
+        entries.sort(key=lambda e: e.get("timestamp", 0), reverse=True)
+        return {"entries": entries[:200], "total": len(entries)}
     except Exception as e:
-        logger.exception("History endpoint failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+        logger.exception("history_failed")
+        return JSONResponse(status_code=500, content={"error": str(e), "entries": [], "total": 0})
 
 
-# ── 8. Ingest ────────────────────────────────────────────────────────────────
+class BulkIngestItem(BaseModel):
+    content: str = Field(min_length=1, max_length=MAX_CONTENT_CHARS)
+    source_type: str = "manual"
+    domain: str = "cti"
+    evolve: bool = True
+
+
+class BulkIngestRequest(BaseModel):
+    items: list[BulkIngestItem] = Field(min_length=1, max_length=100)
 
 
 @app.post("/api/ingest", dependencies=[Depends(require_api_guard)])
-async def ingest(request: Request, req: IngestRequest):
-    """Bulk ingestion endpoint."""
+async def ingest(request: Request, req: BulkIngestRequest):
+    """Bulk ingestion — remember multiple items."""
     tenant_mm = get_mm_for_request(request)
+    total = len(req.items)
+    succeeded = 0
+    failed = 0
     results = []
 
     for item in req.items:
         if not _write_slots.acquire(blocking=False):
             results.append({
-                "status": "error",
-                "error": "Write capacity exhausted; retry shortly",
+                "note_id": None,
+                "status": "skipped",
+                "entities": [],
                 "success": False,
+                "error": "Write capacity exhausted",
             })
+            failed += 1
             continue
         try:
             note, status_text = tenant_mm.remember(
                 content=item.content,
                 source_type=item.source_type,
-                source_ref=item.source_ref,
                 domain=item.domain,
                 evolve=item.evolve,
             )
+            succeeded += 1
             results.append({
                 "note_id": note.id,
                 "status": status_text,
                 "entities": note.semantic.entities[:10],
                 "success": True,
+                "error": None,
             })
         except Exception as e:
+            failed += 1
             results.append({
+                "note_id": None,
                 "status": "error",
-                "error": str(e),
+                "entities": [],
                 "success": False,
+                "error": str(e),
             })
         finally:
             _write_slots.release()
 
     return {
-        "total": len(results),
-        "succeeded": sum(1 for r in results if r.get("success")),
-        "failed": sum(1 for r in results if not r.get("success")),
+        "total": total,
+        "succeeded": succeeded,
+        "failed": failed,
         "results": results,
     }
 
 
-# ── 9. Telemetry ─────────────────────────────────────────────────────────────
-
-
 @app.get("/api/telemetry", dependencies=[Depends(require_api_guard)])
-async def telemetry():
-    """Aggregated telemetry summary from today's data."""
+async def telemetry_summary():
+    """Aggregated telemetry summary from today's telemetry JSONL."""
     try:
         cfg = get_config()
         data_dir = Path(os.path.expanduser(cfg.storage.data_dir))
         telemetry_dir = data_dir / "telemetry"
-        today_str = datetime.now().strftime("%Y-%m-%d")
-        telemetry_file = telemetry_dir / f"telemetry_{today_str}.jsonl"
+        today = datetime.now().strftime("%Y-%m-%d")
+        fpath = telemetry_dir / f"telemetry_{today}.jsonl"
 
-        if not telemetry_file.exists():
+        if not fpath.exists():
             return {
                 "total_queries": 0,
                 "recall_count": 0,
                 "synthesis_count": 0,
-                "avg_latency_ms": None,
-                "p50_ms": None,
-                "p95_ms": None,
+                "avg_latency_ms": 0,
+                "p50_ms": 0,
+                "p95_ms": 0,
                 "top_intents": {},
             }
 
         latencies = []
-        intents: dict[str, int] = {}
         recall_count = 0
         synthesis_count = 0
+        top_intents = {}
 
-        with open(telemetry_file) as f:
+        with open(fpath) as f:
             for line in f:
                 line = line.strip()
                 if not line:
                     continue
                 try:
-                    event = json.loads(line)
-                    event_type = event.get("event_type", "")
-                    if event_type == "recall":
-                        recall_count += 1
-                    elif event_type == "synthesis":
-                        synthesis_count += 1
-
-                    duration = event.get("duration_ms")
-                    if duration is not None:
-                        latencies.append(duration)
-
-                    intent = event.get("intent")
-                    if intent:
-                        intents[intent] = intents.get(intent, 0) + 1
-                except (json.JSONDecodeError, KeyError):
+                    ev = json.loads(line)
+                except json.JSONDecodeError:
                     continue
 
-        total = len(latencies)
-        avg_latency = round(sum(latencies) / total, 1) if total > 0 else None
-        sorted_lat = sorted(latencies)
-        p50 = sorted_lat[len(sorted_lat) // 2] if total > 0 else None
-        p95 = sorted_lat[int(len(sorted_lat) * 0.95)] if total > 0 else None
+                ev_type = ev.get("event_type", "")
+                if ev_type == "recall":
+                    recall_count += 1
+                elif ev_type == "synthesis":
+                    synthesis_count += 1
 
-        # Sort intents by count descending
-        sorted_intents = dict(sorted(intents.items(), key=lambda x: -x[1]))
+                dms = ev.get("duration_ms", 0)
+                if isinstance(dms, (int, float)) and dms > 0:
+                    latencies.append(dms)
+
+                intent = ev.get("intent", "")
+                if intent:
+                    top_intents[intent] = top_intents.get(intent, 0) + 1
+
+        total_queries = recall_count + synthesis_count
+        avg_latency = round(sum(latencies) / len(latencies)) if latencies else 0
+
+        # Percentiles
+        sorted_lat = sorted(latencies)
+        p50 = sorted_lat[len(sorted_lat) // 2] if sorted_lat else 0
+        p95 = sorted_lat[int(len(sorted_lat) * 0.95)] if sorted_lat else 0
 
         return {
-            "total_queries": recall_count + synthesis_count,
+            "total_queries": total_queries,
             "recall_count": recall_count,
             "synthesis_count": synthesis_count,
             "avg_latency_ms": avg_latency,
             "p50_ms": p50,
             "p95_ms": p95,
-            "top_intents": sorted_intents,
+            "top_intents": top_intents,
         }
     except Exception as e:
-        logger.exception("Telemetry endpoint failed")
+        logger.exception("telemetry_summary_failed")
         return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 10. Storage ─────────────────────────────────────────────────────────────
 
 
 @app.get("/api/storage", dependencies=[Depends(require_api_guard)])
-async def storage(request: Request):
-    """Storage statistics."""
+async def storage_stats():
+    """Storage statistics — notes, entities, graph counts."""
     try:
-        tenant_mm = get_mm_for_request(request)
-        s = tenant_mm.get_stats()
-        kg = getattr(tenant_mm, "_knowledge_graph", None)
-
-        graph_node_count = len(getattr(kg, "_nodes", {})) if kg else 0
-        graph_edge_count = len(getattr(kg, "_edges", {})) if kg else 0
-
+        s = mm.get_stats()
+        kg = get_knowledge_graph()
         return {
             "total_notes": s.get("total_notes", 0),
-            "entity_count": len(s.get("entity_index", {})),
-            "graph_node_count": graph_node_count,
-            "graph_edge_count": graph_edge_count,
+            "entity_count": sum(
+                stats.get("unique_entities", 0)
+                for stats in s.get("entity_index", {}).values()
+            ),
+            "graph_node_count": len(kg._nodes),
+            "graph_edge_count": len(kg._edges),
         }
     except Exception as e:
-        logger.exception("Storage endpoint failed")
+        logger.exception("storage_stats_failed")
         return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 11. Logs ─────────────────────────────────────────────────────────────────
-
-
-def _parse_log_line(line: str, level_filter: str | None = None) -> dict | None:
-    """Parse a structlog JSON line into a dict."""
-    try:
-        entry = json.loads(line)
-        if level_filter and entry.get("level", "").upper() != level_filter.upper():
-            return None
-        return entry
-    except (json.JSONDecodeError, KeyError):
-        return None
 
 
 @app.get("/api/logs", dependencies=[Depends(require_api_guard)])
 async def logs(
-    lines: int = Query(default=100, ge=1, le=1000),
-    level: str | None = Query(default=None),
+    lines: int = Query(default=100, ge=1, le=10000),
+    level: Optional[str] = Query(default=None),
 ):
-    """Tail the structlog file with optional level filter."""
+    """Read last N lines from the structlog file. Optionally filter by level."""
     try:
         cfg = get_config()
-        log_file = cfg.logging.log_file
-        if not log_file:
-            # Default log path
-            data_dir = Path(os.path.expanduser(cfg.storage.data_dir))
-            log_file = str(data_dir / "zettelforge.log")
+        log_path = cfg.logging.log_file
+        if not log_path:
+            return {"logs": [], "truncated": False, "error": "No log file configured"}
 
-        log_path = Path(os.path.expanduser(log_file))
-        if not log_path.exists():
-            return {"logs": [], "truncated": False}
+        log_path = os.path.expanduser(log_path) if log_path.startswith("~") else log_path
+        log_file = Path(log_path)
+        if not log_file.exists():
+            return {"logs": [], "truncated": False, "error": f"Log file not found: {log_path}"}
 
         # Read last N lines
-        with open(log_path) as f:
+        with open(log_file) as f:
             all_lines = f.readlines()
 
-        # Parse and filter
-        parsed: list[dict] = []
-        for line in reversed(all_lines):
-            entry = _parse_log_line(line.strip(), level)
-            if entry is not None:
-                parsed.append(entry)
-                if len(parsed) >= lines:
-                    break
+        truncated = len(all_lines) > lines
+        tail = all_lines[-lines:]
 
-        parsed.reverse()
-        return {"logs": parsed, "truncated": len(parsed) < len(all_lines)}
+        parsed_logs = []
+        for line in tail:
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                entry = json.loads(line)
+            except json.JSONDecodeError:
+                entry = {"message": line}
+
+            log_level = entry.get("level", entry.get("event", "")).upper()
+            if level and level.upper() != log_level:
+                continue
+
+            parsed_logs.append(entry)
+
+        return {"logs": parsed_logs, "truncated": truncated}
     except Exception as e:
-        logger.exception("Logs endpoint failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
-
-
-# ── 12. Logs SSE Stream ─────────────────────────────────────────────────────
+        logger.exception("logs_failed")
+        return JSONResponse(status_code=500, content={"error": str(e), "logs": [], "truncated": False})
 
 
 @app.get("/api/logs/stream", dependencies=[Depends(require_api_guard)])
 async def log_stream():
-    """SSE endpoint for live log streaming."""
+    """SSE endpoint that tails the structlog file."""
     cfg = get_config()
-    log_file = cfg.logging.log_file
-    if not log_file:
-        data_dir = Path(os.path.expanduser(cfg.storage.data_dir))
-        log_file = str(data_dir / "zettelforge.log")
-    log_path = Path(os.path.expanduser(log_file))
+    log_path = cfg.logging.log_file
+    if not log_path:
+        return JSONResponse(status_code=400, content={"error": "No log file configured"})
+
+    log_path = os.path.expanduser(log_path) if log_path.startswith("~") else log_path
+    log_file = Path(log_path)
 
     async def event_generator():
-        if not log_path.exists():
-            yield f"data: {json.dumps({'event': 'log stream started', 'level': 'INFO'})}\n\n"
-            return
-
+        seen_inodes = 0
+        last_size = 0
         try:
-            with open(log_path) as f:
+            if log_file.exists():
+                stat = log_file.stat()
+                seen_inodes = stat.st_ino
+                last_size = stat.st_size
                 # Seek to end
-                f.seek(0, 2)
-                while True:
-                    line = f.readline()
-                    if line:
-                        line = line.strip()
-                        if line:
-                            try:
-                                event = json.loads(line)
-                                yield f"data: {json.dumps(event)}\n\n"
-                            except json.JSONDecodeError:
-                                yield f"data: {json.dumps({'message': line, 'level': 'RAW'})}\n\n"
-                    else:
-                        await asyncio.sleep(0.1)
         except Exception:
-            yield f"data: {json.dumps({'event': 'Log stream ended', 'level': 'WARNING'})}\n\n"
+            pass
+
+        while True:
+            try:
+                if not log_file.exists():
+                    await asyncio.sleep(0.1)
+                    continue
+
+                stat = log_file.stat()
+                current_inode = stat.st_ino
+
+                # Handle log rotation (new inode)
+                if current_inode != seen_inodes:
+                    seen_inodes = current_inode
+                    last_size = 0
+
+                current_size = stat.st_size
+                if current_size > last_size:
+                    with open(log_file) as f:
+                        f.seek(last_size)
+                        new_data = f.read()
+                        last_size = f.tell()
+                        if new_data:
+                            for line in new_data.splitlines():
+                                if line.strip():
+                                    yield f"data: {line}\n\n"
+
+                await asyncio.sleep(0.1)
+            except Exception:
+                await asyncio.sleep(0.1)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
-
-
-# ── 13. Telemetry SSE Stream ────────────────────────────────────────────────
 
 
 @app.get("/api/telemetry/stream", dependencies=[Depends(require_api_guard)])
 async def telemetry_stream():
-    """SSE endpoint for live telemetry streaming."""
+    """SSE endpoint for live telemetry. Watches today's telemetry JSONL file."""
     cfg = get_config()
     data_dir = Path(os.path.expanduser(cfg.storage.data_dir))
     telemetry_dir = data_dir / "telemetry"
-    today_str = datetime.now().strftime("%Y-%m-%d")
-    telemetry_path = telemetry_dir / f"telemetry_{today_str}.jsonl"
+    today = datetime.now().strftime("%Y-%m-%d")
+    fpath = telemetry_dir / f"telemetry_{today}.jsonl"
 
     async def event_generator():
-        if not telemetry_path.exists():
-            yield f"data: {json.dumps({'event': 'telemetry stream started', 'level': 'INFO'})}\n\n"
-            return
-
-        try:
-            with open(telemetry_path) as f:
-                f.seek(0, 2)
-                while True:
-                    line = f.readline()
-                    if line:
-                        line = line.strip()
-                        if line:
-                            try:
-                                event = json.loads(line)
-                                yield f"data: {json.dumps(event)}\n\n"
-                            except json.JSONDecodeError:
-                                pass
-                    else:
-                        await asyncio.sleep(0.1)
-        except Exception:
-            yield f"data: {json.dumps({'event': 'Telemetry stream ended', 'level': 'WARNING'})}\n\n"
+        last_size = 0
+        while True:
+            try:
+                telemetry_dir.mkdir(parents=True, exist_ok=True)
+                if fpath.exists():
+                    current_size = fpath.stat().st_size
+                    if current_size > last_size:
+                        with open(fpath) as f:
+                            f.seek(last_size)
+                            new_data = f.read()
+                            last_size = f.tell()
+                            if new_data:
+                                for line in new_data.splitlines():
+                                    if line.strip():
+                                        yield f"data: {line}\n\n"
+                await asyncio.sleep(0.1)
+            except Exception:
+                await asyncio.sleep(0.1)
 
     return StreamingResponse(event_generator(), media_type="text/event-stream")
 
 
-# ── HTML Frontend (SPA) ──────────────────────────────────────────────────────
-# RFC-015: ZettelForge Web Management Interface served from web/ui/
+# ── HTML Frontend ────────────────────────────────────────────────────────────
 
 
 @app.get("/", response_class=HTMLResponse)
-async def index():
-    ui_dir = Path(__file__).parent / "ui"
-    index_path = ui_dir / "index.html"
-    if index_path.exists():
-        return index_path.read_text(encoding="utf-8")
-    return HTMLResponse(
-        content="<html><body><h1>ZettelForge</h1><p>Web UI not found. Run from the project root.</p></body></html>",
-        status_code=200,
-    )
+async def index(request: Request):
+    """Serve the SPA."""
+    return templates.TemplateResponse("index.html", {"request": request})
+
+
+@app.get("/config", response_class=HTMLResponse)
+async def config_page(request: Request):
+    """Serve the config editor."""
+    return templates.TemplateResponse("config_editor.html", {"request": request})
+
+
+@app.get("/api/version", dependencies=[Depends(require_api_guard)])
+async def version_info():
+    """Return version and basic stats for the SPA header."""
+    try:
+        s = mm.get_stats()
+        return {
+            "version": __version__,
+            "notes": s.get("total_notes", 0),
+            "edition": "enterprise" if is_enterprise() else "community",
+        }
+    except Exception as e:
+        logger.exception("version_info_failed")
+        return JSONResponse(status_code=500, content={"error": str(e)})
 
 
 if __name__ == "__main__":

--- a/web/static/css/design_tokens.css
+++ b/web/static/css/design_tokens.css
@@ -1,0 +1,114 @@
+/* ──────────────────────────────────────────────────────────────────────────
+   ZettelForge / ThreatRecall — Design Tokens
+   Converted from colors_and_type.css for Jinja2 template compatibility
+   ────────────────────────────────────────────────────────────────────────── */
+
+@import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap');
+
+:root {
+  /* ── Brand colors ─────────────────────────────────────────────────────── */
+  --signal-neon:        #00FFA3;
+  --signal-neon-dim:    #00CC82;
+  --signal-leaf:        #5EAE78;
+  --signal-leaf-soft:   #8ED1A0;
+  --signal-leaf-deep:   #3F8A59;
+
+  /* Graphite — near-black neutrals */
+  --graphite-0:         #0A0E17;
+  --graphite-1:         #0D0F1C;
+  --graphite-2:         #0D1117;
+  --graphite-3:         #161B22;
+  --graphite-4:         #21262D;
+  --graphite-5:         #30363D;
+  --graphite-6:         #484F58;
+
+  /* Fog — mid/light neutrals */
+  --fog-0:              #FFFFFF;
+  --fog-1:              #F4F6FA;
+  --fog-2:              #E5E9F0;
+  --fog-3:              #C9D1D9;
+  --fog-4:              #8B949E;
+  --fog-5:              #6B7280;
+  --fog-6:              #1F2937;
+
+  /* Semantic signals */
+  --tier-a-fg:          #3FB950;
+  --tier-a-bg:          #1A472A;
+  --tier-b-fg:          #A371F7;
+  --tier-b-bg:          #2A1A47;
+  --tier-c-fg:          #D29922;
+  --tier-c-bg:          #3A2A0F;
+
+  --intent-factual:     #58A6FF;
+  --intent-temporal:    #F0883E;
+  --intent-relational:  #A371F7;
+  --intent-causal:      #DB61A2;
+  --intent-exploratory: #3FB950;
+
+  --danger:             #F85149;
+  --warning:            #D29922;
+  --success:            #3FB950;
+  --info:               #58A6FF;
+
+  /* ── Foreground / background semantic aliases ─────────────────────────── */
+  --bg-app:             var(--graphite-0);
+  --bg-surface:         var(--graphite-3);
+  --bg-surface-hi:      var(--graphite-4);
+  --bg-input:           var(--graphite-2);
+
+  --fg-primary:         var(--fog-3);
+  --fg-secondary:       var(--fog-4);
+  --fg-tertiary:        var(--graphite-6);
+  --fg-inverse:         var(--graphite-0);
+
+  --border-default:     var(--graphite-5);
+  --border-focus:       var(--intent-factual);
+  --border-hover:       var(--intent-factual);
+
+  /* ── Typography ───────────────────────────────────────────────────────── */
+  --font-body:          'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+  --font-mono:          'JetBrains Mono', 'SF Mono', 'Fira Code', monospace;
+  --font-display:       'Neuropol', 'Inter', sans-serif;
+
+  /* ── Spacing ──────────────────────────────────────────────────────────── */
+  --space-1:            4px;
+  --space-2:            8px;
+  --space-3:            12px;
+  --space-4:            16px;
+  --space-5:            20px;
+  --space-6:            24px;
+  --space-8:            32px;
+  --space-10:           40px;
+  --space-12:           48px;
+  --space-16:           64px;
+  --space-20:           80px;
+
+  /* ── Radii ────────────────────────────────────────────────────────────── */
+  --radius-sm:          4px;
+  --radius-md:          6px;
+  --radius-lg:          8px;
+  --radius-pill:        9999px;
+
+  /* ── Shadows ──────────────────────────────────────────────────────────── */
+  --shadow-focus:       0 0 0 3px rgba(88, 166, 255, 0.10);
+  --shadow-glow:        0 0 0 1px rgba(0, 255, 163, 0.35), 0 0 16px rgba(0, 255, 163, 0.15);
+
+  /* ── Transitions ──────────────────────────────────────────────────────── */
+  --transition-fast:    120ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition-base:    200ms cubic-bezier(0.2, 0.8, 0.2, 1);
+  --transition-slow:    320ms cubic-bezier(0.2, 0.8, 0.2, 1);
+}
+
+/* ── Utility classes ─────────────────────────────────────────────────────── */
+.font-mono { font-family: var(--font-mono); }
+.font-display { font-family: var(--font-display); }
+.text-primary { color: var(--fg-primary); }
+.text-secondary { color: var(--fg-secondary); }
+.text-tertiary { color: var(--fg-tertiary); }
+.bg-surface { background: var(--bg-surface); }
+.border-default { border: 1px solid var(--border-default); }
+
+/* Tier badges */
+.tier-a { background: var(--tier-a-bg); color: var(--tier-a-fg); }
+.tier-b { background: var(--tier-b-bg); color: var(--tier-b-fg); }
+.tier-c { background: var(--tier-c-bg); color: var(--tier-c-fg); }

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -187,5 +187,15 @@
     </footer>
     
     {% block scripts %}{% endblock %}
+    
+    <script>
+    // Shared API helper — available across all SPA pages
+    function apiHeaders(extra) {
+        const headers = {...(extra || {})};
+        const key = localStorage.getItem('zettelforgeApiKey');
+        if (key) headers['X-API-Key'] = key;
+        return headers;
+    }
+    </script>
 </body>
 </html>

--- a/web/templates/base.html
+++ b/web/templates/base.html
@@ -1,0 +1,191 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>{% block title %}ZettelForge{% endblock %}</title>
+    
+    <!-- Fonts -->
+    <link rel="preconnect" href="https://fonts.googleapis.com">
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500;600;700&display=swap" rel="stylesheet">
+    
+    <!-- Design Tokens -->
+    <link rel="stylesheet" href="/static/css/design_tokens.css">
+    
+    <!-- Base Styles -->
+    <style>
+        * {
+            margin: 0;
+            padding: 0;
+            box-sizing: border-box;
+        }
+        
+        body {
+            font-family: var(--font-body);
+            background: var(--bg-app);
+            color: var(--fg-primary);
+            min-height: 100vh;
+            line-height: 1.5;
+        }
+        
+        /* Header */
+        .app-header {
+            background: var(--bg-surface);
+            border-bottom: 1px solid var(--border-default);
+            padding: var(--space-3) var(--space-6);
+            display: flex;
+            align-items: center;
+            gap: var(--space-4);
+        }
+        
+        .app-header .logo {
+            display: flex;
+            align-items: center;
+            gap: var(--space-3);
+            text-decoration: none;
+        }
+        
+        .app-header .logo-text {
+            font-size: 18px;
+            font-weight: 700;
+            color: var(--fg-primary);
+        }
+        
+        .app-header .logo-accent {
+            color: var(--signal-neon);
+        }
+        
+        .app-header .version {
+            color: var(--fg-tertiary);
+            font-size: 12px;
+            font-family: var(--font-mono);
+        }
+        
+        .app-header .stats {
+            margin-left: auto;
+            color: var(--fg-secondary);
+            font-size: 13px;
+            font-family: var(--font-mono);
+        }
+        
+        .app-header .nav-links {
+            display: flex;
+            gap: var(--space-4);
+            margin-left: var(--space-6);
+        }
+        
+        .app-header .nav-links a {
+            color: var(--fg-secondary);
+            text-decoration: none;
+            font-size: 13px;
+            font-weight: 500;
+            padding: var(--space-1) var(--space-2);
+            border-radius: var(--radius-md);
+            transition: all var(--transition-fast);
+        }
+        
+        .app-header .nav-links a:hover {
+            color: var(--fg-primary);
+            background: var(--bg-surface-hi);
+        }
+        
+        .app-header .nav-links a.active {
+            color: var(--intent-factual);
+            background: var(--bg-surface-hi);
+        }
+        
+        /* Main Content */
+        .app-main {
+            max-width: 960px;
+            margin: 0 auto;
+            padding: var(--space-6);
+        }
+        
+        /* Search Bar */
+        .search-bar {
+            display: flex;
+            gap: var(--space-2);
+            margin-bottom: var(--space-6);
+        }
+        
+        .search-input {
+            flex: 1;
+            padding: var(--space-3) var(--space-4);
+            background: var(--bg-input);
+            border: 1px solid var(--border-default);
+            border-radius: var(--radius-md);
+            color: var(--fg-primary);
+            font-size: 15px;
+            font-family: var(--font-body);
+            outline: none;
+            transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+        }
+        
+        .search-input:focus {
+            border-color: var(--border-focus);
+            box-shadow: var(--shadow-focus);
+        }
+        
+        .search-input::placeholder {
+            color: var(--fg-tertiary);
+        }
+        
+        .search-button {
+            padding: var(--space-3) var(--space-5);
+            background: var(--signal-leaf-deep);
+            border: none;
+            border-radius: var(--radius-md);
+            color: var(--fog-0);
+            font-size: 15px;
+            font-family: var(--font-body);
+            font-weight: 500;
+            cursor: pointer;
+            transition: background var(--transition-fast);
+        }
+        
+        .search-button:hover {
+            background: var(--signal-leaf);
+        }
+        
+        .search-button:active {
+            opacity: 0.85;
+        }
+        
+        /* Footer */
+        .app-footer {
+            text-align: center;
+            padding: var(--space-6);
+            color: var(--fg-tertiary);
+            font-size: 12px;
+            border-top: 1px solid var(--border-default);
+            margin-top: var(--space-12);
+        }
+    </style>
+    
+    {% block extra_css %}{% endblock %}
+</head>
+<body>
+    <header class="app-header">
+        <a href="/" class="logo">
+            <span class="logo-text">Zettel<span class="logo-accent">Forge</span></span>
+        </a>
+        <span class="version" id="version">v{{ version }}</span>
+        <nav class="nav-links">
+            <a href="/" class="{% if request.url.path == '/' %}active{% endif %}">Search</a>
+            <a href="/config" class="{% if request.url.path == '/config' %}active{% endif %}">Config</a>
+        </nav>
+        <span class="stats" id="stats">{{ stats }}</span>
+    </header>
+    
+    <main class="app-main">
+        {% block content %}{% endblock %}
+    </main>
+    
+    <footer class="app-footer">
+        ZettelForge v{{ version }} — Agentic Memory for Cyber Threat Intelligence
+    </footer>
+    
+    {% block scripts %}{% endblock %}
+</body>
+</html>

--- a/web/templates/components/remember_panel.html
+++ b/web/templates/components/remember_panel.html
@@ -1,0 +1,72 @@
+<!-- RememberPanel Component -->
+<div class="remember-panel" id="remember-section">
+    <textarea 
+        id="remember-content" 
+        placeholder="Paste threat intelligence to store..."
+        class="remember-textarea"
+    ></textarea>
+    <div class="remember-actions">
+        <button onclick="doRemember()" class="remember-button">Store in Memory</button>
+        <span class="remember-hint">Supports STIX 2.1, markdown, and plain text</span>
+    </div>
+</div>
+
+<style>
+.remember-panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    margin-bottom: var(--space-6);
+}
+.remember-textarea {
+    width: 100%;
+    min-height: 120px;
+    padding: var(--space-3);
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--fg-primary);
+    font-size: 14px;
+    font-family: var(--font-body);
+    line-height: 1.6;
+    resize: vertical;
+    outline: none;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+.remember-textarea:focus {
+    border-color: var(--border-focus);
+    box-shadow: var(--shadow-focus);
+}
+.remember-textarea::placeholder {
+    color: var(--fg-tertiary);
+}
+.remember-actions {
+    display: flex;
+    align-items: center;
+    gap: var(--space-3);
+    margin-top: var(--space-3);
+}
+.remember-button {
+    padding: var(--space-2) var(--space-4);
+    background: var(--signal-leaf-deep);
+    border: none;
+    border-radius: var(--radius-md);
+    color: var(--fog-0);
+    font-size: 13px;
+    font-family: var(--font-body);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+}
+.remember-button:hover {
+    background: var(--signal-leaf);
+}
+.remember-button:active {
+    opacity: 0.85;
+}
+.remember-hint {
+    color: var(--fg-tertiary);
+    font-size: 12px;
+}
+</style>

--- a/web/templates/components/result_card.html
+++ b/web/templates/components/result_card.html
@@ -1,0 +1,98 @@
+<!-- ResultCard Component -->
+<div class="result-card" data-note-id="{{ note_id }}">
+    <div class="result-header">
+        <span class="note-id font-mono">{{ note_id }}</span>
+        <span class="tier-badge tier-{{ tier|lower }}">{{ tier }}</span>
+        <span class="domain">{{ domain }}</span>
+    </div>
+    <div class="result-content">
+        {{ content }}
+    </div>
+    <div class="result-footer">
+        {% if entities %}
+        <div class="entities">
+            {% for entity in entities %}
+            <span class="entity-tag">{{ entity }}</span>
+            {% endfor %}
+        </div>
+        {% endif %}
+        <div class="meta">
+            <span class="confidence">{{ confidence }}% confidence</span>
+            <span class="timestamp">{{ timestamp }}</span>
+        </div>
+    </div>
+</div>
+
+<style>
+.result-card {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    transition: border-color var(--transition-fast);
+}
+.result-card:hover {
+    border-color: var(--border-hover);
+}
+.result-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-2);
+    margin-bottom: var(--space-3);
+}
+.note-id {
+    color: var(--intent-factual);
+    font-size: 12px;
+}
+.tier-badge {
+    display: inline-block;
+    padding: 2px 8px;
+    border-radius: var(--radius-pill);
+    font-size: 11px;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.domain {
+    color: var(--fg-tertiary);
+    font-size: 12px;
+    margin-left: auto;
+    font-family: var(--font-mono);
+}
+.result-content {
+    color: var(--fg-primary);
+    font-size: 14px;
+    line-height: 1.6;
+    white-space: pre-wrap;
+    word-break: break-word;
+}
+.result-footer {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    margin-top: var(--space-3);
+    align-items: center;
+}
+.entities {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-1);
+}
+.entity-tag {
+    display: inline-block;
+    padding: 2px 8px;
+    background: var(--bg-surface-hi);
+    border-radius: var(--radius-pill);
+    font-size: 11px;
+    color: var(--fg-secondary);
+    font-family: var(--font-mono);
+}
+.meta {
+    display: flex;
+    gap: var(--space-3);
+    margin-left: auto;
+    color: var(--fg-tertiary);
+    font-size: 12px;
+    font-family: var(--font-mono);
+}
+</style>

--- a/web/templates/components/search_bar.html
+++ b/web/templates/components/search_bar.html
@@ -1,0 +1,11 @@
+<!-- SearchBar Component -->
+<div class="search-bar">
+    <input 
+        type="text" 
+        id="query" 
+        class="search-input"
+        placeholder="Search threat intelligence... (e.g., What tools does APT28 use?)" 
+        autofocus
+    >
+    <button onclick="doSearch()" class="search-button">Search</button>
+</div>

--- a/web/templates/components/synthesis_block.html
+++ b/web/templates/components/synthesis_block.html
@@ -1,0 +1,58 @@
+<!-- SynthesisBlock Component -->
+<div class="synthesis-block">
+    <h3 class="synthesis-title">Synthesized Answer</h3>
+    <div class="synthesis-content">
+        {{ answer }}
+    </div>
+    <div class="synthesis-sources">
+        <span class="sources-label">Sources:</span>
+        {% for source in sources %}
+        <span class="source-id font-mono">{{ source }}</span>
+        {% endfor %}
+    </div>
+</div>
+
+<style>
+.synthesis-block {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+    margin-bottom: var(--space-4);
+}
+.synthesis-title {
+    color: var(--intent-factual);
+    font-size: 14px;
+    font-weight: 600;
+    margin-bottom: var(--space-3);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+.synthesis-content {
+    font-size: 15px;
+    line-height: 1.7;
+    color: var(--fg-primary);
+    margin-bottom: var(--space-4);
+}
+.synthesis-sources {
+    display: flex;
+    flex-wrap: wrap;
+    gap: var(--space-2);
+    align-items: center;
+    padding-top: var(--space-3);
+    border-top: 1px solid var(--border-default);
+}
+.sources-label {
+    color: var(--fg-tertiary);
+    font-size: 12px;
+    font-weight: 500;
+}
+.source-id {
+    display: inline-block;
+    padding: 2px 8px;
+    background: var(--bg-surface-hi);
+    border-radius: var(--radius-pill);
+    font-size: 11px;
+    color: var(--intent-factual);
+}
+</style>

--- a/web/templates/components/tab_bar.html
+++ b/web/templates/components/tab_bar.html
@@ -1,0 +1,42 @@
+<!-- TabBar Component -->
+<div class="tab-bar" role="tablist">
+    {% for tab in tabs %}
+    <button 
+        class="tab-button {% if tab.active %}active{% endif %}" 
+        onclick="setMode('{{ tab.id }}')"
+        role="tab"
+        aria-selected="{{ 'true' if tab.active else 'false' }}"
+    >
+        {{ tab.label }}
+    </button>
+    {% endfor %}
+</div>
+
+<style>
+.tab-bar {
+    display: flex;
+    gap: var(--space-1);
+    margin-bottom: var(--space-4);
+}
+.tab-button {
+    padding: var(--space-2) var(--space-4);
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--fg-secondary);
+    cursor: pointer;
+    font-size: 13px;
+    font-family: var(--font-body);
+    font-weight: 500;
+    transition: all var(--transition-fast);
+}
+.tab-button:hover {
+    border-color: var(--border-hover);
+    color: var(--fg-primary);
+}
+.tab-button.active {
+    background: var(--bg-surface-hi);
+    color: var(--fg-primary);
+    border-color: var(--intent-factual);
+}
+</style>

--- a/web/templates/config_editor.html
+++ b/web/templates/config_editor.html
@@ -1,0 +1,455 @@
+{% extends "base.html" %}
+
+{% block title %}ZettelForge — Configuration{% endblock %}
+
+{% block content %}
+<div class="config-container">
+    <div class="config-header">
+        <h1>Configuration</h1>
+        <span class="config-path">{{ config_path }}</span>
+    </div>
+    
+    <div class="config-layout">
+        <!-- Left: Form-based editor -->
+        <div class="config-form-panel">
+            <h2>Quick Settings</h2>
+            <div id="config-form">
+                <div class="loading">Loading schema...</div>
+            </div>
+            <div class="form-actions">
+                <button onclick="saveConfigForm()" class="btn-primary">Save Changes</button>
+                <button onclick="reloadConfig()" class="btn-secondary">Reload from Disk</button>
+            </div>
+        </div>
+        
+        <!-- Right: YAML editor -->
+        <div class="config-yaml-panel">
+            <h2>YAML Editor</h2>
+            <div class="yaml-editor-wrapper">
+                <textarea 
+                    id="config-yaml" 
+                    class="yaml-editor"
+                    spellcheck="false"
+                >{{ config_yaml }}</textarea>
+            </div>
+            <div class="form-actions">
+                <button onclick="saveConfigYaml()" class="btn-primary">Save YAML</button>
+                <button onclick="validateYaml()" class="btn-secondary">Validate</button>
+            </div>
+        </div>
+    </div>
+    
+    <!-- Status messages -->
+    <div id="config-status" class="config-status"></div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<style>
+.config-container {
+    max-width: 1200px;
+    margin: 0 auto;
+    padding: var(--space-6);
+}
+
+.config-header {
+    display: flex;
+    align-items: center;
+    gap: var(--space-4);
+    margin-bottom: var(--space-6);
+    padding-bottom: var(--space-4);
+    border-bottom: 1px solid var(--border-default);
+}
+
+.config-header h1 {
+    font-size: 24px;
+    font-weight: 700;
+    color: var(--fg-primary);
+}
+
+.config-path {
+    color: var(--fg-tertiary);
+    font-family: var(--font-mono);
+    font-size: 13px;
+}
+
+.config-layout {
+    display: grid;
+    grid-template-columns: 1fr 1fr;
+    gap: var(--space-6);
+}
+
+@media (max-width: 900px) {
+    .config-layout {
+        grid-template-columns: 1fr;
+    }
+}
+
+.config-form-panel,
+.config-yaml-panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-5);
+}
+
+.config-form-panel h2,
+.config-yaml-panel h2 {
+    font-size: 16px;
+    font-weight: 600;
+    color: var(--fg-primary);
+    margin-bottom: var(--space-4);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+}
+
+.config-section {
+    margin-bottom: var(--space-5);
+}
+
+.config-section-title {
+    font-size: 14px;
+    font-weight: 600;
+    color: var(--intent-factual);
+    margin-bottom: var(--space-3);
+    padding-bottom: var(--space-2);
+    border-bottom: 1px solid var(--border-default);
+}
+
+.form-group {
+    margin-bottom: var(--space-3);
+}
+
+.form-group label {
+    display: block;
+    font-size: 13px;
+    font-weight: 500;
+    color: var(--fg-secondary);
+    margin-bottom: var(--space-1);
+}
+
+.form-group input,
+.form-group select {
+    width: 100%;
+    padding: var(--space-2) var(--space-3);
+    background: var(--bg-input);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--fg-primary);
+    font-size: 14px;
+    font-family: var(--font-body);
+    outline: none;
+    transition: border-color var(--transition-fast), box-shadow var(--transition-fast);
+}
+
+.form-group input:focus,
+.form-group select:focus {
+    border-color: var(--border-focus);
+    box-shadow: var(--shadow-focus);
+}
+
+.form-group input[type="checkbox"] {
+    width: auto;
+    margin-right: var(--space-2);
+}
+
+.yaml-editor-wrapper {
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    overflow: hidden;
+}
+
+.yaml-editor {
+    width: 100%;
+    min-height: 500px;
+    padding: var(--space-3);
+    background: var(--bg-input);
+    border: none;
+    color: var(--fg-primary);
+    font-size: 13px;
+    font-family: var(--font-mono);
+    line-height: 1.6;
+    resize: vertical;
+    outline: none;
+}
+
+.yaml-editor:focus {
+    box-shadow: inset 0 0 0 1px var(--border-focus);
+}
+
+.form-actions {
+    display: flex;
+    gap: var(--space-3);
+    margin-top: var(--space-4);
+    padding-top: var(--space-4);
+    border-top: 1px solid var(--border-default);
+}
+
+.btn-primary {
+    padding: var(--space-2) var(--space-4);
+    background: var(--signal-leaf-deep);
+    border: none;
+    border-radius: var(--radius-md);
+    color: var(--fog-0);
+    font-size: 13px;
+    font-family: var(--font-body);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+}
+
+.btn-primary:hover {
+    background: var(--signal-leaf);
+}
+
+.btn-secondary {
+    padding: var(--space-2) var(--space-4);
+    background: transparent;
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-md);
+    color: var(--fg-secondary);
+    font-size: 13px;
+    font-family: var(--font-body);
+    font-weight: 500;
+    cursor: pointer;
+    transition: all var(--transition-fast);
+}
+
+.btn-secondary:hover {
+    border-color: var(--border-hover);
+    color: var(--fg-primary);
+}
+
+.config-status {
+    margin-top: var(--space-4);
+    padding: var(--space-3);
+    border-radius: var(--radius-md);
+    font-size: 13px;
+    display: none;
+}
+
+.config-status.success {
+    display: block;
+    background: var(--tier-a-bg);
+    color: var(--tier-a-fg);
+    border: 1px solid var(--tier-a-fg);
+}
+
+.config-status.error {
+    display: block;
+    background: rgba(248, 81, 73, 0.1);
+    color: var(--danger);
+    border: 1px solid var(--danger);
+}
+
+.loading {
+    color: var(--fg-tertiary);
+    font-size: 14px;
+    text-align: center;
+    padding: var(--space-8);
+}
+</style>
+{% endblock %}
+
+{% block scripts %}
+<script>
+let configSchema = null;
+let currentConfig = null;
+
+// Load config schema and build form
+async function loadConfigSchema() {
+    try {
+        const response = await fetch('/api/v1/config/schema');
+        const data = await response.json();
+        configSchema = data.data;  // GOV-005 envelope
+        
+        const configResponse = await fetch('/api/v1/config');
+        const configData = await configResponse.json();
+        currentConfig = configData.data;  // GOV-005 envelope
+        
+        buildConfigForm();
+    } catch (err) {
+        document.getElementById('config-form').innerHTML = 
+            `<div class="error">Failed to load config: ${err.message}</div>`;
+    }
+}
+
+function buildConfigForm() {
+    const container = document.getElementById('config-form');
+    if (!configSchema || !configSchema.sections) {
+        container.innerHTML = '<div class="error">Invalid schema</div>';
+        return;
+    }
+    
+    let html = '';
+    for (const section of configSchema.sections) {
+        const sectionData = currentConfig[section.name] || {};
+        
+        html += `<div class="config-section">`;
+        html += `<div class="config-section-title">${section.label}</div>`;
+        
+        for (const field of section.fields) {
+            const value = sectionData[field.name] !== undefined ? sectionData[field.name] : field.default;
+            const fieldId = `config-${section.name}-${field.name}`;
+            
+            html += `<div class="form-group">`;
+            html += `<label for="${fieldId}">${field.label}</label>`;
+            
+            if (field.type === 'select') {
+                html += `<select id="${fieldId}" data-section="${section.name}" data-field="${field.name}">`;
+                for (const option of field.options) {
+                    const selected = option === value ? 'selected' : '';
+                    html += `<option value="${option}" ${selected}>${option}</option>`;
+                }
+                html += `</select>`;
+            } else if (field.type === 'boolean') {
+                const checked = value ? 'checked' : '';
+                html += `<input type="checkbox" id="${fieldId}" data-section="${section.name}" data-field="${field.name}" ${checked}>`;
+            } else if (field.type === 'integer' || field.type === 'float') {
+                const step = field.type === 'integer' ? '1' : '0.1';
+                const min = field.min !== undefined ? `min="${field.min}"` : '';
+                const max = field.max !== undefined ? `max="${field.max}"` : '';
+                html += `<input type="number" id="${fieldId}" data-section="${section.name}" data-field="${field.name}" value="${value}" step="${step}" ${min} ${max}>`;
+            } else {
+                html += `<input type="text" id="${fieldId}" data-section="${section.name}" data-field="${field.name}" value="${value}">`;
+            }
+            
+            html += `</div>`;
+        }
+        
+        html += `</div>`;
+    }
+    
+    container.innerHTML = html;
+}
+
+async function saveConfigForm() {
+    // Build config object from form
+    const newConfig = {};
+    
+    document.querySelectorAll('#config-form [data-section]').forEach(el => {
+        const section = el.dataset.section;
+        const field = el.dataset.field;
+        
+        if (!newConfig[section]) {
+            newConfig[section] = {};
+        }
+        
+        if (el.type === 'checkbox') {
+            newConfig[section][field] = el.checked;
+        } else if (el.type === 'number') {
+            newConfig[section][field] = el.step === '1' ? parseInt(el.value) : parseFloat(el.value);
+        } else {
+            newConfig[section][field] = el.value;
+        }
+    });
+    
+    // Convert to YAML
+    const yamlText = objectToYaml(newConfig);
+    
+    await saveConfig(yamlText);
+}
+
+async function saveConfigYaml() {
+    const yamlText = document.getElementById('config-yaml').value;
+    await saveConfig(yamlText);
+}
+
+async function saveConfig(yamlText) {
+    try {
+        const response = await fetch('/api/v1/config', {
+            method: 'POST',
+            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
+            body: `config_yaml=${encodeURIComponent(yamlText)}`
+        });
+        
+        const result = await response.json();
+        
+        if (response.ok) {
+            showStatus('success', result.data.message);
+            document.getElementById('config-yaml').value = yamlText;
+        } else {
+            showStatus('error', result.error.message || 'Failed to save config');
+        }
+    } catch (err) {
+        showStatus('error', 'Network error: ' + err.message);
+    }
+}
+
+async function reloadConfig() {
+    try {
+        const response = await fetch('/api/v1/config');
+        const data = await response.json();
+        document.getElementById('config-yaml').value = objectToYaml(data.data);
+        showStatus('success', 'Config reloaded from disk');
+    } catch (err) {
+        showStatus('error', 'Failed to reload: ' + err.message);
+    }
+}
+
+function validateYaml() {
+    try {
+        const yamlText = document.getElementById('config-yaml').value;
+        // Basic validation: check for valid YAML structure
+        const lines = yamlText.split('\n');
+        let indentLevel = 0;
+        for (let i = 0; i < lines.length; i++) {
+            const line = lines[i];
+            if (line.trim() && !line.startsWith('#')) {
+                const currentIndent = line.match(/^(\s*)/)[1].length;
+                if (currentIndent % 2 !== 0) {
+                    showStatus('error', `Line ${i + 1}: Invalid indentation (must be multiples of 2)`);
+                    return;
+                }
+            }
+        }
+        showStatus('success', 'YAML structure looks valid');
+    } catch (err) {
+        showStatus('error', 'Validation error: ' + err.message);
+    }
+}
+
+function showStatus(type, message) {
+    const status = document.getElementById('config-status');
+    status.className = `config-status ${type}`;
+    status.textContent = message;
+    status.style.display = 'block';
+    
+    setTimeout(() => {
+        status.style.display = 'none';
+    }, 5000);
+}
+
+function objectToYaml(obj, indent = 0) {
+    let yaml = '';
+    const spaces = ' '.repeat(indent);
+    
+    for (const [key, value] of Object.entries(obj)) {
+        if (value === null || value === undefined) {
+            continue;
+        }
+        
+        if (Array.isArray(value)) {
+            yaml += `${spaces}${key}:\n`;
+            for (const item of value) {
+                yaml += `${spaces}  - ${item}\n`;
+            }
+        } else if (typeof value === 'object') {
+            yaml += `${spaces}${key}:\n`;
+            yaml += objectToYaml(value, indent + 2);
+        } else if (typeof value === 'boolean') {
+            yaml += `${spaces}${key}: ${value}\n`;
+        } else if (typeof value === 'number') {
+            yaml += `${spaces}${key}: ${value}\n`;
+        } else {
+            yaml += `${spaces}${key}: "${value}"\n`;
+        }
+    }
+    
+    return yaml;
+}
+
+// Initialize
+loadConfigSchema();
+</script>
+{% endblock %}

--- a/web/templates/config_editor.html
+++ b/web/templates/config_editor.html
@@ -253,203 +253,63 @@
 
 {% block scripts %}
 <script>
-let configSchema = null;
-let currentConfig = null;
-
-// Load config schema and build form
-async function loadConfigSchema() {
+// Load and display current config
+async function loadConfig() {
     try {
-        const response = await fetch('/api/v1/config/schema');
-        const data = await response.json();
-        configSchema = data.data;  // GOV-005 envelope
-        
-        const configResponse = await fetch('/api/v1/config');
-        const configData = await configResponse.json();
-        currentConfig = configData.data;  // GOV-005 envelope
-        
-        buildConfigForm();
+        const response = await fetch('/api/config', {
+            headers: apiHeaders()
+        });
+        if (response.ok) {
+            const config = await response.json();
+            document.getElementById('config-yaml').value = JSON.stringify(config, null, 2);
+        }
     } catch (err) {
-        document.getElementById('config-form').innerHTML = 
-            `<div class="error">Failed to load config: ${err.message}</div>`;
+        showStatus('error', 'Failed to load config: ' + err.message);
     }
-}
-
-function buildConfigForm() {
-    const container = document.getElementById('config-form');
-    if (!configSchema || !configSchema.sections) {
-        container.innerHTML = '<div class="error">Invalid schema</div>';
-        return;
-    }
-    
-    let html = '';
-    for (const section of configSchema.sections) {
-        const sectionData = currentConfig[section.name] || {};
-        
-        html += `<div class="config-section">`;
-        html += `<div class="config-section-title">${section.label}</div>`;
-        
-        for (const field of section.fields) {
-            const value = sectionData[field.name] !== undefined ? sectionData[field.name] : field.default;
-            const fieldId = `config-${section.name}-${field.name}`;
-            
-            html += `<div class="form-group">`;
-            html += `<label for="${fieldId}">${field.label}</label>`;
-            
-            if (field.type === 'select') {
-                html += `<select id="${fieldId}" data-section="${section.name}" data-field="${field.name}">`;
-                for (const option of field.options) {
-                    const selected = option === value ? 'selected' : '';
-                    html += `<option value="${option}" ${selected}>${option}</option>`;
-                }
-                html += `</select>`;
-            } else if (field.type === 'boolean') {
-                const checked = value ? 'checked' : '';
-                html += `<input type="checkbox" id="${fieldId}" data-section="${section.name}" data-field="${field.name}" ${checked}>`;
-            } else if (field.type === 'integer' || field.type === 'float') {
-                const step = field.type === 'integer' ? '1' : '0.1';
-                const min = field.min !== undefined ? `min="${field.min}"` : '';
-                const max = field.max !== undefined ? `max="${field.max}"` : '';
-                html += `<input type="number" id="${fieldId}" data-section="${section.name}" data-field="${field.name}" value="${value}" step="${step}" ${min} ${max}>`;
-            } else {
-                html += `<input type="text" id="${fieldId}" data-section="${section.name}" data-field="${field.name}" value="${value}">`;
-            }
-            
-            html += `</div>`;
-        }
-        
-        html += `</div>`;
-    }
-    
-    container.innerHTML = html;
-}
-
-async function saveConfigForm() {
-    // Build config object from form
-    const newConfig = {};
-    
-    document.querySelectorAll('#config-form [data-section]').forEach(el => {
-        const section = el.dataset.section;
-        const field = el.dataset.field;
-        
-        if (!newConfig[section]) {
-            newConfig[section] = {};
-        }
-        
-        if (el.type === 'checkbox') {
-            newConfig[section][field] = el.checked;
-        } else if (el.type === 'number') {
-            newConfig[section][field] = el.step === '1' ? parseInt(el.value) : parseFloat(el.value);
-        } else {
-            newConfig[section][field] = el.value;
-        }
-    });
-    
-    // Convert to YAML
-    const yamlText = objectToYaml(newConfig);
-    
-    await saveConfig(yamlText);
 }
 
 async function saveConfigYaml() {
     const yamlText = document.getElementById('config-yaml').value;
-    await saveConfig(yamlText);
-}
-
-async function saveConfig(yamlText) {
     try {
-        const response = await fetch('/api/v1/config', {
-            method: 'POST',
-            headers: {'Content-Type': 'application/x-www-form-urlencoded'},
-            body: `config_yaml=${encodeURIComponent(yamlText)}`
+        // Parse as JSON and PUT to /api/config
+        const parsed = JSON.parse(yamlText);
+        const response = await fetch('/api/config', {
+            method: 'PUT',
+            headers: Object.assign(apiHeaders(), {'Content-Type': 'application/json'}),
+            body: JSON.stringify(parsed)
         });
-        
         const result = await response.json();
-        
         if (response.ok) {
-            showStatus('success', result.data.message);
-            document.getElementById('config-yaml').value = yamlText;
+            showStatus('success', 
+                'Applied ' + (result.applied || []).length + ' settings' +
+                (result.pending_restart?.length ? '. Restart required for: ' + result.pending_restart.join(', ') : ''));
         } else {
-            showStatus('error', result.error.message || 'Failed to save config');
+            showStatus('error', result.detail || result.error || 'Failed to save');
         }
     } catch (err) {
-        showStatus('error', 'Network error: ' + err.message);
-    }
-}
-
-async function reloadConfig() {
-    try {
-        const response = await fetch('/api/v1/config');
-        const data = await response.json();
-        document.getElementById('config-yaml').value = objectToYaml(data.data);
-        showStatus('success', 'Config reloaded from disk');
-    } catch (err) {
-        showStatus('error', 'Failed to reload: ' + err.message);
+        showStatus('error', 'Invalid JSON: ' + err.message);
     }
 }
 
 function validateYaml() {
     try {
-        const yamlText = document.getElementById('config-yaml').value;
-        // Basic validation: check for valid YAML structure
-        const lines = yamlText.split('\n');
-        let indentLevel = 0;
-        for (let i = 0; i < lines.length; i++) {
-            const line = lines[i];
-            if (line.trim() && !line.startsWith('#')) {
-                const currentIndent = line.match(/^(\s*)/)[1].length;
-                if (currentIndent % 2 !== 0) {
-                    showStatus('error', `Line ${i + 1}: Invalid indentation (must be multiples of 2)`);
-                    return;
-                }
-            }
-        }
-        showStatus('success', 'YAML structure looks valid');
+        const text = document.getElementById('config-yaml').value;
+        JSON.parse(text);
+        showStatus('success', 'Valid JSON');
     } catch (err) {
-        showStatus('error', 'Validation error: ' + err.message);
+        showStatus('error', 'Invalid JSON: ' + err.message);
     }
 }
 
 function showStatus(type, message) {
     const status = document.getElementById('config-status');
-    status.className = `config-status ${type}`;
+    status.className = 'config-status ' + type;
     status.textContent = message;
     status.style.display = 'block';
-    
-    setTimeout(() => {
-        status.style.display = 'none';
-    }, 5000);
-}
-
-function objectToYaml(obj, indent = 0) {
-    let yaml = '';
-    const spaces = ' '.repeat(indent);
-    
-    for (const [key, value] of Object.entries(obj)) {
-        if (value === null || value === undefined) {
-            continue;
-        }
-        
-        if (Array.isArray(value)) {
-            yaml += `${spaces}${key}:\n`;
-            for (const item of value) {
-                yaml += `${spaces}  - ${item}\n`;
-            }
-        } else if (typeof value === 'object') {
-            yaml += `${spaces}${key}:\n`;
-            yaml += objectToYaml(value, indent + 2);
-        } else if (typeof value === 'boolean') {
-            yaml += `${spaces}${key}: ${value}\n`;
-        } else if (typeof value === 'number') {
-            yaml += `${spaces}${key}: ${value}\n`;
-        } else {
-            yaml += `${spaces}${key}: "${value}"\n`;
-        }
-    }
-    
-    return yaml;
+    setTimeout(() => { status.style.display = 'none'; }, 5000);
 }
 
 // Initialize
-loadConfigSchema();
+loadConfig();
 </script>
 {% endblock %}

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -119,6 +119,16 @@ function apiHeaders(extra = {}) {
     return headers;
 }
 
+function escHtml(s) {
+    const d = document.createElement('div');
+    d.textContent = s;
+    return d.innerHTML;
+}
+
+function cssToken(s) {
+    return String(s || '').toLowerCase().replace(/[^a-z0-9_-]/g, '');
+}
+
 function setMode(m) {
     mode = m;
     document.querySelectorAll('.tab-button').forEach(btn => {

--- a/web/templates/index.html
+++ b/web/templates/index.html
@@ -1,0 +1,269 @@
+{% extends "base.html" %}
+
+{% block title %}ZettelForge — CTI Memory{% endblock %}
+
+{% block content %}
+<!-- Search Bar -->
+{% include "components/search_bar.html" %}
+
+<!-- Tab Navigation -->
+{% set tabs = [
+    {'id': 'recall', 'label': 'Recall', 'active': true},
+    {'id': 'synthesize', 'label': 'Synthesize', 'active': false},
+    {'id': 'remember', 'label': 'Remember', 'active': false},
+    {'id': 'sync', 'label': 'OpenCTI Sync', 'active': false}
+] %}
+{% include "components/tab_bar.html" %}
+
+<!-- Remember Panel (hidden by default) -->
+<div id="remember-panel" style="display: none;">
+    {% include "components/remember_panel.html" %}
+</div>
+
+<!-- Sync Panel (hidden by default) -->
+<div id="sync-panel" class="sync-panel" style="display: none;">
+    <p class="sync-text">Pull latest from OpenCTI into ZettelForge memory.</p>
+    <button onclick="doSync()" class="sync-button">Sync Now (20 per type)</button>
+</div>
+
+<!-- Meta Status -->
+<div class="meta-bar" id="meta"></div>
+
+<!-- Loading Spinner -->
+<div class="spinner" id="spinner" style="display: none;">Searching...</div>
+
+<!-- Synthesis Results -->
+<div id="synthesis"></div>
+
+<!-- Results List -->
+<div class="results" id="results">
+    <div class="empty-state">
+        <h2>ZettelForge CTI Memory</h2>
+        <p>Search across threat actors, CVEs, tools, campaigns, and reports.</p>
+    </div>
+</div>
+{% endblock %}
+
+{% block extra_css %}
+<style>
+.sync-panel {
+    background: var(--bg-surface);
+    border: 1px solid var(--border-default);
+    border-radius: var(--radius-lg);
+    padding: var(--space-4);
+    margin-bottom: var(--space-6);
+}
+.sync-text {
+    color: var(--fg-secondary);
+    font-size: 14px;
+    margin-bottom: var(--space-3);
+}
+.sync-button {
+    padding: var(--space-2) var(--space-4);
+    background: var(--signal-leaf-deep);
+    border: none;
+    border-radius: var(--radius-md);
+    color: var(--fog-0);
+    font-size: 13px;
+    font-family: var(--font-body);
+    font-weight: 500;
+    cursor: pointer;
+    transition: background var(--transition-fast);
+}
+.sync-button:hover {
+    background: var(--signal-leaf);
+}
+.meta-bar {
+    color: var(--fg-tertiary);
+    font-size: 13px;
+    font-family: var(--font-mono);
+    margin-bottom: var(--space-4);
+    min-height: 20px;
+}
+.spinner {
+    text-align: center;
+    padding: var(--space-6);
+    color: var(--fg-secondary);
+    font-size: 14px;
+}
+.results {
+    display: flex;
+    flex-direction: column;
+    gap: var(--space-3);
+}
+.empty-state {
+    text-align: center;
+    padding: var(--space-16);
+    color: var(--fg-tertiary);
+}
+.empty-state h2 {
+    font-size: 18px;
+    margin-bottom: var(--space-2);
+    color: var(--fg-secondary);
+    font-weight: 600;
+}
+.empty-state p {
+    font-size: 14px;
+}
+</style>
+{% endblock %}
+
+{% block scripts %}
+<script>
+let mode = 'recall';
+
+function apiHeaders(extra = {}) {
+    const headers = {...extra};
+    const key = localStorage.getItem('zettelforgeApiKey');
+    if (key) headers['X-API-Key'] = key;
+    return headers;
+}
+
+function setMode(m) {
+    mode = m;
+    document.querySelectorAll('.tab-button').forEach(btn => {
+        btn.classList.toggle('active', btn.textContent.toLowerCase().includes(m));
+    });
+    document.getElementById('remember-panel').style.display = m === 'remember' ? 'block' : 'none';
+    document.getElementById('sync-panel').style.display = m === 'sync' ? 'block' : 'none';
+    document.getElementById('results').style.display = m === 'remember' || m === 'sync' ? 'none' : 'block';
+    document.getElementById('synthesis').style.display = m === 'synthesize' ? 'block' : 'none';
+}
+
+async function doSearch() {
+    const query = document.getElementById('query').value;
+    if (!query.trim()) return;
+    
+    document.getElementById('spinner').style.display = 'block';
+    document.getElementById('results').innerHTML = '';
+    document.getElementById('synthesis').innerHTML = '';
+    
+    try {
+        let data;
+        if (mode === 'synthesize') {
+            const response = await fetch('/api/synthesize', {
+                method: 'POST',
+                headers: apiHeaders({'Content-Type': 'application/json'}),
+                body: JSON.stringify({query, format: 'synthesized_brief', k: 10})
+            });
+            data = await response.json();
+            if (!response.ok) throw new Error(data.detail || data.error || 'Synthesis failed');
+            renderSynthesis(data);
+        } else {
+            const response = await fetch('/api/recall', {
+                method: 'POST',
+                headers: apiHeaders({'Content-Type': 'application/json'}),
+                body: JSON.stringify({query, k: 10})
+            });
+            data = await response.json();
+            if (!response.ok) throw new Error(data.detail || data.error || 'Recall failed');
+            renderResults(data);
+        }
+    } catch (err) {
+        document.getElementById('meta').textContent = 'Error: ' + err.message;
+    } finally {
+        document.getElementById('spinner').style.display = 'none';
+    }
+}
+
+function renderResults(data) {
+    const container = document.getElementById('results');
+    document.getElementById('meta').textContent = 
+        `${data.count || 0} results in ${data.latency_ms || 0}ms`;
+    
+    if (!data.results?.length) {
+        container.innerHTML = '<div class="empty-state"><h2>No results</h2><p>Try a different query or check your memory index.</p></div>';
+        return;
+    }
+    
+    container.innerHTML = data.results.map(r => `
+        <div class="result-card">
+            <div class="result-header">
+                <span class="note-id font-mono">${escHtml(r.id)}</span>
+                <span class="tier-badge tier-${(r.tier||'').toLowerCase()}">${escHtml(r.tier)}</span>
+                <span class="domain">${escHtml(r.domain)}</span>
+            </div>
+            <div class="result-content">${escHtml(r.content || '')}</div>
+            <div class="result-footer">
+                ${r.entities ? `<div class="entities">${r.entities.map(e => `<span class="entity-tag">${escHtml(e)}</span>`).join('')}</div>` : ''}
+                <div class="meta">
+                    <span class="confidence">${r.confidence || 0}% confidence</span>
+                    <span class="timestamp">${r.created_at || ''}</span>
+                </div>
+            </div>
+        </div>
+    `).join('');
+}
+
+function renderSynthesis(data) {
+    const syn = data.synthesis || {};
+    const answer = syn.summary || syn.answer || (syn.citations ? syn.citations.map(c => c.text || c).join('\n') : '');
+    const sources = syn.citations || syn.source_ids || [];
+    document.getElementById('synthesis').innerHTML = `
+        <div class="synthesis-block">
+            <h3 class="synthesis-title">Synthesized Answer (${data.latency_ms || 0}ms)</h3>
+            <div class="synthesis-content">${escHtml(answer || 'No synthesis available.')}</div>
+            ${sources.length ? `<div class="synthesis-sources">
+                <span class="sources-label">Sources (${data.sources_count || 0}):</span>
+                ${sources.map(s => `<span class="source-id font-mono">${escHtml(typeof s === 'string' ? s : (s.id || ''))}</span>`).join('')}
+            </div>` : ''}
+        </div>
+    `;
+}
+
+async function doRemember() {
+    const textarea = document.getElementById('remember-content');
+    const content = textarea.value;
+    if (!content.trim()) return;
+    
+    try {
+        const response = await fetch('/api/remember', {
+            method: 'POST',
+            headers: apiHeaders({'Content-Type': 'application/json'}),
+            body: JSON.stringify({content, domain: 'cti'})
+        });
+        const data = await response.json();
+        if (!response.ok) {
+            document.getElementById('meta').textContent = 'Error: ' + (data.detail || data.error || 'Store failed');
+            return;
+        }
+        document.getElementById('meta').textContent = `Stored: ${data.note_id} (${data.status}, ${data.latency_ms}ms, entities: ${(data.entities||[]).join(', ')})`;
+        textarea.value = '';
+    } catch (err) {
+        document.getElementById('meta').textContent = 'Error: ' + err.message;
+    }
+}
+
+async function doSync() {
+    try {
+        const response = await fetch('/api/sync', {
+            method: 'POST',
+            headers: apiHeaders({'Content-Type': 'application/json'}),
+            body: JSON.stringify({limit: 20})
+        });
+        const data = await response.json();
+        if (!response.ok) {
+            document.getElementById('meta').textContent = 'Sync error: ' + (data.detail || data.error || 'Sync failed');
+            return;
+        }
+        document.getElementById('meta').textContent = `Synced ${data.synced || 0} objects, ${data.skipped || 0} skipped, ${data.errors || 0} errors (${data.duration_s || 0}s)`;
+    } catch (err) {
+        document.getElementById('meta').textContent = 'Sync error: ' + err.message;
+    }
+}
+
+// Enter key triggers search
+document.getElementById('query')?.addEventListener('keypress', (e) => {
+    if (e.key === 'Enter') doSearch();
+});
+
+// Load version info
+fetch('/api/version', {headers: apiHeaders()})
+    .then(r => r.json())
+    .then(d => {
+        document.getElementById('version').textContent = `v${d.version}`;
+        document.getElementById('stats').textContent = `${d.notes || 0} notes`;
+    })
+    .catch(() => {});
+</script>
+{% endblock %}


### PR DESCRIPTION
## v2.6.0 Release

### Features
- Configurable content size limits for DoS mitigation (RFC-014)
- Config-driven per-call-site LLM token budgets (no more monkey-patching)
- Web GUI SPA — Jinja2 templates + design tokens + 13 new API endpoints (RFC-015)
- Flat JS SPA alternative via web/ui/ (coexists with Jinja2 version)
- Recall timeout support (PR #129)

### New API endpoints (web/app.py)
- GET /api/health, GET/PUT /api/config, GET /api/graph/nodes, /api/graph/edges
- GET /api/entities, GET /api/history, POST /api/ingest
- GET /api/telemetry, GET /api/storage, GET /api/logs
- GET /api/logs/stream (SSE), GET /api/telemetry/stream (SSE)
- GET /api/version

### New web UIs
- **Jinja2 SPA** (default): web/templates/ + web/static/css/design_tokens.css
- **Flat JS SPA** (alternative): web/ui/ with full dashboard, search, graph viz

### Docs
- RFC-015: ZettelForge Web GUI
- Web API reference (docs/reference/web-api.md)
- Module inventory (docs/reference/module-inventory.md)
- Web interface how-to (docs/how-to/use-web-interface.md)

### Internal
- docs/superpowers/ removed from version control (PR #128)
- Config reconciliation for v2.5.2 knobs