### PR TITLE
fix: show inline error on empty search query

### DIFF
--- a/web/ui/js/views/search.js
+++ b/web/ui/js/views/search.js
@@ -161,7 +161,22 @@ window.SearchView = {
 
   runSearch: function() {
     var q = this._state.query.trim();
-    if (!q) return;
+    if (!q) {
+      // Route through state + renderResults() rather than mutating the DOM
+      // inline. Three reasons this matters:
+      //   1. The view re-renders on navigate-away/back; without a state
+      //      entry the error vanishes silently.
+      //   2. renderResults() already owns the error-card styling (single
+      //      source of truth instead of duplicated style strings).
+      //   3. Status-bar text and card text stay in sync (renderResults
+      //      derives the status from the same _state.error value).
+      this._state.error = 'Please enter a query before searching.';
+      this._state.results = [];
+      this._state.synthesis = null;
+      this._state.loading = false;
+      this.renderResults();
+      return;
+    }
     this._state.loading = true;
     this._state.error = '';
     this._state.synthesis = null;


### PR DESCRIPTION
## Summary
Replaces the silent no-op when submitting an empty search query with an inline error card.

## Changes
- `web/ui/js/views/search.js` — `runSearch()`: replaced `if (!q) return;` with an inline error that:
  - Updates the status bar with `error: enter a query`
  - Renders a red-bordered error card in the results area reading `Please enter a query before searching.`
  - Error styling matches existing `renderResults()` error card pattern (uses `var(--danger,...) CSS var`)

## Testing
- [ ] Empty search submission shows error card + status message
- [ ] Non-empty search still works correctly
- [ ] No JS console errors