### PR TITLE
fix(web): resolve PR #130 blockers in /config and /api/config

### DIFF
--- a/tests/test_web_api.py
+++ b/tests/test_web_api.py
@@ -106,6 +106,33 @@ class TestConfigEndpoint:
         assert "pending_restart" in data
         assert any("backend" in str(item).lower() for item in data["pending_restart"])
 
+    def test_put_config_nested_restart_required_is_flagged(self, client, api_key):
+        """Regression: nested {"embedding": {"provider": ...}} must report
+        embedding.provider in pending_restart, not silently appear in applied.
+        """
+        resp = client.put(
+            "/api/config",
+            headers={**_headers(api_key), "Content-Type": "application/json"},
+            json={"embedding": {"provider": "fastembed"}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "embedding.provider" in data["pending_restart"]
+        assert "embedding.provider" not in data["applied"]
+        assert "embedding" not in data["applied"]  # bare top-level key is not a leaf
+
+    def test_put_config_nested_non_restart_is_applied(self, client, api_key):
+        """Nested non-restart leaf must appear in applied (not pending_restart)."""
+        resp = client.put(
+            "/api/config",
+            headers={**_headers(api_key), "Content-Type": "application/json"},
+            json={"retrieval": {"default_k": 5}},
+        )
+        assert resp.status_code == 200
+        data = resp.json()
+        assert "retrieval.default_k" in data["applied"]
+        assert "retrieval.default_k" not in data["pending_restart"]
+
 
 # ── Graph Nodes / Edges ──────────────────────────────────────────────────────
 
@@ -317,3 +344,33 @@ class TestFrontendEndpoint:
         assert resp.headers.get("content-type", "").startswith("text/html")
         html = resp.text
         assert "ZettelForge" in html
+
+
+class TestConfigPage:
+    """GET /config — auth-gated config editor HTML."""
+
+    def test_config_page_requires_auth_when_key_set(self, client, monkeypatch):
+        """When an API key is configured, /config rejects unauthenticated requests.
+
+        require_api_guard reads API_KEY at module-import time, so we patch the
+        module attribute directly rather than the env var.
+        """
+        from web import app as web_app
+
+        monkeypatch.setattr(web_app, "API_KEY", "test-api-key-12345")
+        resp = client.get("/config")
+        assert resp.status_code == 401
+
+    def test_config_page_renders_yaml_body_when_authenticated(self, client, api_key):
+        """Regression: server-side render of config_editor.html must not silently
+        fail with NameError on _to_dict and leave config_yaml blank.
+        """
+        resp = client.get("/config", headers=_headers(api_key))
+        assert resp.status_code == 200
+        assert resp.headers.get("content-type", "").startswith("text/html")
+        html = resp.text
+        # The textarea is server-populated; verify it is non-empty and contains
+        # at least one expected top-level config key dumped as YAML.
+        assert "<textarea" in html
+        assert 'id="config-yaml"' in html
+        assert ("llm:" in html) or ("embedding:" in html) or ("storage:" in html)

--- a/web/app.py
+++ b/web/app.py
@@ -351,6 +351,44 @@ def _redact_secrets(data: Any, depth: int = 0) -> Any:
     return data
 
 
+def _config_to_dict(obj: Any) -> Any:
+    """Convert nested dataclass config to plain dict for JSON/YAML serialization."""
+    if hasattr(obj, "__dataclass_fields__"):
+        return {k: _config_to_dict(v) for k, v in obj.__dict__.items()}
+    if isinstance(obj, dict):
+        return {k: _config_to_dict(v) for k, v in obj.items()}
+    if isinstance(obj, (list, tuple)):
+        return [_config_to_dict(item) for item in obj]
+    if isinstance(obj, (int, float, bool, str, type(None))):
+        return obj
+    return str(obj)
+
+
+def _flatten_keys(data: dict, prefix: str = "") -> list[str]:
+    """Flatten a nested dict to dotted paths (leaves only)."""
+    out: list[str] = []
+    for k, v in data.items():
+        path = f"{prefix}.{k}" if prefix else k
+        if isinstance(v, dict):
+            out.extend(_flatten_keys(v, path))
+        else:
+            out.append(path)
+    return out
+
+
+_RESTART_REQUIRED_FIELDS = {
+    "backend",
+    "embedding.provider",
+    "embedding.url",
+    "llm.provider",
+    "llm.model",
+    "llm.url",
+    "storage.data_dir",
+    "logging.log_file",
+    "logging.level",
+}
+
+
 @app.get("/api/health", dependencies=[Depends(require_api_guard)])
 async def health():
     """System health endpoint — version, config, queue depths, uptime."""
@@ -392,22 +430,7 @@ async def get_config_endpoint():
     """Return current config as JSON with secrets redacted."""
     try:
         cfg = get_config()
-
-        def _to_dict(obj):
-            """Convert dataclass to plain dict."""
-            if hasattr(obj, "__dataclass_fields__"):
-                return {k: _to_dict(v) for k, v in obj.__dict__.items()}
-            if isinstance(obj, dict):
-                return {k: _to_dict(v) for k, v in obj.items()}
-            if isinstance(obj, (list, tuple)):
-                return [_to_dict(item) for item in obj]
-            if isinstance(obj, (int, float, bool, str, type(None))):
-                return obj
-            return str(obj)
-
-        raw = _to_dict(cfg)
-        redacted = _redact_secrets(raw)
-        return redacted
+        return _redact_secrets(_config_to_dict(cfg))
     except Exception as e:
         logger.exception("get_config_failed")
         return JSONResponse(status_code=500, content={"error": str(e)})
@@ -423,26 +446,26 @@ async def update_config(req: dict):
     """Apply config changes in-memory. Returns applied + pending-restart fields."""
     try:
         cfg = get_config()
-        # Fields that require a restart to take effect
-        RESTART_REQUIRED = {"backend", "embedding.provider", "embedding.url",
-                            "llm.provider", "llm.model", "llm.url",
-                            "storage.data_dir", "logging.log_file"}
-        applied = []
-        pending_restart = []
 
         _apply_yaml(cfg, req)
 
-        # Determine which changes need restart
-        for key in req:
-            if key in RESTART_REQUIRED:
-                pending_restart.append(key)
-            else:
-                applied.append(key)
+        # Flatten the nested payload to dotted leaf paths so we can compare
+        # against _RESTART_REQUIRED_FIELDS (also dotted). A top-level key like
+        # "embedding" must not match a restart-required leaf like
+        # "embedding.provider".
+        leaves = _flatten_keys(req)
+        applied = [k for k in leaves if k not in _RESTART_REQUIRED_FIELDS]
+        pending_restart = [k for k in leaves if k in _RESTART_REQUIRED_FIELDS]
+
+        if pending_restart:
+            message = "Config updated in-memory. Some changes require a restart."
+        else:
+            message = "Config updated in-memory."
 
         return {
             "applied": applied,
             "pending_restart": pending_restart,
-            "message": "Config updated in-memory. Some changes require a restart."
+            "message": message,
         }
     except Exception as e:
         logger.exception("update_config_failed")
@@ -876,14 +899,23 @@ async def index(request: Request):
     return templates.TemplateResponse(request, "index.html")
 
 
-@app.get("/config", response_class=HTMLResponse)
+@app.get(
+    "/config",
+    response_class=HTMLResponse,
+    dependencies=[Depends(require_api_guard)],
+)
 async def config_page(request: Request):
-    """Serve the config editor."""
+    """Serve the config editor (auth-gated; SPA also fetches /api/config)."""
     try:
-        cfg = get_config()
         import yaml
-        config_yaml = yaml.dump(_to_dict(cfg), default_flow_style=False, sort_keys=False)
+        cfg = get_config()
+        config_yaml = yaml.dump(
+            _redact_secrets(_config_to_dict(cfg)),
+            default_flow_style=False,
+            sort_keys=False,
+        )
     except Exception:
+        logger.exception("config_page_render_failed")
         config_yaml = ""
     return templates.TemplateResponse(
         request, "config_editor.html",


### PR DESCRIPTION
## Summary

Three blockers found while reviewing PR #130 after it had already been merged. Fixes follow up on `8730499` (v2.6.0).

- **`config_page` NameError**: `_to_dict` was a closure inside `get_config_endpoint`, so every render of `/config` hit a `NameError` that was silently swallowed by a bare `except`, leaving `config_yaml` empty. Promoted to module-level `_config_to_dict`.
- **`update_config` restart-detection**: compared top-level payload keys against a set of dotted-path restart-required fields, so `{"embedding": {"provider": "x"}}` was reported as `applied: ["embedding"]`, `pending_restart: []` — telling operators a restart-required change had taken effect when it had not. Added `_flatten_keys` walker; `applied` and `pending_restart` now contain dotted leaf paths.
- **`/config` HTML route was unauthenticated**: `/api/config` was protected, but the page shell (and its server-rendered YAML body once the NameError was fixed) was reachable without an API key. Added `Depends(require_api_guard)` and made the YAML body redact secrets before serialization.

## Note on the original review's blocker #2

I originally flagged a "multi-tenancy regression" on the graph/entity/storage endpoints. That was wrong: there is no per-tenant `MemoryManager._knowledge_graph` anywhere in community or enterprise. `get_knowledge_graph()` is a process-wide singleton, and `get_mm_for_request` is a stub returning the default `MemoryManager`. The old code's `getattr(tenant_mm, "_knowledge_graph", None)` always returned `None`, so the old graph endpoints were effectively dead. The new singleton call is a functional improvement, not a regression. No code change needed.

## Test plan

- [x] Added regression tests in `tests/test_web_api.py`:
  - `test_put_config_nested_restart_required_is_flagged`
  - `test_put_config_nested_non_restart_is_applied`
  - `TestConfigPage::test_config_page_requires_auth_when_key_set`
  - `TestConfigPage::test_config_page_renders_yaml_body_when_authenticated`
- [x] `pytest tests/test_web_api.py`: 24 passed, 2 skipped (was 20 + 2).
- [x] `ruff check web/app.py`: 22 pre-existing issues; my edits cleared the `F821 Undefined name '_to_dict'` blocker (down from 24).

🤖 Generated with [Claude Code](https://claude.com/claude-code)