### PR TITLE
Release v2.7.0 with memory defenses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,8 +6,31 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+## [2.7.0] - 2026-05-26
+
+Security and OSINT release. Adds the RFC-016 OSINT layer and the first
+SEC-011 / MemSAD-inspired write-time memory-poisoning defense. No data
+migration is required. The new memory defense ships in audit mode by default.
+
 ### Added
 
+- **OSINT layer scaffold and Phase 1 collectors** (RFC-016). Adds
+  `zettelforge.osint` with infrastructure, breach, people, social, and
+  technology collector packages; OSINT ontology and relation extensions;
+  entity canonicalization helpers; collector registry; and tests covering
+  DNS, WHOIS, certificates, BGP, ports, breach, people, social, and tech
+  collector contracts. Optional runtime dependencies are available with
+  `pip install zettelforge[osint]`.
+- **Write-time memory anomaly defense** (SEC-011 / MemSAD). New
+  `MemoryAnomalyGate` scores candidate notes before persistence using
+  MemSAD-style max/mean embedding similarity against recent domain
+  calibration notes plus character n-gram Jensen-Shannon divergence to
+  reduce synonym/paraphrase evasion. Config lives under
+  `governance.memory_defense`; default mode is `audit`, with `block` and
+  `quarantine` available once a deployment has a clean calibration corpus.
+- **Quarantine path for rejected memory writes.** In `quarantine` mode,
+  flagged notes are written to JSONL forensic quarantine and are not exposed
+  to recall, entity lookup, LanceDB, or graph traversal.
 - **CrewAI integration** (issue #40). New optional extra
   `pip install zettelforge[crewai]` exposes `ZettelForgeRecallTool`,
   `ZettelForgeRememberTool`, and `ZettelForgeSynthesizeTool` as CrewAI
@@ -18,6 +41,23 @@ Versioning follows [Semantic Versioning](https://semver.org/).
   See `examples/crewai_cti_crew.py` for a runnable two-agent demo.
   Tests gated on `pytest.importorskip("crewai")`; 11 pass against
   crewai 1.14.x.
+
+### Changed
+
+- **Telemetry attribution compatibility.** `caller` is now supported in
+  telemetry events while the previous `actor` field and method arguments
+  remain backward-compatible for existing dashboards and tests.
+- **Real LLM integration and performance tests are explicit opt-in.**
+  Set `ZETTELFORGE_RUN_LLM_INTEGRATION=1` or
+  `ZETTELFORGE_RUN_PERFORMANCE_TESTS=1` to run environment-sensitive suites.
+  The default regression suite is now deterministic on machines without
+  local LLM credentials or dedicated benchmark hardware.
+
+### Tests
+
+- Added focused memory-defense tests for insufficient calibration, audit-mode
+  anomaly detection, and quarantine writes.
+- Default regression gate: `742 passed, 13 skipped`.
 
 ## [2.6.2] - 2026-04-27
 

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -376,6 +376,10 @@ synthesis:
 #   ZETTELFORGE_PII_ACTION=redact
 #   ZETTELFORGE_LIMITS_MAX_CONTENT_LENGTH=104857600
 #   ZETTELFORGE_LIMITS_RECALL_TIMEOUT=60
+#   ZETTELFORGE_MEMORY_DEFENSE_ENABLED=true
+#   ZETTELFORGE_MEMORY_DEFENSE_MODE=audit       # audit | block | quarantine
+#   ZETTELFORGE_MEMORY_DEFENSE_MIN_CALIBRATION=50
+#   ZETTELFORGE_MEMORY_DEFENSE_KAPPA=2.0
 #
 governance:
   enabled: true
@@ -390,6 +394,17 @@ governance:
   limits:
     max_content_length: 52428800  # 50 MB, 0 = unlimited
     recall_timeout_seconds: 30.0  # seconds, 0 = unlimited
+  memory_defense:
+    enabled: true
+    mode: audit  # audit | block | quarantine
+    min_calibration_notes: 50
+    max_reference_notes: 50
+    kappa: 2.0
+    lexical_weight: 0.25
+    ngram_size: 3
+    monitored_domains: []  # empty = all domains
+    quarantine_path: ""  # default: <storage.data_dir>/quarantine/memory_anomalies.jsonl
+    quarantine_raw_content: true
 
 
 # ── LanceDB Maintenance (RFC-009 Phase 1.5) ─────────────────────────────────
@@ -487,4 +502,3 @@ web:
   enabled: true
   host: 0.0.0.0
   port: 8088
-

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -8,8 +8,8 @@ tags:
   - environment-variables
   - settings
   - deployment
-last_updated: "2026-04-25"
-version: "2.6.0"
+last_updated: "2026-05-26"
+version: "2.7.0"
 ---
 
 # Configuration Reference
@@ -264,6 +264,8 @@ class GovernanceConfig:
     enabled: bool = True
     min_content_length: int = 1
     pii: PIIConfig = field(default_factory=PIIConfig)
+    limits: LimitsConfig = field(default_factory=LimitsConfig)
+    memory_defense: MemoryDefenseConfig = field(default_factory=MemoryDefenseConfig)
 ```
 
 | Key | Type | Default | Env Override | Description |
@@ -308,6 +310,36 @@ class LimitsConfig:
 |:----|:-----|:--------|:-------------|:------------|
 | `governance.limits.max_content_length` | `int` | `52428800` | `ZETTELFORGE_LIMITS_MAX_CONTENT_LENGTH` | Maximum content length in bytes for `remember()`. 0 = unlimited. 50 MB default. |
 | `governance.limits.recall_timeout_seconds` | `float` | `30.0` | `ZETTELFORGE_LIMITS_RECALL_TIMEOUT` | Maximum seconds for a recall() query. 0 = unlimited. |
+
+#### governance.memory_defense (SEC-011 / MemSAD)
+
+```python
+@dataclass
+class MemoryDefenseConfig:
+    enabled: bool = True
+    mode: str = "audit"
+    min_calibration_notes: int = 50
+    max_reference_notes: int = 50
+    kappa: float = 2.0
+    lexical_weight: float = 0.25
+    ngram_size: int = 3
+    monitored_domains: list[str] = field(default_factory=list)
+    quarantine_path: str = ""
+    quarantine_raw_content: bool = True
+```
+
+| Key | Type | Default | Env Override | Description |
+|:----|:-----|:--------|:-------------|:------------|
+| `governance.memory_defense.enabled` | `bool` | `True` | `ZETTELFORGE_MEMORY_DEFENSE_ENABLED` | Enable write-time memory-poisoning anomaly evaluation before notes are persisted or indexed. |
+| `governance.memory_defense.mode` | `str` | `audit` | `ZETTELFORGE_MEMORY_DEFENSE_MODE` | Policy for flagged writes: `audit` logs only, `block` rejects the write, `quarantine` writes a forensic JSONL record and rejects the write. |
+| `governance.memory_defense.min_calibration_notes` | `int` | `50` | `ZETTELFORGE_MEMORY_DEFENSE_MIN_CALIBRATION` | Minimum same-domain reference notes required before thresholding. Below this count, writes are allowed with `calibration_insufficient` audit metadata. |
+| `governance.memory_defense.max_reference_notes` | `int` | `50` | -- | Maximum recent same-domain reference notes used for calibration and scoring. |
+| `governance.memory_defense.kappa` | `float` | `2.0` | `ZETTELFORGE_MEMORY_DEFENSE_KAPPA` | Threshold multiplier: `mean + kappa * stddev` over calibration scores. |
+| `governance.memory_defense.lexical_weight` | `float` | `0.25` | -- | Weight applied to character n-gram Jensen-Shannon divergence, complementing embedding similarity against synonym/paraphrase evasion. |
+| `governance.memory_defense.ngram_size` | `int` | `3` | -- | Character n-gram size for lexical divergence. |
+| `governance.memory_defense.monitored_domains` | `list[str]` | `[]` | -- | Domains to evaluate. Empty list means every domain. |
+| `governance.memory_defense.quarantine_path` | `str` | `""` | -- | JSONL quarantine path. Empty uses `<storage.data_dir>/quarantine/memory_anomalies.jsonl`. |
+| `governance.memory_defense.quarantine_raw_content` | `bool` | `True` | -- | Include raw rejected content in quarantine records. Disable if quarantine storage is not approved for raw content. |
 
 ---
 

--- a/docs/rfcs/RFC-017-memsad-write-time-defenses.md
+++ b/docs/rfcs/RFC-017-memsad-write-time-defenses.md
@@ -1,0 +1,402 @@
+# RFC-017: MemSAD-Inspired Write-Time Memory Defenses
+
+**Status:** Proposed  
+**Date:** 2026-05-26  
+**Related brief:** `/home/rolandpg/research/briefs/2026-05-25-SEC-011-memsad.md`  
+**Scope:** Community repository `rolandpg/zettelforge`, local checkout, and GitHub repository controls
+
+## Summary
+
+SEC-011 identifies the highest-risk gap as absent write-time anomaly detection for
+ZettelForge memory and entity ingestion. The current write path validates size and
+optional PII, then constructs a note, writes it, indexes its vector, extracts
+entities, and writes entity mappings. There is no calibrated anomaly gate before
+the note becomes retrievable.
+
+This RFC proposes a composite memory-write defense:
+
+1. A MemSAD-style similarity anomaly scorer against a trusted calibration set.
+2. A lexical drift scorer using character n-gram Jensen-Shannon divergence to
+   reduce synonym/paraphrase evasion.
+3. Source provenance and trust gates before high-impact CTI writes are indexed.
+4. A quarantine path that preserves forensic evidence without exposing rejected
+   content to recall, entity lookup, or graph traversal.
+5. Repository and web hardening items that close the immediately visible control
+   gaps found during the evaluation.
+
+The first implementation should ship in dry-run/audit mode, then move to
+enforced quarantine once a trusted calibration corpus is available.
+
+## Evaluation Findings
+
+### Local Project
+
+- The direct `remember()` write path has no anomaly gate between governance
+  validation and persistence. The note is constructed at
+  `src/zettelforge/memory_manager.py:288`, written at
+  `src/zettelforge/memory_manager.py:293`, added to the in-memory entity index
+  at `src/zettelforge/memory_manager.py:314`, and persisted to the SQLite entity
+  index at `src/zettelforge/memory_manager.py:319`.
+- Entity extraction is deterministic regex plus optional LLM NER, but the
+  extracted entity set is trusted once produced. `EntityExtractor.extract_all()`
+  starts at `src/zettelforge/entity_indexer.py:340`; it normalizes strings but
+  does not score entity-write risk.
+- Existing governance covers structural validation, content length, and optional
+  PII redaction/blocking, but not memory poisoning. The governance config
+  currently has PII and limits only in `src/zettelforge/config.py:205`.
+- Audit logging exists for authorization/API/file events, but there is no memory
+  anomaly event class or quarantine audit record.
+- The web API has an API-key guard and rate limiting in `web/app.py:156`, but
+  several exception handlers return `str(e)` to clients. GitHub CodeQL reports
+  11 open medium `py/stack-trace-exposure` alerts in `web/app.py`.
+- MCP stdio is local-process scoped, but tool calls do not enforce the same
+  input length, `k`, or synthesis format constraints as the web API.
+
+### GitHub Repository
+
+Observed via GitHub API on 2026-05-26:
+
+- Repository is public, default branch is `master`, and the current user has
+  admin permissions.
+- Branch protection on `master` is enabled with strict required checks:
+  `lint`, `test (3.12)`, `test (3.13)`, `governance`, and `build`.
+- Admin enforcement, linear history, conversation resolution, no force pushes,
+  and no deletions are enabled.
+- Required approving review count is `1`, but code owner reviews and stale review
+  dismissal are disabled.
+- Dependabot alerts and secret-scanning alerts are currently empty.
+- Code scanning default setup is configured, but open CodeQL alerts remain.
+- Repository Actions allow all actions and `sha_pinning_required` is false.
+  Most local workflows pin action SHAs, but `.github/workflows/stale.yml` uses
+  `actions/stale@v9`, so the `SECURITY.md` claim that all third-party actions
+  are SHA-pinned is not fully true.
+- `pip-audit` and Snyk jobs exist, but branch protection does not require
+  `pip-audit` or `Snyk Security`.
+- Open PR #146 addresses unrelated P0 hardening for LLM budgets, bulk ingest,
+  and CCCS regexes. There is no open MemSAD/anomaly-filter issue or PR.
+
+## Threat Model
+
+The cross-mission chain in SEC-011 is:
+
+```text
+Memory poisoning -> entity stored without write-time filtering ->
+triggered CTI recall -> poisoned context steers tool/action selection ->
+downstream exfiltration or false intelligence
+```
+
+The defense objective is to break the chain before the poison is indexed. A
+rejected or quarantined write must not be present in:
+
+- vector retrieval,
+- entity index lookup,
+- knowledge graph traversal,
+- synthesis context,
+- neighbor evolution or supersession decisions.
+
+## Design
+
+### 1. Memory Write Assessment
+
+Add `src/zettelforge/memory_security.py` with these core types:
+
+- `MemoryWriteAssessment`
+  - `decision`: `allow`, `audit`, `quarantine`, or `reject`
+  - `risk_score`
+  - `memsad_score`
+  - `lexical_drift_score`
+  - `source_trust_score`
+  - `reasons`
+  - `calibration_version`
+- `MemoryWriteFilter`
+  - `assess(content, note, entities, domain, source_type, source_ref)`
+  - `record_decision(assessment, note_id=None)`
+
+The filter should be called after in-memory note construction and entity
+extraction, but before `store.write_note()`, LanceDB indexing, entity indexing,
+KG updates, supersession, and enrichment dispatch.
+
+### 2. MemSAD-Style Similarity Score
+
+For a candidate content embedding `E(c)` and trusted domain history `H`:
+
+```text
+s_comb(c; H) = 0.5 * max cos(E(c), E(q)) + 0.5 * mean cos(E(c), E(q))
+```
+
+Initial threshold:
+
+```text
+tau = mean(reference_scores) + kappa * stddev(reference_scores)
+```
+
+Default `kappa` should be `2.0` in audit mode. Enforcement should not be enabled
+until at least 50 trusted calibration entries exist for the target domain.
+
+### 3. Lexical Drift Scorer
+
+Pure embedding defenses are weak against discrete synonym substitution. Add a
+second feature family:
+
+- character 3-gram and 4-gram distributions,
+- Jensen-Shannon divergence against the nearest trusted neighbors,
+- optional token-level Jaccard/containment features,
+- suspicious instruction phrases such as "ignore previous", "system prompt",
+  "tool call", "exfiltrate", and "secret".
+
+This scorer should not be used as a standalone reject rule at first. It should
+raise the composite score, add reasons, and help prioritize quarantine review.
+
+### 4. Provenance Gates
+
+Add source-aware policy before high-impact CTI writes:
+
+- `source_type` must be present and normalized.
+- `source_ref` is required for `domain="cti"` unless explicitly disabled.
+- `evolve=True` writes should require provenance above a configurable trust
+  floor before they supersede existing notes.
+- Bulk ingest from YARA/Sigma/OpenCTI can be allowlisted by source type but
+  should still be scored.
+
+### 5. Quarantine Store
+
+Add SQLite tables through the storage backend:
+
+```sql
+CREATE TABLE IF NOT EXISTS memory_write_assessments (
+    assessment_id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    note_id TEXT,
+    domain TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    source_ref TEXT DEFAULT '',
+    decision TEXT NOT NULL,
+    risk_score REAL NOT NULL,
+    memsad_score REAL,
+    lexical_drift_score REAL,
+    source_trust_score REAL,
+    calibration_version TEXT DEFAULT '',
+    reasons TEXT DEFAULT '[]'
+);
+
+CREATE TABLE IF NOT EXISTS memory_quarantine (
+    quarantine_id TEXT PRIMARY KEY,
+    created_at TEXT NOT NULL,
+    content_raw TEXT NOT NULL,
+    domain TEXT NOT NULL,
+    source_type TEXT NOT NULL,
+    source_ref TEXT DEFAULT '',
+    assessment_id TEXT NOT NULL
+);
+```
+
+Quarantined content is evidence, not memory. It must not be written to the
+`notes`, `entity_index`, `kg_nodes`, `kg_edges`, or LanceDB tables.
+
+### 6. Configuration
+
+Add a nested config section:
+
+```yaml
+security:
+  memory_filter:
+    enabled: true
+    mode: audit        # off | audit | quarantine | reject
+    min_calibration_entries: 50
+    kappa: 2.0
+    calibration_window: 500
+    require_cti_source_ref: true
+    quarantine_on_high_risk: true
+    lexical_ngram_sizes: [3, 4]
+    max_quarantine_content_length: 50000
+```
+
+Environment overrides should mirror existing config style:
+
+- `ZETTELFORGE_MEMORY_FILTER_ENABLED`
+- `ZETTELFORGE_MEMORY_FILTER_MODE`
+- `ZETTELFORGE_MEMORY_FILTER_KAPPA`
+- `ZETTELFORGE_MEMORY_FILTER_MIN_CALIBRATION`
+
+### 7. Audit Logging
+
+Add OCSF-compatible memory anomaly events. Minimum fields:
+
+- `operation="memory_write_assessment"`
+- `request_id`
+- `note_id` when allowed
+- `assessment_id`
+- `decision`
+- `risk_score`
+- `reasons`
+- `domain`
+- `source_type`
+- `source_ref_hash` instead of full source ref when sensitive
+
+The web API should expose aggregate counts only by default. Raw quarantine
+content should require an authenticated admin route or remain CLI-only in
+Community edition.
+
+## Implementation Plan
+
+### Phase 0: Close Existing Control Gaps
+
+1. Fix the 11 open CodeQL `py/stack-trace-exposure` findings in `web/app.py` by
+   returning generic client errors and logging details server-side.
+2. Add a FastAPI global exception handler so future routes do not reintroduce
+   `{"error": str(e)}` responses.
+3. Align `SECURITY.md` and `.github/SECURITY.md` into one current policy.
+4. Pin `actions/stale` by SHA or restrict repository Actions to selected
+   pinned actions.
+5. Add branch-protection required checks for `pip-audit` and the Snyk workflow
+   once the Snyk token is present.
+6. Decide whether open PR #146 should merge first. It is not a dependency for
+   MemSAD, but it touches ingestion behavior and may reduce merge conflicts.
+
+Acceptance:
+
+- Code scanning open alerts for `web/app.py` are zero.
+- Branch protection includes all security gates that are expected to block.
+- Security policy no longer claims controls that are not enforced.
+
+### Phase 1: Dry-Run Memory Filter
+
+1. Add config dataclasses and env overrides for `security.memory_filter`.
+2. Add `MemoryWriteFilter` and pure scorer functions with deterministic unit
+   tests.
+3. Add storage methods for `memory_write_assessments`.
+4. Wire assessment into `MemoryManager._remember_inner()` before persistence,
+   but keep `mode=audit` as default.
+5. Emit audit events for every write assessment.
+
+Acceptance:
+
+- `remember()` still stores notes in audit mode.
+- Every direct write produces one assessment record and one audit event.
+- Tests cover empty calibration, exactly 50 calibration entries, and
+  over-threshold scoring.
+
+### Phase 2: Quarantine Enforcement
+
+1. Add `memory_quarantine` storage methods.
+2. In `mode=quarantine`, prevent high-risk writes from reaching note/vector/
+   entity/KG stores.
+3. Return a structured status such as `("quarantined")` without leaking raw
+   scorer internals to unauthenticated clients.
+4. Update web and MCP handlers to surface quarantine safely.
+
+Acceptance:
+
+- Quarantined notes are absent from `recall()`, `recall_entity()`,
+  `traverse_graph()`, and `synthesize()`.
+- Quarantine writes preserve content and assessment metadata for review.
+- Regression tests prove the enrichment worker is not dispatched for
+  quarantined content.
+
+### Phase 3: Entity and Evolution Hardening
+
+1. Score both raw content and extracted entity set deltas.
+2. Add entity-count, rare-entity, and suspicious-relationship heuristics.
+3. Add provenance gates to `MemoryUpdater.apply()` so LLM-decided update/delete
+   operations cannot supersede trusted notes from untrusted sources.
+4. Add source trust metadata to notes or assessment records for downstream
+   policy.
+
+Acceptance:
+
+- High-risk entities can be filtered before `add_entity_mapping()`.
+- Untrusted evolved facts cannot supersede a trusted note without explicit
+  policy.
+- Tests cover poisoning attempts through direct remember, evolve, bulk ingest,
+  and MCP.
+
+### Phase 4: Calibration Management
+
+1. Add CLI commands:
+   - `zettelforge security calibrate --domain cti --trusted-source <selector>`
+   - `zettelforge security status`
+   - `zettelforge security quarantine list/show/release/reject`
+2. Seed calibration from explicit trusted notes only, never from arbitrary first
+   writes.
+3. Add rolling calibration that only admits allowed, non-quarantined,
+   provenance-sufficient notes.
+4. Store `calibration_version` on assessments.
+
+Acceptance:
+
+- New deployments remain audit-only until calibration is sufficient.
+- Recalibration is reproducible and logged.
+- Releasing a quarantined note re-assesses it against the current calibration
+  version before indexing.
+
+### Phase 5: Operational Logging and Repo Controls
+
+1. Add optional audit-log HMAC chaining or document external log shipping as the
+   supported tamper-evidence path.
+2. Add a SIEM/syslog export guide for `~/.amem/logs/audit.log`.
+3. Require CodeQL, Snyk, pip-audit, tests, and governance gates in branch
+   protection.
+4. Enable code owner reviews for `.github/**`, `src/zettelforge/config.py`,
+   `src/zettelforge/memory_manager.py`, `src/zettelforge/entity_indexer.py`,
+   storage backends, and security modules.
+
+Acceptance:
+
+- Security-sensitive code paths require CODEOWNER review or documented
+  solo-maintainer compensating control.
+- Audit events can be shipped off-machine.
+- The repository control docs match GitHub settings.
+
+## Test Strategy
+
+Add focused tests before broad end-to-end coverage:
+
+- `tests/test_memory_write_filter.py`
+  - cosine score math,
+  - threshold calculation,
+  - insufficient calibration fallback,
+  - lexical n-gram JSD,
+  - composite decision ordering.
+- `tests/test_memory_quarantine.py`
+  - quarantined content is not retrievable,
+  - no entity mappings or KG edges are written,
+  - assessment and quarantine records are present.
+- `tests/test_memory_filter_integration.py`
+  - direct `remember()`,
+  - `remember(evolve=True)`,
+  - MCP tool call,
+  - web `/api/remember` and `/api/ingest`.
+- `tests/test_web_api.py`
+  - generic 500 responses,
+  - no `str(e)` leakage,
+  - quarantine status shape.
+- Governance drift test update:
+  - add new runtime controls for memory anomaly filtering and quarantine audit.
+
+## Rollout
+
+1. Default `mode=off` for one patch release if compatibility risk is high, or
+   `mode=audit` if telemetry volume is acceptable.
+2. Dogfood on the maintainer CTI corpus with `mode=audit`, `kappa=2.0`,
+   `min_calibration_entries=50`.
+3. Review false positives and tune lexical/composite weights.
+4. Switch CTI deployments to `mode=quarantine`.
+5. Keep `mode=reject` reserved for highly controlled sources after observed
+   false-positive rates are acceptable.
+
+## Non-Goals
+
+- Proving a complete defense against all synonym/paraphrase attacks.
+- Replacing OS-level filesystem protection or encryption at rest.
+- Multi-tenant authorization in Community edition.
+- Off-machine log infrastructure in the first code PR.
+
+## Immediate Backlog
+
+1. `fix(web): sanitize API error responses and close CodeQL alerts`
+2. `chore(ci): require pip-audit/Snyk and pin stale action`
+3. `feat(security): add memory write assessment dry-run mode`
+4. `feat(security): add quarantine storage and enforcement`
+5. `feat(security): add entity/evolution provenance gates`
+6. `docs(security): document calibration, quarantine review, and log shipping`
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "zettelforge"
-version = "2.6.2"
+version = "2.7.0"
 description = "ZettelForge: Agentic Memory System with vector search, knowledge graph, and synthesis"
 readme = "README.md"
 license = "MIT"

--- a/src/zettelforge/__init__.py
+++ b/src/zettelforge/__init__.py
@@ -61,7 +61,7 @@ from zettelforge.vector_retriever import VectorRetriever
 # importable for advanced use but are not part of the advertised public API
 # and are therefore excluded from __all__ below.
 
-__version__ = "2.6.2"
+__version__ = "2.7.0"
 __all__ = [
     # Ontology reference tables (TypedEntityStore / OntologyValidator are
     # importable from zettelforge.ontology but are not part of the public API

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -202,11 +202,28 @@ class LimitsConfig:
 
 
 @dataclass
+class MemoryDefenseConfig:
+    """Write-time memory poisoning defense settings (SEC-011 / MemSAD)."""
+
+    enabled: bool = True
+    mode: str = "audit"  # audit | block | quarantine
+    min_calibration_notes: int = 50
+    max_reference_notes: int = 50
+    kappa: float = 2.0
+    lexical_weight: float = 0.25
+    ngram_size: int = 3
+    monitored_domains: list[str] = field(default_factory=list)  # empty = all domains
+    quarantine_path: str = ""
+    quarantine_raw_content: bool = True
+
+
+@dataclass
 class GovernanceConfig:
     enabled: bool = True
     min_content_length: int = 1
     pii: PIIConfig = field(default_factory=PIIConfig)
     limits: LimitsConfig = field(default_factory=LimitsConfig)
+    memory_defense: MemoryDefenseConfig = field(default_factory=MemoryDefenseConfig)
 
 
 @dataclass
@@ -251,6 +268,15 @@ class ExtensionsConfig:
 
 
 @dataclass
+class TelemetryConfig:
+    """RFC-007 Operational Telemetry settings."""
+
+    enabled: bool = True
+    data_dir: str = "~/.amem/telemetry"  # Shared fleet-wide telemetry
+    debug: bool = False
+
+
+@dataclass
 class OpenCTIConfig:
     """OpenCTI integration settings (Enterprise edition only)."""
 
@@ -288,6 +314,7 @@ class ZettelForgeConfig:
     lance: LanceConfig = field(default_factory=LanceConfig)
     logging: LoggingConfig = field(default_factory=LoggingConfig)
     enterprise: ExtensionsConfig = field(default_factory=ExtensionsConfig)
+    telemetry: TelemetryConfig = field(default_factory=TelemetryConfig)
     opencti: OpenCTIConfig = field(default_factory=OpenCTIConfig)
     web: WebConfig = field(default_factory=WebConfig)
 
@@ -427,6 +454,10 @@ def _apply_yaml(cfg: ZettelForgeConfig, data: dict):
                 for lk, lv in v.items():
                     if hasattr(cfg.governance.limits, lk):
                         setattr(cfg.governance.limits, lk, lv)
+            elif k == "memory_defense" and isinstance(v, dict):
+                for mk, mv in v.items():
+                    if hasattr(cfg.governance.memory_defense, mk):
+                        setattr(cfg.governance.memory_defense, mk, mv)
             else:
                 setattr(cfg.governance, k, v)
 
@@ -492,6 +523,12 @@ def _apply_env(cfg: ZettelForgeConfig):
     if v := os.environ.get("AMEM_EMBEDDING_MODEL"):
         cfg.embedding.model = v
 
+    # Telemetry (RFC-007)
+    if v := os.environ.get("ZETTELFORGE_TELEMETRY_DIR"):
+        cfg.telemetry.data_dir = v
+    if v := os.environ.get("ZETTELFORGE_TELEMETRY_DEBUG"):
+        cfg.telemetry.debug = v.lower() in ("1", "true", "yes")
+
     # LLM
     if v := os.environ.get("ZETTELFORGE_LLM_PROVIDER"):
         cfg.llm.provider = v
@@ -538,6 +575,16 @@ def _apply_env(cfg: ZettelForgeConfig):
         cfg.governance.limits.max_content_length = int(v)
     if v := os.environ.get("ZETTELFORGE_LIMITS_RECALL_TIMEOUT"):
         cfg.governance.limits.recall_timeout_seconds = float(v)
+
+    # SEC-011 / MemSAD write-time memory defense
+    if v := os.environ.get("ZETTELFORGE_MEMORY_DEFENSE_ENABLED"):
+        cfg.governance.memory_defense.enabled = v.lower() in ("true", "1", "yes")
+    if v := os.environ.get("ZETTELFORGE_MEMORY_DEFENSE_MODE"):
+        cfg.governance.memory_defense.mode = v
+    if v := os.environ.get("ZETTELFORGE_MEMORY_DEFENSE_MIN_CALIBRATION"):
+        cfg.governance.memory_defense.min_calibration_notes = int(v)
+    if v := os.environ.get("ZETTELFORGE_MEMORY_DEFENSE_KAPPA"):
+        cfg.governance.memory_defense.kappa = float(v)
 
     # Extensions license key (used by zettelforge-enterprise fallback path)
     if v := os.environ.get("THREATENGRAM_LICENSE_KEY"):

--- a/src/zettelforge/memory_defense.py
+++ b/src/zettelforge/memory_defense.py
@@ -1,0 +1,384 @@
+"""Write-time memory poisoning defenses.
+
+Implements the first SEC-011 / MemSAD-inspired control: score a candidate
+memory before it is persisted, using recent trusted memories as calibration.
+Default mode is audit-only; block/quarantine can be enabled by config once a
+site has a clean calibration corpus.
+"""
+
+from __future__ import annotations
+
+import fcntl
+import hashlib
+import json
+import math
+import os
+from collections import Counter
+from dataclasses import asdict, dataclass
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+from zettelforge.config import MemoryDefenseConfig, get_config
+from zettelforge.log import get_logger
+from zettelforge.memory_store import get_default_data_dir
+
+_logger = get_logger("zettelforge.memory_defense")
+_VALID_MODES = {"audit", "block", "quarantine"}
+
+
+class MemoryAnomalyError(RuntimeError):
+    """Raised when memory defense blocks or quarantines a write."""
+
+    def __init__(self, message: str, decision: MemoryAnomalyDecision) -> None:
+        super().__init__(message)
+        self.decision = decision
+
+
+@dataclass
+class MemoryAnomalyDecision:
+    """Decision metadata for a single memory-write anomaly evaluation."""
+
+    enabled: bool
+    mode: str
+    action: str
+    flagged: bool
+    reason: str
+    content_hash: str
+    score: float | None = None
+    threshold: float | None = None
+    memsad_score: float | None = None
+    lexical_jsd: float | None = None
+    max_similarity: float | None = None
+    mean_similarity: float | None = None
+    calibration_mean: float | None = None
+    calibration_std: float | None = None
+    reference_count: int = 0
+
+    @property
+    def should_stop_write(self) -> bool:
+        return self.flagged and self.mode in {"block", "quarantine"}
+
+    def as_event_fields(self) -> dict[str, Any]:
+        return asdict(self)
+
+
+class MemoryAnomalyGate:
+    """MemSAD-style write-time anomaly scorer.
+
+    The embedding score mirrors the MemSAD shape:
+
+    ``0.5 * max_similarity(candidate, refs) + 0.5 * mean_similarity(candidate, refs)``
+
+    A character n-gram Jensen-Shannon divergence term is added to reduce the
+    synonym/paraphrase loophole called out in SEC-011. Calibration uses the
+    same composite score in leave-one-out form over the reference notes.
+    """
+
+    def __init__(self, config: MemoryDefenseConfig | None = None) -> None:
+        self._config = config
+
+    def evaluate(
+        self,
+        note: Any,
+        reference_notes: list[Any],
+        *,
+        domain: str = "",
+        source_type: str = "",
+        source_ref: str = "",
+        request_id: str = "",
+    ) -> MemoryAnomalyDecision:
+        cfg = self._config or get_config().governance.memory_defense
+        mode = (cfg.mode or "audit").lower()
+        if mode not in _VALID_MODES:
+            mode = "audit"
+
+        raw_content = _note_text(note)
+        content_hash = _content_hash(raw_content)
+        if not cfg.enabled:
+            return MemoryAnomalyDecision(
+                enabled=False,
+                mode=mode,
+                action="allow",
+                flagged=False,
+                reason="disabled",
+                content_hash=content_hash,
+            )
+
+        if cfg.monitored_domains and domain not in cfg.monitored_domains:
+            return MemoryAnomalyDecision(
+                enabled=True,
+                mode=mode,
+                action="allow",
+                flagged=False,
+                reason="domain_not_monitored",
+                content_hash=content_hash,
+            )
+
+        candidate_vector = _note_vector(note)
+        if not _valid_vector(candidate_vector):
+            decision = MemoryAnomalyDecision(
+                enabled=True,
+                mode=mode,
+                action="audit",
+                flagged=False,
+                reason="candidate_embedding_unavailable",
+                content_hash=content_hash,
+            )
+            self._log_decision(decision, domain, source_type, source_ref, request_id)
+            return decision
+
+        refs = _select_reference_notes(note, reference_notes, cfg.max_reference_notes)
+        if len(refs) < cfg.min_calibration_notes:
+            decision = MemoryAnomalyDecision(
+                enabled=True,
+                mode=mode,
+                action="audit",
+                flagged=False,
+                reason="calibration_insufficient",
+                content_hash=content_hash,
+                reference_count=len(refs),
+            )
+            self._log_decision(decision, domain, source_type, source_ref, request_id)
+            return decision
+
+        calibration_scores = _calibration_scores(refs, cfg)
+        if not calibration_scores:
+            decision = MemoryAnomalyDecision(
+                enabled=True,
+                mode=mode,
+                action="audit",
+                flagged=False,
+                reason="calibration_unscorable",
+                content_hash=content_hash,
+                reference_count=len(refs),
+            )
+            self._log_decision(decision, domain, source_type, source_ref, request_id)
+            return decision
+
+        memsad_score, max_similarity, mean_similarity = _memsad_score(candidate_vector, refs)
+        lexical_jsd = _lexical_jsd(raw_content, [_note_text(ref) for ref in refs], cfg.ngram_size)
+        score = memsad_score + (cfg.lexical_weight * lexical_jsd)
+
+        calibration_mean = sum(calibration_scores) / len(calibration_scores)
+        calibration_std = _stddev(calibration_scores, calibration_mean)
+        threshold = calibration_mean + (float(cfg.kappa) * calibration_std)
+        flagged = score > threshold
+        action = mode if flagged and mode in {"block", "quarantine"} else "audit"
+
+        decision = MemoryAnomalyDecision(
+            enabled=True,
+            mode=mode,
+            action=action,
+            flagged=flagged,
+            reason="score_above_threshold" if flagged else "score_within_threshold",
+            content_hash=content_hash,
+            score=score,
+            threshold=threshold,
+            memsad_score=memsad_score,
+            lexical_jsd=lexical_jsd,
+            max_similarity=max_similarity,
+            mean_similarity=mean_similarity,
+            calibration_mean=calibration_mean,
+            calibration_std=calibration_std,
+            reference_count=len(refs),
+        )
+        self._log_decision(decision, domain, source_type, source_ref, request_id)
+        return decision
+
+    def enforce(
+        self,
+        note: Any,
+        reference_notes: list[Any],
+        *,
+        domain: str = "",
+        source_type: str = "",
+        source_ref: str = "",
+        request_id: str = "",
+    ) -> MemoryAnomalyDecision:
+        decision = self.evaluate(
+            note,
+            reference_notes,
+            domain=domain,
+            source_type=source_type,
+            source_ref=source_ref,
+            request_id=request_id,
+        )
+        if decision.should_stop_write:
+            if decision.mode == "quarantine":
+                self._write_quarantine(note, decision, domain, source_type, source_ref, request_id)
+            raise MemoryAnomalyError(
+                f"memory write {decision.action}ed by anomaly defense: "
+                f"score={decision.score:.4f} threshold={decision.threshold:.4f}",
+                decision,
+            )
+        return decision
+
+    def _write_quarantine(
+        self,
+        note: Any,
+        decision: MemoryAnomalyDecision,
+        domain: str,
+        source_type: str,
+        source_ref: str,
+        request_id: str,
+    ) -> None:
+        cfg = self._config or get_config().governance.memory_defense
+        path = Path(os.path.expanduser(cfg.quarantine_path)) if cfg.quarantine_path else None
+        if path is None:
+            path = get_default_data_dir() / "quarantine" / "memory_anomalies.jsonl"
+        path.parent.mkdir(parents=True, exist_ok=True)
+
+        record: dict[str, Any] = {
+            "timestamp": datetime.now(timezone.utc).isoformat(),
+            "request_id": request_id,
+            "domain": domain,
+            "source_type": source_type,
+            "source_ref": source_ref,
+            "note_id": getattr(note, "id", ""),
+            "decision": decision.as_event_fields(),
+        }
+        if cfg.quarantine_raw_content:
+            record["raw_content"] = _note_text(note)
+
+        with open(path, "a", encoding="utf-8") as f:
+            fcntl.flock(f, fcntl.LOCK_EX)
+            f.write(json.dumps(record, default=str) + "\n")
+            fcntl.flock(f, fcntl.LOCK_UN)
+
+    def _log_decision(
+        self,
+        decision: MemoryAnomalyDecision,
+        domain: str,
+        source_type: str,
+        source_ref: str,
+        request_id: str,
+    ) -> None:
+        fields = decision.as_event_fields()
+        fields.update(
+            {
+                "domain": domain,
+                "source_type": source_type,
+                "source_ref": source_ref,
+                "request_id": request_id,
+            }
+        )
+        if decision.flagged:
+            _logger.warning("memory_anomaly_detected", **fields)
+        elif decision.enabled:
+            _logger.debug("memory_anomaly_evaluated", **fields)
+
+
+def _select_reference_notes(candidate: Any, notes: list[Any], limit: int) -> list[Any]:
+    candidate_id = getattr(candidate, "id", "")
+    refs = [
+        note
+        for note in notes
+        if getattr(note, "id", "") != candidate_id and _valid_vector(_note_vector(note))
+    ]
+    refs.sort(key=lambda n: getattr(n, "created_at", "") or "", reverse=True)
+    return refs[: max(0, int(limit))]
+
+
+def _calibration_scores(notes: list[Any], cfg: MemoryDefenseConfig) -> list[float]:
+    scores: list[float] = []
+    for i, note in enumerate(notes):
+        refs = notes[:i] + notes[i + 1 :]
+        if not refs:
+            continue
+        memsad_score, _, _ = _memsad_score(_note_vector(note), refs)
+        lexical_jsd = _lexical_jsd(
+            _note_text(note), [_note_text(ref) for ref in refs], cfg.ngram_size
+        )
+        scores.append(memsad_score + (cfg.lexical_weight * lexical_jsd))
+    return scores
+
+
+def _memsad_score(candidate_vector: list[float], refs: list[Any]) -> tuple[float, float, float]:
+    similarities = [_cosine(candidate_vector, _note_vector(ref)) for ref in refs]
+    if not similarities:
+        return 0.0, 0.0, 0.0
+    max_similarity = max(similarities)
+    mean_similarity = sum(similarities) / len(similarities)
+    return 0.5 * max_similarity + 0.5 * mean_similarity, max_similarity, mean_similarity
+
+
+def _cosine(a: list[float], b: list[float]) -> float:
+    if not _valid_vector(a) or not _valid_vector(b) or len(a) != len(b):
+        return 0.0
+    dot = sum(x * y for x, y in zip(a, b, strict=True))
+    norm_a = math.sqrt(sum(x * x for x in a))
+    norm_b = math.sqrt(sum(y * y for y in b))
+    if norm_a == 0.0 or norm_b == 0.0:
+        return 0.0
+    return dot / (norm_a * norm_b)
+
+
+def _stddev(values: list[float], mean: float) -> float:
+    if len(values) < 2:
+        return 0.0
+    variance = sum((value - mean) ** 2 for value in values) / (len(values) - 1)
+    return math.sqrt(variance)
+
+
+def _lexical_jsd(text: str, reference_texts: list[str], ngram_size: int) -> float:
+    candidate = _ngram_counts(text, ngram_size)
+    reference = Counter()
+    for ref_text in reference_texts:
+        reference.update(_ngram_counts(ref_text, ngram_size))
+    return _jensen_shannon(candidate, reference)
+
+
+def _ngram_counts(text: str, ngram_size: int) -> Counter[str]:
+    normalized = " ".join(text.lower().split())
+    if not normalized:
+        return Counter()
+    n = max(1, int(ngram_size))
+    if len(normalized) <= n:
+        return Counter([normalized])
+    return Counter(normalized[i : i + n] for i in range(0, len(normalized) - n + 1))
+
+
+def _jensen_shannon(left: Counter[str], right: Counter[str]) -> float:
+    if not left and not right:
+        return 0.0
+    if not left or not right:
+        return 1.0
+    left_total = sum(left.values())
+    right_total = sum(right.values())
+    keys = set(left) | set(right)
+    divergence = 0.0
+    for key in keys:
+        p = left[key] / left_total
+        q = right[key] / right_total
+        m = 0.5 * (p + q)
+        if p:
+            divergence += 0.5 * p * math.log2(p / m)
+        if q:
+            divergence += 0.5 * q * math.log2(q / m)
+    return min(1.0, max(0.0, divergence))
+
+
+def _note_vector(note: Any) -> list[float]:
+    embedding = getattr(note, "embedding", None)
+    vector = getattr(embedding, "vector", None)
+    return vector if isinstance(vector, list) else []
+
+
+def _note_text(note: Any) -> str:
+    content = getattr(note, "content", None)
+    raw = getattr(content, "raw", "")
+    return raw if isinstance(raw, str) else str(raw)
+
+
+def _valid_vector(vector: list[float] | None) -> bool:
+    if not isinstance(vector, list) or not vector:
+        return False
+    try:
+        return any(float(v) != 0.0 for v in vector)
+    except (TypeError, ValueError):
+        return False
+
+
+def _content_hash(content: str) -> str:
+    return hashlib.sha256(content.encode("utf-8")).hexdigest()[:16]

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -29,6 +29,7 @@ from zettelforge.extensions import has_extension
 from zettelforge.fact_extractor import FactExtractor
 from zettelforge.governance_validator import GovernanceValidator, GovernanceViolationError
 from zettelforge.log import get_logger
+from zettelforge.memory_defense import MemoryAnomalyError, MemoryAnomalyGate
 from zettelforge.memory_store import MemoryStore, get_default_data_dir
 from zettelforge.memory_updater import MemoryUpdater
 from zettelforge.note_constructor import NoteConstructor
@@ -120,6 +121,7 @@ class MemoryManager:
         )
         self.resolver = AliasResolver()
         self.consolidation = ConsolidationMiddleware(self)
+        self.memory_defense = MemoryAnomalyGate()
 
         self._logger = get_logger("zettelforge.memory")
         self.stats = {
@@ -288,6 +290,52 @@ class MemoryManager:
             raw_content=content, source_type=source_type, source_ref=source_ref, domain=domain
         )
         phase_timings_ms["construct"] = (time.perf_counter() - _p) * 1000
+
+        _p = time.perf_counter()
+        try:
+            reference_notes = self.store.get_notes_by_domain(domain)
+            self.memory_defense.enforce(
+                note,
+                reference_notes,
+                domain=domain,
+                source_type=source_type,
+                source_ref=source_ref,
+                request_id=request_id,
+            )
+        except MemoryAnomalyError as exc:
+            phase_timings_ms["memory_defense"] = (time.perf_counter() - _p) * 1000
+            decision = exc.decision
+            log_authorization(
+                actor="system",
+                resource="remember",
+                status_id=STATUS_FAILURE,
+                severity_id=SEVERITY_HIGH,
+                policy="SEC-011",
+                request_id=request_id,
+                violation="memory_anomaly",
+                action=decision.action,
+                score=decision.score,
+                threshold=decision.threshold,
+                content_hash=decision.content_hash,
+            )
+            log_api_activity(
+                operation="remember",
+                status_id=STATUS_FAILURE,
+                severity_id=SEVERITY_HIGH,
+                note_id=note.id,
+                domain=domain,
+                duration_ms=(time.perf_counter() - start) * 1000,
+                request_id=request_id,
+                memory_defense_action=decision.action,
+                memory_defense_score=decision.score,
+                memory_defense_threshold=decision.threshold,
+                memory_defense_content_hash=decision.content_hash,
+                phase_timings_ms=phase_timings_ms,
+            )
+            raise
+        except Exception:
+            self._logger.warning("memory_defense_eval_failed", request_id=request_id, exc_info=True)
+        phase_timings_ms["memory_defense"] = (time.perf_counter() - _p) * 1000
 
         _p = time.perf_counter()
         self.store.write_note(note)
@@ -550,6 +598,7 @@ class MemoryManager:
         include_links: bool = True,
         exclude_superseded: bool = True,
         include_expired: bool = False,
+        caller: str | None = None,
         actor: str | None = None,
     ) -> list[MemoryNote]:
         """
@@ -565,6 +614,7 @@ class MemoryManager:
         defense-in-depth control for D-03 (deep graph traversal DoS) per
         RFC-014.
         """
+        telemetry_caller = caller if caller is not None else actor
         timeout = get_config().governance.limits.recall_timeout_seconds
         if timeout > 0:
             with concurrent.futures.ThreadPoolExecutor(max_workers=1) as pool:
@@ -576,7 +626,7 @@ class MemoryManager:
                     include_links,
                     exclude_superseded,
                     include_expired,
-                    actor,
+                    telemetry_caller,
                 )
                 try:
                     return future.result(timeout=timeout)
@@ -604,7 +654,7 @@ class MemoryManager:
             include_links,
             exclude_superseded,
             include_expired,
-            actor,
+            telemetry_caller,
         )
 
     def _recall_inner(
@@ -615,14 +665,16 @@ class MemoryManager:
         include_links: bool = True,
         exclude_superseded: bool = True,
         include_expired: bool = False,
+        caller: str | None = None,
         actor: str | None = None,
     ) -> list[MemoryNote]:
+        caller = caller if caller is not None else actor
         request_id = uuid.uuid4().hex
         start = time.perf_counter()
         self.stats["retrievals"] += 1
 
         # ── RFC-007 US-002: telemetry ─────────────────────────────────
-        query_id = self._telemetry.start_query(query, actor=actor)
+        query_id = self._telemetry.start_query(query, caller=caller)
         self._telemetry_query_id = query_id
 
         # Classify query intent
@@ -815,7 +867,7 @@ class MemoryManager:
             duration_ms=duration_ms,
             request_id=request_id,
             telemetry_query_id=query_id,
-            telemetry_actor=actor,
+            telemetry_caller=caller,
         )
         return results
 
@@ -1449,6 +1501,7 @@ class MemoryManager:
         format: str = "direct_answer",
         k: int = 10,
         tier_filter: list[str] | None = None,
+        caller: str | None = None,
         actor: str | None = None,
     ) -> dict[str, Any]:
         """
@@ -1466,6 +1519,7 @@ class MemoryManager:
         Returns:
             Dictionary with synthesis result, metadata, and sources
         """
+        telemetry_caller = caller if caller is not None else actor
         _extended_formats = {"synthesized_brief", "timeline_analysis", "relationship_map"}
         if format in _extended_formats and not has_extension("enterprise"):
             self._logger.info("synthesis_format_fallback", requested=format, using="direct_answer")
@@ -1475,9 +1529,11 @@ class MemoryManager:
         start = time.perf_counter()
 
         # Reuse query_id from the last recall() so synthesis telemetry
-        # correlates to the same query.  If the caller passed actor directly
-        # without a preceding recall() call, start a fresh query.
-        query_id = self._telemetry_query_id or self._telemetry.start_query(query, actor=actor)
+        # correlates to the same query. If the caller supplied attribution
+        # directly without a preceding recall() call, start a fresh query.
+        query_id = self._telemetry_query_id or self._telemetry.start_query(
+            query, caller=telemetry_caller
+        )
         if query_id and self._telemetry_query_id is None:
             # Fresh query started here — keep the id for consistency
             self._telemetry_query_id = query_id
@@ -1511,7 +1567,7 @@ class MemoryManager:
             duration_ms=duration_ms,
             request_id=request_id,
             telemetry_query_id=query_id,
-            telemetry_actor=actor,
+            telemetry_caller=telemetry_caller,
         )
         return result
 

--- a/src/zettelforge/scripts/human_eval_sampler.py
+++ b/src/zettelforge/scripts/human_eval_sampler.py
@@ -44,12 +44,12 @@ def _format_briefing(event: dict[str, Any], index: int) -> str:
     sources_count = event.get("result_count", 0)
     duration_ms = event.get("duration_ms", 0)
     cited = event.get("cited_notes", [])
-    actor = event.get("actor", "unknown")
+    caller = event.get("caller") or event.get("actor", "unknown")
     ts = event.get("ts", event.get("timestamp", "unknown"))
 
     lines = [f"### Briefing #{index}\n"]
     lines.append(f"- **Query:** `{query}`")
-    lines.append(f"- **Agent:** {actor}")
+    lines.append(f"- **Agent:** {caller}")
     lines.append(f"- **Sources:** {sources_count}")
     lines.append(f"- **Cited Notes:** {len(cited)}")
     lines.append(f"- **Confidence:** {confidence}")

--- a/src/zettelforge/scripts/telemetry_dashboard.py
+++ b/src/zettelforge/scripts/telemetry_dashboard.py
@@ -80,7 +80,7 @@ def to_dataframe(events: list[dict[str, Any]]) -> pd.DataFrame:
                 "date": date_str,
                 "duration_ms": ev.get("duration_ms"),
                 "confidence": ev.get("confidence"),
-                "actor": ev.get("actor"),
+                "caller": ev.get("caller") or ev.get("actor"),
                 "query_id": ev.get("query_id"),
                 "result_count": ev.get("result_count"),
                 "utility": ev.get("utility"),

--- a/src/zettelforge/telemetry.py
+++ b/src/zettelforge/telemetry.py
@@ -27,6 +27,8 @@ from datetime import datetime
 from pathlib import Path
 from typing import Any
 
+from zettelforge.config import get_config
+
 _QUERY_TTL_SECONDS = 3600  # evict tracked queries older than this on start_query
 
 
@@ -35,9 +37,14 @@ class _QueryContext:
     """In-memory bookkeeping for an active query. Not persisted."""
 
     query: str
-    actor: str | None
+    caller: str | None
     start_ts: float
     results: list[Any] = field(default_factory=list)
+
+    @property
+    def actor(self) -> str | None:
+        """Backward-compatible alias for the pre-caller telemetry field."""
+        return self.caller
 
 
 class TelemetryCollector:
@@ -45,7 +52,7 @@ class TelemetryCollector:
 
     Typical flow from ``MemoryManager``::
 
-        qid = telemetry.start_query(query, actor="vigil")
+        qid = telemetry.start_query(query, caller="vigil")
         results = run_retrieval(...)
         telemetry.log_recall(qid, results, intent="factual", ...)
         result = run_synthesis(...)
@@ -66,15 +73,22 @@ class TelemetryCollector:
 
     # ── Query lifecycle ────────────────────────────────────────────────
 
-    def start_query(self, query: str, actor: str | None = None) -> str:
+    def start_query(
+        self,
+        query: str,
+        caller: str | None = None,
+        actor: str | None = None,
+    ) -> str:
         """Begin tracking a query. Returns ``query_id`` (UUID4 hex) for correlation.
 
         Evicts tracked queries older than 1 hour on each call so memory use
         stays bounded even if callers never call ``log_synthesis``.
         """
+        if caller is None:
+            caller = actor
         query_id = uuid.uuid4().hex
         now = time.time()
-        ctx = _QueryContext(query=query, actor=actor, start_ts=now)
+        ctx = _QueryContext(query=query, caller=caller, start_ts=now)
         with self._queries_lock:
             self._queries[query_id] = ctx
             # Evict stale contexts
@@ -109,13 +123,14 @@ class TelemetryCollector:
         ctx = self._get_context(query_id)
         duration_ms = self._duration_ms(ctx)
         query_text = self._truncate_query(ctx.query if ctx else "", debug)
-        actor = ctx.actor if ctx else None
+        caller = ctx.caller if ctx else None
 
         event: dict[str, Any] = {
             "event_type": "recall",
             "timestamp": time.time(),
             "query_id": query_id,
-            "actor": actor,
+            "actor": caller,
+            "caller": caller,
             "query": query_text,
             "result_count": len(results),
             "duration_ms": duration_ms,
@@ -153,7 +168,7 @@ class TelemetryCollector:
         ctx = self._get_context(query_id)
         duration_ms = self._duration_ms(ctx)
         query_text = self._truncate_query(ctx.query if ctx else "", debug)
-        actor = ctx.actor if ctx else None
+        caller = ctx.caller if ctx else None
 
         cited_notes = _cited_note_ids(result)
         sources_count = _sources_count(result)
@@ -162,7 +177,8 @@ class TelemetryCollector:
             "event_type": "synthesis",
             "timestamp": time.time(),
             "query_id": query_id,
-            "actor": actor,
+            "actor": caller,
+            "caller": caller,
             "query": query_text,
             "result_count": sources_count,
             "duration_ms": duration_ms,
@@ -183,16 +199,20 @@ class TelemetryCollector:
         query_id: str,
         note_id: str,
         utility: int,
+        caller: str | None = None,
         agent: str | None = None,
     ) -> None:
         """Write an explicit feedback event. Utility is 1–5."""
+        if caller is None:
+            caller = agent
         event = {
             "event_type": "feedback",
             "timestamp": time.time(),
             "query_id": query_id,
             "note_id": note_id,
             "utility": int(utility),
-            "agent": agent,
+            "agent": caller,
+            "caller": caller,
         }
         self._append(event)
 
@@ -212,18 +232,28 @@ class TelemetryCollector:
             return
         cited = set(_cited_note_ids(synthesis_result))
         ctx = self._get_context(query_id)
-        agent = ctx.actor if ctx else None
+        caller = ctx.caller if ctx else None
         for note in retrieved_notes:
             nid = _note_id(note)
             if nid is None:
                 continue
             utility = 4 if nid in cited else 2
-            self.log_feedback(query_id, nid, utility, agent=agent)
+            self.log_feedback(query_id, nid, utility, caller=caller)
 
     # ── Internals ──────────────────────────────────────────────────────
 
     def _debug_enabled(self) -> bool:
-        return logging.getLogger(self._logger_name).isEnabledFor(logging.DEBUG)
+        logger = logging.getLogger(self._logger_name)
+        while logger and (
+            logger.name == "zettelforge.telemetry"
+            or logger.name.startswith("zettelforge.telemetry.")
+        ):
+            if logger.level != logging.NOTSET:
+                return logger.level <= logging.DEBUG
+            if logger.name == "zettelforge.telemetry":
+                break
+            logger = logger.parent
+        return False
 
     def _duration_ms(self, ctx: _QueryContext | None) -> int:
         if ctx is None:
@@ -324,12 +354,18 @@ _telemetry_singleton_lock = threading.Lock()
 
 
 def get_telemetry() -> TelemetryCollector:
-    """Return the process-wide TelemetryCollector instance (lazy singleton)."""
+    """Return the process-wide TelemetryCollector instance (lazy singleton).
+
+    data_dir is sourced from ZETTELFORGE_TELEMETRY_DIR env > config.yaml >
+    ~/.amem/telemetry default.
+    """
     global _telemetry_instance
     if _telemetry_instance is None:
         with _telemetry_singleton_lock:
             if _telemetry_instance is None:
-                _telemetry_instance = TelemetryCollector()
+                cfg = get_config()
+                data_dir = cfg.telemetry.data_dir
+                _telemetry_instance = TelemetryCollector(data_dir=data_dir)
     return _telemetry_instance
 
 

--- a/tests/test_llm_client.py
+++ b/tests/test_llm_client.py
@@ -7,9 +7,13 @@ import pytest
 
 from zettelforge.llm_client import _get_local_llm, generate
 
+_RUN_LLM_INTEGRATION = os.environ.get("ZETTELFORGE_RUN_LLM_INTEGRATION") == "1"
 _SKIP_INTEGRATION = pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="LLM integration tests require local model or Ollama",
+    not _RUN_LLM_INTEGRATION,
+    reason=(
+        "LLM integration tests require an explicitly configured local model "
+        "or Ollama; set ZETTELFORGE_RUN_LLM_INTEGRATION=1 to run them"
+    ),
 )
 
 

--- a/tests/test_llm_providers.py
+++ b/tests/test_llm_providers.py
@@ -143,7 +143,7 @@ class TestOllamaProvider:
             )
 
             assert result == "ok"
-            mock_client_cls.assert_called_once_with(host="http://host:11434", timeout=60.0)
+            mock_client_cls.assert_called_once_with(host="http://host:11434", timeout=180.0)
             args, kwargs = mock_client.generate.call_args
             assert kwargs["model"] == "qwen2.5:3b"
             assert kwargs["prompt"] == "hello"
@@ -174,7 +174,7 @@ class TestOllamaProvider:
         with patch("ollama.Client") as mock_client_cls:
             mock_client_cls.return_value.generate.return_value = {"response": "ok"}
             provider.generate("hello")
-            mock_client_cls.assert_called_once_with(host="http://gpu-box:11434", timeout=60.0)
+            mock_client_cls.assert_called_once_with(host="http://gpu-box:11434", timeout=180.0)
 
     def test_timeout_threads_through_to_client(self):
         """[RFC-010] Configured timeout must reach ``ollama.Client``.
@@ -344,6 +344,7 @@ class TestOnnxGenAIBackend:
 
         # Patch the onnxruntime_genai module at import time in _load()
         import types
+
         fake_module = types.ModuleType("onnxruntime_genai")
         fake_module.Model = _FakeOnnxGenAI.Model
         fake_module.Tokenizer = _FakeOnnxGenAI.Tokenizer
@@ -358,6 +359,7 @@ class TestOnnxGenAIBackend:
         backend = OnnxGenAIBackend(model="test/model", filename="test.onnx")
 
         import types
+
         fake_module = types.ModuleType("onnxruntime_genai")
         fake_module.Model = _FakeOnnxGenAI.Model
         fake_module.Tokenizer = _FakeOnnxGenAI.Tokenizer
@@ -365,9 +367,7 @@ class TestOnnxGenAIBackend:
         fake_module.Generator = _FakeOnnxGenAI.Generator
         monkeypatch.setitem(__import__("sys").modules, "onnxruntime_genai", fake_module)
 
-        result = backend.generate(
-            "hello", max_tokens=100, system="You are a helpful assistant."
-        )
+        result = backend.generate("hello", max_tokens=100, system="You are a helpful assistant.")
         assert result == "decoded output"
 
     def test_import_error_raised_when_sdk_missing(self):
@@ -445,13 +445,30 @@ class TestLiteLLMProvider:
         from zettelforge.llm_providers.litellm_provider import LiteLLMProvider
 
         provider = LiteLLMProvider(model="gpt-4o")
-        with pytest.raises(ImportError, match="litellm"):
-            provider.generate("hello")
+        with patch(
+            "zettelforge.llm_providers.litellm_provider._import_litellm",
+            side_effect=ImportError("litellm is missing"),
+        ):
+            with pytest.raises(ImportError, match="litellm"):
+                provider.generate("hello")
+
+    def test_generate_uses_installed_litellm_when_available(self, monkeypatch):
+        from zettelforge.llm_providers.litellm_provider import LiteLLMProvider
+
+        import types
+
+        mock_module = types.ModuleType("litellm")
+        mock_module.completion = _FakeLiteLLM.completion
+        monkeypatch.setitem(__import__("sys").modules, "litellm", mock_module)
+
+        provider = LiteLLMProvider(model="gpt-4o")
+        assert provider.generate("hello") == "lorem ipsum"
 
     def test_generate_with_mock_completion(self, monkeypatch):
         from zettelforge.llm_providers.litellm_provider import LiteLLMProvider
 
         import types
+
         mock_module = types.ModuleType("litellm")
         mock_module.completion = _FakeLiteLLM.completion
         monkeypatch.setitem(__import__("sys").modules, "litellm", mock_module)
@@ -771,9 +788,9 @@ class TestLLMConfigRepr:
     def test_api_key_is_redacted(self):
         from zettelforge.config import LLMConfig
 
-        cfg = LLMConfig(api_key="***")
+        cfg = LLMConfig(api_key="sk-secret")
         text = repr(cfg)
-        assert "***" not in text
+        assert "sk-secret" not in text
         assert "***" in text
 
     def test_empty_api_key_shows_empty_string(self):

--- a/tests/test_memory_defense.py
+++ b/tests/test_memory_defense.py
@@ -1,0 +1,90 @@
+"""Tests for SEC-011 write-time memory anomaly defenses."""
+
+from __future__ import annotations
+
+import json
+from types import SimpleNamespace
+
+import pytest
+
+from zettelforge.config import MemoryDefenseConfig
+from zettelforge.memory_defense import MemoryAnomalyError, MemoryAnomalyGate
+
+
+def _note(note_id: str, vector: list[float], raw: str = "benign cti note"):
+    return SimpleNamespace(
+        id=note_id,
+        created_at=f"2026-05-25T00:00:{note_id[-1]}Z",
+        content=SimpleNamespace(raw=raw),
+        embedding=SimpleNamespace(vector=vector),
+    )
+
+
+def test_insufficient_calibration_allows_write():
+    cfg = MemoryDefenseConfig(enabled=True, min_calibration_notes=3)
+    gate = MemoryAnomalyGate(config=cfg)
+    candidate = _note("candidate", [1.0, 0.0])
+    refs = [_note("ref1", [1.0, 0.0]), _note("ref2", [0.0, 1.0])]
+
+    decision = gate.evaluate(candidate, refs, domain="cti", request_id="req")
+
+    assert decision.reason == "calibration_insufficient"
+    assert decision.reference_count == 2
+    assert decision.flagged is False
+    assert decision.should_stop_write is False
+
+
+def test_high_similarity_candidate_flags_in_audit_mode():
+    cfg = MemoryDefenseConfig(
+        enabled=True,
+        mode="audit",
+        min_calibration_notes=4,
+        max_reference_notes=4,
+        lexical_weight=0.0,
+    )
+    gate = MemoryAnomalyGate(config=cfg)
+    refs = [
+        _note("ref1", [1.0, 0.0, 0.0], "alpha benign"),
+        _note("ref2", [0.0, 1.0, 0.0], "bravo benign"),
+        _note("ref3", [0.0, 0.0, 1.0], "charlie benign"),
+        _note("ref4", [-1.0, 0.0, 0.0], "delta benign"),
+    ]
+    candidate = _note("candidate", [1.0, 0.0, 0.0], "triggered write payload")
+
+    decision = gate.evaluate(candidate, refs, domain="cti", request_id="req")
+
+    assert decision.flagged is True
+    assert decision.action == "audit"
+    assert decision.score is not None
+    assert decision.threshold is not None
+    assert decision.score > decision.threshold
+    assert decision.should_stop_write is False
+
+
+def test_quarantine_mode_writes_forensic_record_and_blocks(tmp_path):
+    quarantine_path = tmp_path / "quarantine.jsonl"
+    cfg = MemoryDefenseConfig(
+        enabled=True,
+        mode="quarantine",
+        min_calibration_notes=4,
+        max_reference_notes=4,
+        lexical_weight=0.0,
+        quarantine_path=str(quarantine_path),
+    )
+    gate = MemoryAnomalyGate(config=cfg)
+    refs = [
+        _note("ref1", [1.0, 0.0, 0.0], "alpha benign"),
+        _note("ref2", [0.0, 1.0, 0.0], "bravo benign"),
+        _note("ref3", [0.0, 0.0, 1.0], "charlie benign"),
+        _note("ref4", [-1.0, 0.0, 0.0], "delta benign"),
+    ]
+    candidate = _note("candidate", [1.0, 0.0, 0.0], "poison payload")
+
+    with pytest.raises(MemoryAnomalyError) as exc_info:
+        gate.enforce(candidate, refs, domain="cti", source_type="test", request_id="req")
+
+    assert exc_info.value.decision.action == "quarantine"
+    records = [json.loads(line) for line in quarantine_path.read_text().splitlines()]
+    assert len(records) == 1
+    assert records[0]["raw_content"] == "poison payload"
+    assert records[0]["decision"]["flagged"] is True

--- a/tests/test_performance.py
+++ b/tests/test_performance.py
@@ -13,10 +13,14 @@ import statistics
 from zettelforge import MemoryManager
 from zettelforge.note_schema import MemoryNote, Content, Semantic, Embedding, Metadata
 
-# Performance tests are sensitive to runner hardware; skip in CI.
+# Performance tests are sensitive to runner hardware and persistent local
+# configuration. Keep them opt-in so the default regression suite is bounded.
 pytestmark = pytest.mark.skipif(
-    os.environ.get("CI") == "true",
-    reason="Performance tests require dedicated hardware, not CI runners",
+    os.environ.get("ZETTELFORGE_RUN_PERFORMANCE_TESTS") != "1",
+    reason=(
+        "Performance tests require dedicated hardware; set "
+        "ZETTELFORGE_RUN_PERFORMANCE_TESTS=1 to run them"
+    ),
 )
 
 


### PR DESCRIPTION
## Summary
- Release ZettelForge 2.7.0
- Add write-time MemSAD memory defenses with audit/block/quarantine modes
- Document governance.memory_defense configuration and RFC-017 threat model
- Preserve OSINT-enabled baseline and CrewAI integration behavior while adding telemetry actor/caller compatibility

## Validation
- `ruff check src/zettelforge/`
- `ruff format --check src/zettelforge/ tests/test_memory_defense.py tests/test_llm_client.py tests/test_llm_providers.py tests/test_performance.py`
- `pytest -q tests/test_memory_defense.py tests/test_telemetry_collector.py tests/test_telemetry_integration.py tests/test_llm_client.py tests/test_llm_providers.py tests/test_performance.py --tb=short --disable-warnings` -> 99 passed, 9 skipped
- `pytest -q --tb=short --disable-warnings` -> 742 passed, 13 skipped
- `python3 -m build --outdir <tmp>` and `python3 -m twine check <tmp>/*`