### PR TITLE
docs: establish open source community scaffolding

### DIFF
--- a/.github/workflows/stale.yml
+++ b/.github/workflows/stale.yml
@@ -1,0 +1,47 @@
+name: Stale issue and PR management
+
+on:
+  schedule:
+    - cron: "0 9 * * 1"  # Every Monday at 09:00 UTC
+
+permissions:
+  issues: write
+  pull-requests: write
+
+jobs:
+  stale:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/stale@v9
+        with:
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+          # Issues
+          stale-issue-message: >
+            This issue has been inactive for 60 days. It will be closed
+            in 14 days unless there is new activity. If this is still
+            relevant, please comment to keep it open.
+          close-issue-message: >
+            This issue has been automatically closed after 14 days of
+            inactivity. It can be reopened at any time.
+          days-before-issue-stale: 60
+          days-before-issue-close: 14
+          stale-issue-label: stale
+          exempt-issue-labels: "p0,planned,help wanted,good first issue"
+
+          # PRs
+          stale-pr-message: >
+            This pull request has been inactive for 60 days. It will be
+            closed in 14 days unless there is new activity.
+          close-pr-message: >
+            This pull request has been automatically closed after 14 days
+            of inactivity.
+          days-before-pr-stale: 60
+          days-before-pr-close: 14
+          stale-pr-label: stale
+          exempt-pr-labels: "draft,work-in-progress"
+
+          # General
+          operations-per-run: 100
+          remove-stale-when-updated: true
+          delete-branch: false

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -37,6 +37,49 @@ If your contribution needs TypeDB or OpenCTI, open an issue to discuss.
 We keep the extension boundary clear so contributors know their work
 will always remain open source.
 
+### For major features: Start with an RFC
+
+If you're proposing a significant new feature (new subsystem, new backend,
+breaking API change), open an RFC before writing code. RFCs live in
+`docs/rfcs/` and follow the template from the existing RFCs in that
+directory. Open a Discussion first to socialize the idea, then file a
+draft RFC as a PR. This prevents wasted effort on work that won't be
+accepted.
+
+See [ROADMAP.md](ROADMAP.md) for the current priorities and what's
+planned for upcoming releases.
+
+### Good first issues
+
+Issues tagged [good first issue](https://github.com/rolandpg/zettelforge/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22)
+have structured acceptance criteria in the issue body. Check the issue
+for: which files to edit, test expectations, and example input/output.
+If an issue is unclear, ask in the issue comments.
+
+## Issue triage
+
+This project is maintained by a solo developer (per GOV-006). Here is
+what you can expect:
+
+- **New issues**: triaged within 7 days. You will get a response (even
+  if it's "not planned, closing").
+- **Bug reports**: severity assessed within 7 days. P0 (crash, data
+  loss, security) gets a same-day response.
+- **Feature requests**: tagged with `enhancement` on creation. The
+  maintainer will add `planned`, `deferred`, or `won't fix` within 7
+  days.
+- **PR reviews**: first review within 14 days of submission. Smaller
+  PRs get reviewed faster.
+- **Stale issues**: issues with no activity for 60 days are tagged
+  `stale` and closed after 14 more days without response. This keeps
+  the tracker manageable for a solo maintainer.
+
+## Contributor recognition
+
+Every contributor is listed in [CONTRIBUTORS.md](CONTRIBUTORS.md),
+regardless of contribution size. If you submit a PR that gets merged,
+you will be added. If your name is missing, open a PR.
+
 ## Code Style
 
 - Follow PEP 8

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -1,0 +1,17 @@
+# Contributors
+
+Thank you to everyone who has contributed to ZettelForge.
+
+## Maintainers
+
+- **Patrick G. Roland II** — creator and lead maintainer
+
+## Contributors
+
+This file tracks individuals who have contributed code, documentation, design, or other improvements. The maintainer updates it with each release.
+
+If you have contributed and your name is missing, please open a PR or issue.
+
+---
+
+*This project uses a "thank you, next" acknowledgment model. All contributors are listed regardless of contribution size. A typo fix counts.*

--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ It extracts CVEs, threat actors, IOCs, and ATT&CK techniques from analyst notes 
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/rolandpg/zettelforge/actions/workflows/ci.yml/badge.svg)](https://github.com/rolandpg/zettelforge/actions)
+[![Open Issues](https://img.shields.io/github/issues/rolandpg/zettelforge?color=blue)](https://github.com/rolandpg/zettelforge/issues)
 
-**[⭐ Star](https://github.com/rolandpg/zettelforge) · [📦 `pip install zettelforge`](https://pypi.org/project/zettelforge/) · [📖 Docs](https://docs.threatrecall.ai/) · [🧪 Hosted beta](https://threatrecall.ai)**
+**[⭐ Star](https://github.com/rolandpg/zettelforge) · [📦 `pip install zettelforge`](https://pypi.org/project/zettelforge/) · [📖 Docs](https://docs.threatrecall.ai/) · [🧪 Hosted beta](https://threatrecall.ai) · [🗺️ Roadmap](ROADMAP.md)**
 
 <p align="center">
 <a href="https://www.buymeacoffee.com/xypher22pr0" target="_blank"><img src="https://cdn.buymeacoffee.com/buttons/v2/default-green.png" alt="Buy Me a Coffee" style="height: 60px !important;width: 217px !important;" ></a>

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,0 +1,94 @@
+# ZettelForge Roadmap
+
+Last updated: 2026-04-25
+
+This document communicates what the maintainer is building, what is on hold, and what is out of scope. It is updated when priorities shift.
+
+---
+
+## Current release: v2.6.1
+
+Shipped: 2026-04-25. See `CHANGELOG.md` for details.
+
+The v2.6 series (RFC-013 through RFC-015) delivered PII detection (Presidio), configurable content size limits, and the Web Management Interface. The v2.5 series (RFC-009 through RFC-012) delivered the enrichment pipeline v2, local LLM backends, and unified provider config.
+
+---
+
+## v2.7.0 targets (next release)
+
+Target: 2026-05-09. Scope is frozen at the items below. Everything else defers to v2.8.0 unless marked **P0**.
+
+### Must ship (P0)
+
+- [ ] **Issue #125: Harden reasoning-model LLM budget plumbing.** Regression tests for `max_tokens` at each call site, config-overridable budgets, `thinking` tag stripping in `json_parse.py`, and a `reasoning_model: bool` auto-scaling flag. Post-#124 follow-up. (Est: 2-3 days)
+- [ ] **Issue #73: Tighten CCCS metadata regexes (SEC-6 / SEC-7).** Low hanging security hardening. (Est: 0.5 day)
+- [ ] **Issue #72: MemoryManager.remember(sync=True) dominates bulk ingest.** The YARA p95 plyara tail needs a timeout or chunked processing path. (Est: 1 day)
+
+### Nice to have (P1)
+
+- [ ] **Issue #71: Add typed DetectionMeta extension to MemoryNote.Metadata.** Paves the way for richer entity metadata downstream. (Est: 0.5 day)
+- [ ] **Issue #51: Ratchet governance coverage threshold from 67% toward 80%.** Incremental. (Est: 1 day)
+
+### Community items (open for contribution)
+
+See the [good first issue](https://github.com/rolandpg/zettelforge/issues?q=is%3Aissue+is%3Aopen+label%3A%22good+first+issue%22) label. These are pre-scoped with acceptance criteria:
+
+- #47 — IPv6 address extraction
+- #46 — YARA rule reference extraction
+- #45 — Sigma rule ID extraction
+- #39 — Threat actor alias mappings for Chinese APT groups
+- #36 — Architecture decision records (ADRs)
+- #44 — Example: MISP JSON feed ingestion
+- #43 — Example: Slack bot for CTI queries
+- #41 — Example: Jupyter notebook CTI analysis workflow
+
+---
+
+## Next release (v2.7.1+)
+
+Target: approximately 2026-05-23. Provisional scope; will be finalized after v2.7.0 ships.
+
+- [ ] **CrewAI tool wrapper** (#40). Integration path for CrewAI agents to use ZettelForge as a memory backend.
+- [ ] **OpenCTI sync overhaul**. Improving the bidirectional sync reliability from the initial implementation.
+- [ ] **Detection rules as first-class entities** (#feat/detection-rules-first-class branch). Sigma/YARA rules stored and searchable as knowledge graph nodes.
+
+---
+
+## Backlog / on hold
+
+These are tracked but not actively scheduled:
+
+- **MCP registry publish** (feat/mcp-registry-publish branch). Publishing the MCP server to the official MCP registry.
+- **Enterprise split**. Separating the current monolithic package into community + enterprise tiers. Governance, license boundary, and packaging work. Not blocked, but deferred until community adoption justifies the overhead.
+- **TypeDB read-path hardening**. Depth routing and schema versioning for the TypeDB backend. Most users run on JSONL/SQLite; TypeDB is a small fraction of the install base.
+- **Conversational entity extractor** (stash: feature/RFC-001-conversational-entity-extractor). Interactive refinement of extracted entities by analyst chat. Requires UX thinking and a frontend update.
+- **Pydantic v3 upgrade prep** (stash: test-fix/pydantic-v3-prep). Preparing internal models for Pydantic v3 migration. Low urgency; no upstream pressure yet.
+
+---
+
+## Out of scope (not building)
+
+These have been proposed or discussed and explicitly decided against:
+
+- **UI framework migration** (React, Vue, Svelte, etc.). The web GUI is a vanilla JS SPA using the ZettelForge Design System. No npm build step, no JS framework. This is intentional: the SPA must remain maintainable by a solo developer and installable with `pip install zettelforge[web]` without a separate build step. Not changing.
+- **Docker containerization**. Deferred to v2.x post-v1.0 per the tech stack decision. The in-process architecture already makes deployment trivial.
+- **Cloud-hosted memory backend**. ZettelForge is designed for local-first, air-gapped, and on-prem deployments. A cloud sync layer would compromise the security model and is not on the roadmap.
+- **LangChain / LangGraph integration as a default**. Out of scope per the CLAUDE.md rules in this repo. Community wraps are welcome (see the CrewAI issue for how integration should work).
+
+---
+
+## Release cadence
+
+- **Minor releases (v2.x.0)**: roughly every 2-3 weeks, bundling feature work and hardening.
+- **Patch releases (v2.x.y)**: as needed for P0 bugs, security fixes, and regressions. No pre-scheduled date.
+- **Major releases (v3.0.0+)**: not yet planned. The API is still evolving. A major version bump will come with a public deprecation notice and migration guide.
+
+## Commitment
+
+This roadmap is a best-effort forecast, not a contract. Priorities shift based on user feedback, security findings, and the maintainer's availability (solo maintainer, GOV-006 declared).
+
+Issues tagged with a target release are actively planned. Issues without a release tag are candidates for the next roadmap refresh.
+
+---
+
+[Back to README](README.md)


### PR DESCRIPTION
## Changes

Five files that establish the community-facing infrastructure for ZettelForge's open source presence:

**ROADMAP.md** -- new file. Release cadence (2-3 week minor, P0 patches as needed), v2.7.0 P0/P1 targets, backlog, explicit out-of-scope items, and maintainer commitment note.

**CONTRIBUTING.md** -- expanded. Added RFC process for major features, good-first-issue path, issue triage SLA (7-day triage, 60-day stale close window), and contributor recognition policy.

**CONTRIBUTORS.md** -- new file. Initial entry for maintainer with note that future contributors are added on merge.

**.github/workflows/stale.yml** -- new workflow. 60-day stale threshold, 14-day close window, exempts p0/planned/help-wanted/good-first-issue labels. Runs weekly.

**README.md** -- added Open Issues badge and Roadmap link to the hero badge bar.

## Why

These address the gaps identified in the open source community review: no visible roadmap, no triage SLA, no RFC discoverability from the contributor path, no stale management, and no contributor recognition.

## Verification

All five new/modified files are documentation only. No code changes, no test changes, no behavioral impact.

Closes no issue directly; these are foundational scaffolding for community growth.