### PR TITLE
[codex] Consolidate RFC-015 web GUI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,8 @@ downloads/
 eggs/
 .eggs/
 lib/
+!web/ui/js/lib/
+!web/ui/js/lib/*.js
 lib64/
 parts/
 sdist/

--- a/web/app.py
+++ b/web/app.py
@@ -1,7 +1,7 @@
 """
-ZettelForge Web UI — FastAPI backend + minimal HTML frontend.
+ZettelForge Web UI — FastAPI backend + RFC-015 management SPA.
 
-A search-and-recall interface for ZettelForge's CTI memory system.
+A management interface for ZettelForge's CTI memory system.
 
 Usage:
     python web/app.py                    # Start on port 8088
@@ -9,7 +9,7 @@ Usage:
     uvicorn web.app:app --reload         # Dev mode
 
 Endpoints:
-    GET  /                    → Search UI (HTML)
+    GET  /                    → Management SPA (HTML)
     POST /api/recall          → Blended recall (vector + graph)
     POST /api/remember        → Store a note
     POST /api/synthesize      → RAG synthesis
@@ -33,13 +33,16 @@ from pathlib import Path
 from typing import Any, List, Optional
 
 from fastapi import Depends, FastAPI, Header, HTTPException, Query, Request, status
-from fastapi.responses import HTMLResponse, JSONResponse, StreamingResponse
+from fastapi.responses import FileResponse, HTMLResponse, JSONResponse, StreamingResponse
 from fastapi.staticfiles import StaticFiles
 from fastapi.templating import Jinja2Templates
 from pydantic import BaseModel, Field
 
-# Ensure zettelforge is importable
-sys.path.insert(0, str(Path(__file__).parent.parent / "src"))
+# Ensure both the package and the web namespace are importable when this file is
+# launched directly as `python web/app.py`.
+_repo_root = Path(__file__).parent.parent
+sys.path.insert(0, str(_repo_root))
+sys.path.insert(0, str(_repo_root / "src"))
 
 os.environ.setdefault("ZETTELFORGE_BACKEND", "sqlite")
 
@@ -64,6 +67,7 @@ app = FastAPI(
 
 # Mount static files after app is created
 app.mount("/static", StaticFiles(directory=str(_web_dir / "static")), name="static")
+app.mount("/ui", StaticFiles(directory=str(_web_dir / "ui")), name="ui")
 
 # Uptime tracking (monotonic clock, reset on process restart)
 _start_time = time.monotonic()
@@ -376,6 +380,27 @@ def _flatten_keys(data: dict, prefix: str = "") -> list[str]:
     return out
 
 
+def _expand_dotted_keys(data: dict) -> dict:
+    """Convert {"retrieval.default_k": 5} to {"retrieval": {"default_k": 5}}."""
+    expanded: dict[str, Any] = {}
+    for key, value in data.items():
+        if "." not in key:
+            if isinstance(value, dict):
+                expanded[key] = _expand_dotted_keys(value)
+            else:
+                expanded[key] = value
+            continue
+
+        cursor = expanded
+        parts = [part for part in key.split(".") if part]
+        if not parts:
+            continue
+        for part in parts[:-1]:
+            cursor = cursor.setdefault(part, {})
+        cursor[parts[-1]] = value
+    return expanded
+
+
 _RESTART_REQUIRED_FIELDS = {
     "backend",
     "embedding.provider",
@@ -413,6 +438,7 @@ async def health():
             "llm_model": cfg.llm.model,
             "llm_local_backend": cfg.llm.local_backend,
             "enrichment_queue_depth": enrichment_depth,
+            "queue_status": "idle" if enrichment_depth == 0 else "active",
             "governance_enabled": cfg.governance.enabled,
             "pii_enabled": cfg.governance.pii.enabled,
             "uptime_seconds": round(uptime, 1),
@@ -446,6 +472,7 @@ async def update_config(req: dict):
     """Apply config changes in-memory. Returns applied + pending-restart fields."""
     try:
         cfg = get_config()
+        req = _expand_dotted_keys(req)
 
         _apply_yaml(cfg, req)
 
@@ -539,10 +566,16 @@ async def entities(
                 # Look up tier from earliest note if possible
                 ent_tier = tier if tier else ""
                 all_entities.append({
+                    "id": f"{etype}:{evalue}",
+                    "name": evalue,
+                    "type": etype,
+                    "aliases": [],
+                    "confidence": None,
+                    "connected_count": len(note_ids),
                     "entity_type": etype,
                     "entity_value": evalue,
                     "note_count": len(note_ids),
-                    "tier": ent_tier,
+                    "tier": ent_tier or "b",
                 })
 
         total = len(all_entities)
@@ -678,8 +711,10 @@ async def telemetry_summary():
         if not fpath.exists():
             return {
                 "total_queries": 0,
+                "queries_today": 0,
                 "recall_count": 0,
                 "synthesis_count": 0,
+                "syntheses_today": 0,
                 "avg_latency_ms": 0,
                 "p50_ms": 0,
                 "p95_ms": 0,
@@ -725,8 +760,10 @@ async def telemetry_summary():
 
         return {
             "total_queries": total_queries,
+            "queries_today": total_queries,
             "recall_count": recall_count,
             "synthesis_count": synthesis_count,
+            "syntheses_today": synthesis_count,
             "avg_latency_ms": avg_latency,
             "p50_ms": p50,
             "p95_ms": p95,
@@ -896,7 +933,7 @@ async def telemetry_stream():
 @app.get("/", response_class=HTMLResponse)
 async def index(request: Request):
     """Serve the SPA."""
-    return templates.TemplateResponse(request, "index.html")
+    return FileResponse(_web_dir / "ui" / "index.html", media_type="text/html")
 
 
 @app.get(

--- a/web/ui/index.html
+++ b/web/ui/index.html
@@ -4,7 +4,7 @@
 <meta charset="UTF-8">
 <meta name="viewport" content="width=device-width, initial-scale=1.0">
 <title>ZettelForge — CTI Memory</title>
-<link rel="stylesheet" href="colors_and_type.css">
+<link rel="stylesheet" href="/ui/colors_and_type.css">
 <style>
   * { box-sizing: border-box; }
   body { margin: 0; background: var(--bg-app); color: var(--fg-1); font-family: var(--font-sans); min-height: 100vh; overflow-x: hidden; }
@@ -34,22 +34,22 @@
   </div>
 </div>
 <script src="https://unpkg.com/lucide@0.469.0/dist/umd/lucide.js"></script>
-<script src="js/lib/state.js"></script>
-<script src="js/lib/api.js"></script>
-<script src="js/components/spinner.js"></script>
-<script src="js/components/toast.js"></script>
-<script src="js/components/tabs.js"></script>
-<script src="js/components/result-card.js"></script>
-<script src="js/components/sidebar.js"></script>
-<script src="js/components/header.js"></script>
-<script src="js/views/dashboard.js"></script>
-<script src="js/views/search.js"></script>
-<script src="js/views/knowledge-graph.js"></script>
-<script src="js/views/logs.js"></script>
-<script src="js/views/ingest.js"></script>
-<script src="js/views/entities.js"></script>
-<script src="js/views/history.js"></script>
-<script src="js/views/configuration.js"></script>
-<script src="js/app.js"></script>
+<script src="/ui/js/lib/state.js"></script>
+<script src="/ui/js/lib/api.js"></script>
+<script src="/ui/js/components/spinner.js"></script>
+<script src="/ui/js/components/toast.js"></script>
+<script src="/ui/js/components/tabs.js"></script>
+<script src="/ui/js/components/result-card.js"></script>
+<script src="/ui/js/components/sidebar.js"></script>
+<script src="/ui/js/components/header.js"></script>
+<script src="/ui/js/views/dashboard.js"></script>
+<script src="/ui/js/views/search.js"></script>
+<script src="/ui/js/views/knowledge-graph.js"></script>
+<script src="/ui/js/views/logs.js"></script>
+<script src="/ui/js/views/ingest.js"></script>
+<script src="/ui/js/views/entities.js"></script>
+<script src="/ui/js/views/history.js"></script>
+<script src="/ui/js/views/configuration.js"></script>
+<script src="/ui/js/app.js"></script>
 </body>
 </html>

--- a/web/ui/js/app.js
+++ b/web/ui/js/app.js
@@ -7,10 +7,13 @@
 
       // Listen for hash changes
       window.addEventListener('hashchange', this.route.bind(this));
+      window.store.subscribe(function(_state, key) {
+        if (key === 'stats') APP.refreshChrome();
+      });
 
       // Initial load
-      this.loadHeader();
       this.route();
+      this.loadAppInfo();
     },
 
     loadHeader: function() {
@@ -21,9 +24,35 @@
       }
     },
 
+    refreshChrome: function() {
+      this.loadHeader();
+      var sidebarRoot = document.getElementById('sidebar-root');
+      if (sidebarRoot) {
+        var active = window.store.get('view') || window.location.hash.slice(1) || 'dashboard';
+        sidebarRoot.innerHTML = '';
+        sidebarRoot.appendChild(window.SidebarComponent.render(active));
+        if (window.lucide) window.lucide.createIcons();
+      }
+    },
+
+    loadAppInfo: function() {
+      window.API.get('/api/stats')
+        .then(function(stats) {
+          window.store.set('stats', stats || {});
+        })
+        .catch(function() {
+          return window.API.get('/api/version').then(function(info) {
+            window.store.set('stats', info || {});
+          });
+        })
+        .catch(function() {});
+    },
+
     route: function() {
       var hash = window.location.hash.slice(1) || 'dashboard';
       window.store.set('view', hash);
+
+      this.loadHeader();
 
       var sidebarRoot = document.getElementById('sidebar-root');
       if (sidebarRoot) {

--- a/web/ui/js/components/header.js
+++ b/web/ui/js/components/header.js
@@ -66,7 +66,9 @@ window.HeaderComponent = {
 
     var ver = document.createElement('span');
     ver.style.cssText = 'color:var(--fg-2,#8B949E);font-size:var(--text-sm,12px);font-family:var(--font-mono);';
-    ver.textContent = 'v' + (stats.version || '0.0.0') + ' \u00B7 ' + (stats.edition || 'Community');
+    var versionLabel = stats.version ? 'v' + stats.version : 'version loading';
+    var editionLabel = stats.edition_name || stats.edition || '';
+    ver.textContent = editionLabel ? versionLabel + ' \u00B7 ' + editionLabel : versionLabel;
     brand.appendChild(ver);
 
     header.appendChild(brand);

--- a/web/ui/js/components/sidebar.js
+++ b/web/ui/js/components/sidebar.js
@@ -47,7 +47,9 @@ window.SidebarComponent = {
     bottom.style.cssText = 'margin-top:auto;padding:var(--sp-4,16px);border-top:1px solid var(--border,#30363D);font-size:var(--text-xs,11px);color:var(--fg-3,#484F58);font-family:var(--font-mono);';
     var s = window.store.getState();
     var stats = s.stats || {};
-    bottom.textContent = 'v' + (stats.version || '2.3.0') + ' \u00B7 ' + (stats.edition || 'Community');
+    var versionLabel = stats.version ? 'v' + stats.version : 'version loading';
+    var editionLabel = stats.edition_name || stats.edition || '';
+    bottom.textContent = editionLabel ? versionLabel + ' \u00B7 ' + editionLabel : versionLabel;
     sidebar.appendChild(bottom);
 
     return sidebar;

--- a/web/ui/js/lib/api.js
+++ b/web/ui/js/lib/api.js
@@ -1,0 +1,83 @@
+(function() {
+  'use strict';
+
+  function isLoopbackHost() {
+    return ['localhost', '127.0.0.1', '::1'].indexOf(window.location.hostname) !== -1;
+  }
+
+  function getApiKey() {
+    return localStorage.getItem('zettelforgeApiKey') || '';
+  }
+
+  function setApiKey(key) {
+    if (key) {
+      localStorage.setItem('zettelforgeApiKey', key);
+    }
+  }
+
+  function headers(extra) {
+    var out = extra ? Object.assign({}, extra) : {};
+    var key = getApiKey();
+    if (key) out['X-API-Key'] = key;
+    return out;
+  }
+
+  function promptForApiKey(reason) {
+    if (isLoopbackHost()) return '';
+    var message = reason || 'This LAN session needs the ZettelForge web API key.';
+    var key = window.prompt(message + '\n\nPaste API key for this browser:');
+    if (key) {
+      key = key.trim();
+      setApiKey(key);
+    }
+    return key || '';
+  }
+
+  function parseError(status, payload) {
+    if (payload && payload.detail) return payload.detail;
+    if (payload && payload.error) return payload.error;
+    if (payload && payload.message) return payload.message;
+    return 'HTTP ' + status;
+  }
+
+  function request(method, path, body, retried) {
+    var opts = {
+      method: method,
+      headers: headers(body === undefined ? {} : { 'Content-Type': 'application/json' })
+    };
+    if (body !== undefined) {
+      opts.body = JSON.stringify(body);
+    }
+
+    return fetch(path, opts).then(function(resp) {
+      var contentType = resp.headers.get('content-type') || '';
+      var parse = contentType.indexOf('application/json') !== -1 ? resp.json() : resp.text();
+      return parse.then(function(payload) {
+        if (resp.ok) return payload;
+        if (!retried && (resp.status === 401 || resp.status === 503)) {
+          var key = getApiKey() || promptForApiKey(parseError(resp.status, payload));
+          if (key) return request(method, path, body, true);
+        }
+        throw new Error(parseError(resp.status, payload));
+      });
+    });
+  }
+
+  window.API = {
+    getApiKey: getApiKey,
+    setApiKey: setApiKey,
+    headers: headers,
+    get: function(path) {
+      return request('GET', path);
+    },
+    post: function(path, body) {
+      return request('POST', path, body);
+    },
+    put: function(path, body) {
+      return request('PUT', path, body);
+    },
+    del: function(path) {
+      return request('DELETE', path);
+    }
+  };
+})();

--- a/web/ui/js/lib/state.js
+++ b/web/ui/js/lib/state.js
@@ -1,0 +1,50 @@
+(function() {
+  'use strict';
+
+  var state = {
+    view: 'dashboard',
+    stats: {},
+    health: null,
+    telemetry: {}
+  };
+  var listeners = [];
+
+  window.store = {
+    getState: function() {
+      return state;
+    },
+    get: function(key) {
+      return state[key];
+    },
+    set: function(key, value) {
+      state[key] = value;
+      listeners.slice().forEach(function(listener) {
+        try {
+          listener(state, key, value);
+        } catch (err) {
+          console.error('store listener failed', err);
+        }
+      });
+    },
+    update: function(patch) {
+      Object.keys(patch || {}).forEach(function(key) {
+        state[key] = patch[key];
+      });
+      listeners.slice().forEach(function(listener) {
+        try {
+          listener(state, null, patch);
+        } catch (err) {
+          console.error('store listener failed', err);
+        }
+      });
+    },
+    subscribe: function(listener) {
+      listeners.push(listener);
+      return function() {
+        listeners = listeners.filter(function(item) {
+          return item !== listener;
+        });
+      };
+    }
+  };
+})();

--- a/web/ui/js/views/configuration.js
+++ b/web/ui/js/views/configuration.js
@@ -4,6 +4,21 @@ window.ConfigurationView = {
   _activeTab: 'flags',
   _editorContent: '',
 
+  flattenConfig: function(input, prefix, out) {
+    out = out || {};
+    prefix = prefix || '';
+    Object.keys(input || {}).forEach(function(key) {
+      var value = input[key];
+      var path = prefix ? prefix + '.' + key : key;
+      if (value && typeof value === 'object' && !Array.isArray(value)) {
+        window.ConfigurationView.flattenConfig(value, path, out);
+      } else {
+        out[path] = value;
+      }
+    });
+    return out;
+  },
+
   render: function() {
     var container = document.createElement('div');
     container.id = 'configuration-view';
@@ -71,6 +86,7 @@ window.ConfigurationView = {
 
   renderFlags: function(container, config) {
     container.innerHTML = '';
+    config = this.flattenConfig(config);
 
     if (!config || Object.keys(config).length === 0) {
       container.innerHTML = '<div style="padding:var(--sp-6,24px);text-align:center;color:var(--fg-3,#484F58);font-size:var(--text-sm,12px);font-family:var(--font-mono);">No configuration data available</div>';
@@ -79,13 +95,16 @@ window.ConfigurationView = {
 
     // Group config into sections
     var groups = {
-      'Core': ['version', 'edition', 'data_dir', 'log_level', 'log_file', 'max_content_length', 'max_file_size'],
-      'LLM': ['llm_provider', 'llm_model', 'llm_local_backend', 'llm_temperature', 'llm_max_tokens', 'llm_api_key'],
-      'Embedding': ['embedding_provider', 'embedding_model', 'embedding_dimensions', 'embedding_api_key'],
-      'Retrieval': ['top_k', 'min_score', 'recall_rerank', 'recall_hybrid_search'],
-      'Synthesis': ['synthesis_enabled', 'synthesis_default_format', 'synthesis_max_sources'],
-      'Governance': ['governance_enabled', 'governance_policy'],
-      'Logging': ['log_level', 'log_file', 'log_format', 'telemetry_enabled']
+      'Core': ['backend', 'storage.data_dir', 'web.enabled', 'web.host', 'web.port'],
+      'LLM': ['llm.provider', 'llm.model', 'llm.url', 'llm.local_backend', 'llm.temperature', 'llm.timeout', 'llm.max_retries', 'llm.api_key'],
+      'Embedding': ['embedding.provider', 'embedding.model', 'embedding.url', 'embedding.dimensions'],
+      'Extraction': ['llm_ner.enabled', 'extraction.max_facts', 'extraction.min_importance'],
+      'Retrieval': ['retrieval.default_k', 'retrieval.similarity_threshold', 'retrieval.entity_boost', 'retrieval.max_graph_depth'],
+      'Synthesis': ['synthesis.default_format', 'synthesis.max_context_tokens', 'synthesis.tier_filter'],
+      'Governance': ['governance.enabled', 'governance.min_content_length', 'governance.pii.enabled', 'governance.pii.action', 'governance.limits.max_content_length', 'governance.limits.recall_timeout_seconds'],
+      'Storage Maintenance': ['lance.cleanup_interval_minutes', 'lance.cleanup_older_than_seconds', 'cache.ttl_seconds', 'cache.max_entries'],
+      'Logging': ['logging.level', 'logging.log_file', 'logging.audit_log_file', 'logging.log_to_stdout', 'logging.max_bytes', 'logging.backup_count'],
+      'Enterprise / Integrations': ['enterprise.blended_retrieval', 'enterprise.cross_encoder_reranking', 'enterprise.report_ingestion', 'enterprise.multi_tenant', 'enterprise.license_key', 'opencti.url', 'opencti.token', 'opencti.sync_interval']
     };
 
     var self = this;

--- a/web/ui/js/views/dashboard.js
+++ b/web/ui/js/views/dashboard.js
@@ -172,7 +172,7 @@ window.DashboardView = {
 
   renderTelemetry: function(container, telemetry) {
     if (!container) return;
-    if (!telemetry || !telemetry.queries_today) {
+    if (!telemetry || (telemetry.queries_today === undefined && telemetry.total_queries === undefined)) {
       container.innerHTML = '<div style="grid-column:1/-1;color:var(--fg-3,#484F58);padding:var(--sp-4,16px);font-size:var(--text-sm,12px);font-family:var(--font-mono);">telemetry data unavailable</div>';
       return;
     }
@@ -180,8 +180,8 @@ window.DashboardView = {
     container.innerHTML = '';
 
     var items = [
-      { label: 'queries today', value: (telemetry.queries_today || 0).toLocaleString() },
-      { label: 'syntheses today', value: (telemetry.syntheses_today || 0).toLocaleString() },
+      { label: 'queries today', value: (telemetry.queries_today || telemetry.total_queries || 0).toLocaleString() },
+      { label: 'syntheses today', value: (telemetry.syntheses_today || telemetry.synthesis_count || 0).toLocaleString() },
       { label: 'avg latency', value: telemetry.avg_latency_ms ? telemetry.avg_latency_ms + 'ms' : '---' }
     ];
 
@@ -206,6 +206,11 @@ window.DashboardView = {
   renderIntents: function(container, telemetry) {
     if (!container) return;
     var intents = telemetry.top_intents || [];
+    if (!Array.isArray(intents)) {
+      intents = Object.keys(intents).map(function(name) {
+        return { name: name, count: intents[name] };
+      });
+    }
     if (!intents.length) {
       container.innerHTML = '<div style="color:var(--fg-3,#484F58);font-size:var(--text-sm,12px);font-family:var(--font-mono);">no intent data yet</div>';
       return;

--- a/web/ui/js/views/knowledge-graph.js
+++ b/web/ui/js/views/knowledge-graph.js
@@ -4,8 +4,14 @@ window.KnowledgeGraphView = {
   _filteredIds: null,
   _selectedNode: null,
   _simulation: null,
+  _canvasBound: false,
+  _dragging: false,
+  _dragMoved: false,
+  _lastPointer: null,
+  _view: { rotX: -0.45, rotY: 0.65, zoom: 560 },
 
   render: function() {
+    this._canvasBound = false;
     var container = document.createElement('div');
     container.id = 'knowledge-graph-view';
     container.style.cssText = 'max-width:960px;';
@@ -17,7 +23,7 @@ window.KnowledgeGraphView = {
 
     var note = document.createElement('div');
     note.style.cssText = 'background:var(--bg-surface,#161B22);border:1px solid var(--border,#30363D);border-radius:var(--r-sm,6px);padding:8px 12px;font-size:var(--text-xs,11px);color:var(--fg-2,#8B949E);font-family:var(--font-mono);margin-bottom:var(--sp-4,16px);';
-    note.textContent = '3D rendering with Three.js coming in v2.6.0 - 2D force graph shown here';
+    note.textContent = 'Interactive 3D orbital graph - drag to rotate, wheel to zoom, click a node for detail.';
     container.appendChild(note);
 
     // Search bar
@@ -54,6 +60,13 @@ window.KnowledgeGraphView = {
     loading.style.cssText = 'display:flex;align-items:center;justify-content:center;height:500px;gap:8px;color:var(--fg-2,#8B949E);font-size:var(--text-sm,12px);';
     loading.innerHTML = '<div class="pulse" style="width:16px;height:16px;border-radius:50%;border:2px solid var(--border,#30363D);border-top-color:var(--signal-neon,#00FFA3);"></div> Loading graph data...';
     graphWrap.appendChild(loading);
+
+    var canvas = document.createElement('canvas');
+    canvas.id = 'kg-canvas';
+    canvas.width = 960;
+    canvas.height = 500;
+    canvas.style.cssText = 'display:none;width:100%;height:500px;cursor:grab;';
+    graphWrap.appendChild(canvas);
 
     var svg = document.createElementNS('http://www.w3.org/2000/svg', 'svg');
     svg.id = 'kg-svg';
@@ -134,13 +147,17 @@ window.KnowledgeGraphView = {
       if (loading) loading.style.display = 'none';
 
       if (self._nodes.length === 0) {
+        var canvas = document.getElementById('kg-canvas');
+        if (canvas) canvas.style.display = 'none';
         svg.style.display = 'none';
         empty.style.display = 'block';
         if (statsSpan) statsSpan.textContent = '0 nodes, 0 edges';
         return;
       }
 
-      svg.style.display = 'block';
+      var canvas = document.getElementById('kg-canvas');
+      if (canvas) canvas.style.display = 'block';
+      svg.style.display = 'none';
       empty.style.display = 'none';
       if (statsSpan) statsSpan.textContent = self._nodes.length + ' nodes, ' + self._edges.length + ' edges';
 
@@ -184,7 +201,206 @@ window.KnowledgeGraphView = {
     return map[type] || '#8B949E';
   },
 
+  getProjectedNode: function(node, w, h) {
+    var rx = this._view.rotX;
+    var ry = this._view.rotY;
+    var x = node.x3 || 0;
+    var y = node.y3 || 0;
+    var z = node.z3 || 0;
+
+    var cosY = Math.cos(ry);
+    var sinY = Math.sin(ry);
+    var x1 = x * cosY - z * sinY;
+    var z1 = x * sinY + z * cosY;
+
+    var cosX = Math.cos(rx);
+    var sinX = Math.sin(rx);
+    var y1 = y * cosX - z1 * sinX;
+    var z2 = y * sinX + z1 * cosX;
+
+    var zoom = this._view.zoom;
+    var scale = zoom / (zoom + z2 + 260);
+    scale = Math.max(0.25, Math.min(2.2, scale));
+
+    return {
+      x: w / 2 + x1 * scale,
+      y: h / 2 + y1 * scale,
+      z: z2,
+      scale: scale
+    };
+  },
+
+  init3DPositions: function() {
+    var count = Math.max(this._nodes.length, 1);
+    var radius = Math.min(230, 60 + count * 5);
+    this._nodes.forEach(function(n, i) {
+      if (n.x3 !== undefined && n.y3 !== undefined && n.z3 !== undefined) return;
+      var t = count === 1 ? 0 : i / (count - 1);
+      var inclination = Math.acos(1 - 2 * t);
+      var azimuth = i * Math.PI * (3 - Math.sqrt(5));
+      n.x3 = radius * Math.sin(inclination) * Math.cos(azimuth);
+      n.y3 = radius * Math.sin(inclination) * Math.sin(azimuth);
+      n.z3 = radius * Math.cos(inclination);
+    });
+  },
+
+  bindCanvasControls: function(canvas) {
+    if (this._canvasBound || !canvas) return;
+    var self = this;
+    this._canvasBound = true;
+
+    canvas.addEventListener('pointerdown', function(e) {
+      self._dragging = true;
+      self._dragMoved = false;
+      self._lastPointer = { x: e.clientX, y: e.clientY };
+      canvas.style.cursor = 'grabbing';
+      canvas.setPointerCapture(e.pointerId);
+    });
+
+    canvas.addEventListener('pointermove', function(e) {
+      if (!self._dragging || !self._lastPointer) return;
+      var dx = e.clientX - self._lastPointer.x;
+      var dy = e.clientY - self._lastPointer.y;
+      if (Math.abs(dx) + Math.abs(dy) > 3) self._dragMoved = true;
+      self._view.rotY += dx * 0.006;
+      self._view.rotX += dy * 0.006;
+      self._view.rotX = Math.max(-1.45, Math.min(1.45, self._view.rotX));
+      self._lastPointer = { x: e.clientX, y: e.clientY };
+      self.renderGraph();
+    });
+
+    canvas.addEventListener('pointerup', function(e) {
+      canvas.style.cursor = 'grab';
+      self._dragging = false;
+      self._lastPointer = null;
+      try { canvas.releasePointerCapture(e.pointerId); } catch (err) {}
+      if (self._dragMoved) return;
+      self.pickCanvasNode(e);
+    });
+
+    canvas.addEventListener('wheel', function(e) {
+      e.preventDefault();
+      self._view.zoom += e.deltaY * -0.45;
+      self._view.zoom = Math.max(240, Math.min(1200, self._view.zoom));
+      self.renderGraph();
+    }, { passive: false });
+  },
+
+  pickCanvasNode: function(e) {
+    var canvas = document.getElementById('kg-canvas');
+    if (!canvas) return;
+    var rect = canvas.getBoundingClientRect();
+    var px = e.clientX - rect.left;
+    var py = e.clientY - rect.top;
+    var best = null;
+    var bestDist = Infinity;
+    var self = this;
+    this._nodes.forEach(function(n) {
+      var p = self.getProjectedNode(n, rect.width, 500);
+      var radius = (8 + Math.min(n.confidence || 0.5, 1) * 8) * p.scale;
+      var dist = Math.hypot(px - p.x, py - p.y);
+      if (dist < Math.max(12, radius + 4) && dist < bestDist) {
+        best = n;
+        bestDist = dist;
+      }
+    });
+    if (best) this.selectNode(best.id);
+    else this.deselectNode();
+  },
+
+  renderCanvasGraph: function() {
+    var canvas = document.getElementById('kg-canvas');
+    if (!canvas || !canvas.getContext) return false;
+
+    this.init3DPositions();
+    this.bindCanvasControls(canvas);
+
+    var rect = canvas.getBoundingClientRect();
+    var w = rect.width || 960;
+    var h = 500;
+    var dpr = window.devicePixelRatio || 1;
+    canvas.width = w * dpr;
+    canvas.height = h * dpr;
+
+    var ctx = canvas.getContext('2d');
+    ctx.setTransform(dpr, 0, 0, dpr, 0, 0);
+    ctx.clearRect(0, 0, w, h);
+
+    var bg = ctx.createRadialGradient(w / 2, h / 2, 20, w / 2, h / 2, Math.max(w, h) / 1.2);
+    bg.addColorStop(0, 'rgba(88,166,255,0.08)');
+    bg.addColorStop(1, 'rgba(10,14,23,0.98)');
+    ctx.fillStyle = bg;
+    ctx.fillRect(0, 0, w, h);
+
+    var self = this;
+    var nodeMap = {};
+    var projected = {};
+    this._nodes.forEach(function(n) {
+      nodeMap[n.id] = n;
+      projected[n.id] = self.getProjectedNode(n, w, h);
+    });
+
+    this._edges.forEach(function(e) {
+      var s = projected[e.source];
+      var t = projected[e.target];
+      if (!s || !t) return;
+      var visible = !self._filteredIds || (self._filteredIds[e.source] && self._filteredIds[e.target]);
+      var edgeColor = '48,54,61';
+      if (e.relationship === 'uses') edgeColor = '163,113,247';
+      else if (e.relationship === 'targets') edgeColor = '248,81,73';
+      else if (e.relationship === 'related_to') edgeColor = '88,166,255';
+      else if (e.relationship === 'attributed_to') edgeColor = '210,153,34';
+      ctx.strokeStyle = 'rgba(' + edgeColor + ',' + (visible ? 0.52 : 0.08) + ')';
+      ctx.lineWidth = visible ? 1.2 : 0.6;
+      ctx.beginPath();
+      ctx.moveTo(s.x, s.y);
+      ctx.lineTo(t.x, t.y);
+      ctx.stroke();
+    });
+
+    var sortedNodes = this._nodes.slice().sort(function(a, b) {
+      return projected[a.id].z - projected[b.id].z;
+    });
+
+    sortedNodes.forEach(function(n) {
+      var p = projected[n.id];
+      var visible = !self._filteredIds || !!self._filteredIds[n.id];
+      var selected = self._selectedNode === n.id;
+      var radius = (7 + Math.min(n.confidence || 0.5, 1) * 7) * p.scale;
+      var color = self.getNodeColor(n.type);
+
+      ctx.globalAlpha = visible ? 1 : 0.16;
+      ctx.beginPath();
+      ctx.arc(p.x, p.y, radius, 0, Math.PI * 2);
+      ctx.fillStyle = color;
+      ctx.fill();
+      ctx.lineWidth = selected ? 3 : 1;
+      ctx.strokeStyle = selected ? '#00FFA3' : 'rgba(255,255,255,0.18)';
+      ctx.stroke();
+
+      if (selected) {
+        ctx.beginPath();
+        ctx.arc(p.x, p.y, radius + 8, 0, Math.PI * 2);
+        ctx.strokeStyle = 'rgba(0,255,163,0.28)';
+        ctx.lineWidth = 2;
+        ctx.stroke();
+      }
+
+      if (visible && p.scale > 0.45) {
+        ctx.font = '11px JetBrains Mono, monospace';
+        ctx.fillStyle = '#8B949E';
+        ctx.textAlign = 'center';
+        ctx.fillText(n.label || n.id, p.x, p.y + radius + 13);
+      }
+      ctx.globalAlpha = 1;
+    });
+
+    return true;
+  },
+
   renderGraph: function() {
+    if (this.renderCanvasGraph()) return;
+
     var svg = document.getElementById('kg-svg');
     if (!svg) return;
 
@@ -346,6 +562,7 @@ window.KnowledgeGraphView = {
 
     panel.innerHTML = html;
     panel.style.display = 'block';
+    this.renderGraph();
 
     // Highlight node
     var allNodes = document.getElementById('kg-nodes');
@@ -384,5 +601,6 @@ window.KnowledgeGraphView = {
         }
       });
     }
+    this.renderGraph();
   }
 };

--- a/web/ui/js/views/search.js
+++ b/web/ui/js/views/search.js
@@ -56,9 +56,10 @@ window.SearchView = {
     formatRow.appendChild(formatLabel);
 
     var formats = [
+      { value: 'direct_answer', label: 'Direct' },
       { value: 'synthesized_brief', label: 'Brief' },
-      { value: 'synthesized_detailed', label: 'Detailed' },
-      { value: 'synthesized_narrative', label: 'Narrative' }
+      { value: 'timeline_analysis', label: 'Timeline' },
+      { value: 'relationship_map', label: 'Relationships' }
     ];
     var self = this;
     formats.forEach(function(f) {
@@ -182,8 +183,12 @@ window.SearchView = {
         format: this._state.format
       }).then(function(data) {
         self._state.loading = false;
-        self._state.synthesis = data;
-        self._state.status = 'synthesis complete \u00B7 ' + (data.latency_ms || '---') + 'ms \u00B7 ' + (data.sources ? data.sources.length : 0) + ' sources';
+        var synthesis = data.synthesis || data;
+        synthesis.format = data.format || self._state.format;
+        synthesis.latency_ms = data.latency_ms;
+        synthesis.sources_count = data.sources_count || 0;
+        self._state.synthesis = synthesis;
+        self._state.status = 'synthesis complete \u00B7 ' + (data.latency_ms || '---') + 'ms \u00B7 ' + (data.sources_count || 0) + ' sources';
         self.renderResults();
       }).catch(function(err) {
         self._state.loading = false;
@@ -241,18 +246,19 @@ window.SearchView = {
       head.appendChild(title);
 
       var meta = document.createElement('span');
-      var srcCount = synth.sources ? synth.sources.length : 0;
+      var sources = synth.sources || synth.source_ids || synth.citations || [];
+      var srcCount = synth.sources_count !== undefined ? synth.sources_count : sources.length;
       meta.textContent = (synth.format || this._state.format) + ' \u00B7 ' + (synth.latency_ms || '---') + 'ms \u00B7 ' + srcCount + ' sources';
       meta.style.cssText = 'font-family:var(--font-mono);font-size:var(--text-xs,11px);color:var(--fg-2,#8B949E);';
       head.appendChild(meta);
       block.appendChild(head);
 
       var answer = document.createElement('div');
-      answer.textContent = synth.answer || synth.content || 'No synthesis content returned.';
+      answer.textContent = synth.answer || synth.summary || synth.content || (Array.isArray(synth.citations) ? synth.citations.map(function(c) { return c.text || c.id || String(c); }).join('\n') : '') || 'No synthesis content returned.';
       answer.style.cssText = 'font-size:var(--text-base,14px);line-height:var(--lh-relaxed,1.7);color:var(--fg-1,#C9D1D9);white-space:pre-wrap;';
       block.appendChild(answer);
 
-      if (synth.sources && synth.sources.length) {
+      if (sources && sources.length) {
         var srcSection = document.createElement('div');
         srcSection.style.cssText = 'margin-top:14px;padding-top:12px;border-top:1px solid var(--bg-surface-hi,#21262D);display:flex;gap:var(--sp-2,8px);flex-wrap:wrap;font-family:var(--font-mono);font-size:var(--text-xs,11px);color:var(--fg-2,#8B949E);align-items:center;';
 
@@ -260,9 +266,9 @@ window.SearchView = {
         srcLabel.textContent = 'sources:';
         srcSection.appendChild(srcLabel);
 
-        synth.sources.forEach(function(s) {
+        sources.forEach(function(s) {
           var src = document.createElement('span');
-          src.textContent = s;
+          src.textContent = typeof s === 'string' ? s : (s.id || s.note_id || s.text || JSON.stringify(s));
           src.style.cssText = 'color:var(--intent-factual,#58A6FF);';
           srcSection.appendChild(src);
         });
@@ -317,11 +323,16 @@ window.SearchView = {
     if (!content) return;
 
     var self = this;
-    window.API.post('/api/notes', { content: content }).then(function(data) {
+    window.API.post('/api/remember', {
+      content: content,
+      domain: 'cti',
+      source_type: 'manual',
+      evolve: true
+    }).then(function(data) {
       self._state.rememberValue = '';
       var ta = document.getElementById('remember-textarea');
       if (ta) ta.value = '';
-      window.ToastComponent.show('Stored: ' + (data.id || 'ok'), 'success');
+      window.ToastComponent.show('Stored: ' + (data.note_id || 'ok'), 'success');
 
       var statusEl = document.getElementById('search-status');
       if (statusEl) statusEl.textContent = 'Stored note successfully';


### PR DESCRIPTION
## Summary

- Serve the RFC-015 management SPA from the canonical `web/app.py` root route and mount `/ui` static assets.
- Add the missing SPA `state` and `api` helpers so the dashboard, search, graph, ingest, entities, history, logs, and configuration views can call the backend consistently.
- Make header and sidebar version labels runtime-driven from `/api/stats` instead of stale hardcoded fallback versions.
- Align frontend payloads with existing backend endpoints and replace the external graph dependency with an offline canvas-based 3D graph view.

## Why

The shipped root page was still the older search-only interface while the RFC-015 SPA existed separately and was missing required shared JS modules. This left the product with multiple confusing web implementations and stale version labels in the visible chrome.

## Validation

- `bash -lc 'for f in web/ui/js/**/*.js web/ui/js/*.js; do node --check "$f" >/dev/null || exit 1; done; echo js-ok'`
- `pytest -q tests/test_web_api.py::TestFrontendEndpoint tests/test_web_api.py::TestConfigPage tests/test_web_api.py::TestHealthEndpoint tests/test_web_api.py::TestTelemetryEndpoint`
- Playwright live check confirmed the rendered GUI contains `v2.6.1`, does not contain `v2.3.0` or `v0.0.0`, and has no browser console errors.

Note: a full `pytest -q tests/test_web_api.py` run stalled after initial progress in this local environment, so it was stopped and replaced with the focused web/API checks above.