### PR TITLE
Fix P0 issue backlog: LLM budgets, bulk ingest, CCCS hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,21 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
+### Added
+
+- Configurable LLM generation budgets for causal extraction, synthesis,
+  fact extraction, NER, and memory evolution, plus `reasoning_model` scaling
+  floors and `<think>` / `<thinking>` JSON parse stripping.
+- Bulk Sigma/YARA ingest can defer enrichment and drain once via
+  `MemoryManager.flush()`.
+
+### Fixed
+
+- Hardened CCCS YARA metadata validation against multiline regex injection
+  and overly permissive author values.
+- `MemoryManager.flush()` now waits for in-flight enrichment work, not only
+  queued work; cached `Plyara` parsing is serialized for concurrent callers.
+
 ## [2.7.0] - 2026-05-26
 
 Security and OSINT release. Adds the RFC-016 OSINT layer and the first

--- a/config.default.yaml
+++ b/config.default.yaml
@@ -218,6 +218,13 @@ llm:
   max_retries: 2
   fallback: ""
   local_backend: llama-cpp-python  # used when provider=local (RFC-011)
+  max_tokens: 400
+  max_tokens_causal: 8000
+  max_tokens_synthesis: 2500
+  max_tokens_extraction: 2500
+  max_tokens_ner: 2500
+  max_tokens_evolve: 2500
+  reasoning_model: false
   extra: {}
 
 

--- a/docs/reference/configuration.md
+++ b/docs/reference/configuration.md
@@ -129,6 +129,13 @@ class LLMConfig:
     max_retries: int = 2
     fallback: str = ""             # "" preserves implicit local->ollama fallback
     local_backend: str = "llama-cpp-python"  # RFC-011
+    max_tokens: int = 400
+    max_tokens_causal: int = 8000
+    max_tokens_synthesis: int = 2500
+    max_tokens_extraction: int = 2500
+    max_tokens_ner: int = 2500
+    max_tokens_evolve: int = 2500
+    reasoning_model: bool = False
     extra: dict = field(default_factory=dict)
 ```
 
@@ -143,6 +150,13 @@ class LLMConfig:
 | `llm.max_retries` | `int` | `2` | `ZETTELFORGE_LLM_MAX_RETRIES` | Number of retries on transient failure. Applied by `litellm` (via `num_retries` kwarg). |
 | `llm.fallback` | `str` | `""` | `ZETTELFORGE_LLM_FALLBACK` | Backup provider invoked when the primary fails with a non-configuration error. Empty string preserves the implicit `local -> ollama` fallback for backward compatibility; set explicitly to any other registered provider to route elsewhere. |
 | `llm.local_backend` | `str` | `llama-cpp-python` | `ZETTELFORGE_LLM_LOCAL_BACKEND` | In-process inference engine when `provider: local`. Options: `llama-cpp-python` (GGUF, default, requires `zettelforge[local]`), `onnxruntime-genai` (ONNX, requires `zettelforge[local-onnx]`). Ignored for all other providers. |
+| `llm.max_tokens` | `int` | `400` | `ZETTELFORGE_LLM_MAX_TOKENS` | Default generation budget when a caller does not pass an explicit `max_tokens`. |
+| `llm.max_tokens_causal` | `int` | `8000` | `ZETTELFORGE_LLM_MAX_TOKENS_CAUSAL` | Budget for causal triple extraction. |
+| `llm.max_tokens_synthesis` | `int` | `2500` | `ZETTELFORGE_LLM_MAX_TOKENS_SYNTHESIS` | Budget for RAG synthesis JSON output. |
+| `llm.max_tokens_extraction` | `int` | `2500` | `ZETTELFORGE_LLM_MAX_TOKENS_EXTRACTION` | Budget for two-phase fact extraction. |
+| `llm.max_tokens_ner` | `int` | `2500` | `ZETTELFORGE_LLM_MAX_TOKENS_NER` | Budget for conversational LLM NER and its retry path. |
+| `llm.max_tokens_evolve` | `int` | `2500` | `ZETTELFORGE_LLM_MAX_TOKENS_EVOLVE` | Budget for memory evolution decisions and retry path. |
+| `llm.reasoning_model` | `bool` | `false` | `ZETTELFORGE_LLM_REASONING_MODEL` | Raises timeout and per-call-site budgets to the known-good reasoning-model floors without lowering already larger operator overrides. |
 | `llm.extra` | `dict` | `{}` | -- | Provider-specific kwargs forwarded to the constructor. String values inside `extra` also honour `${ENV_VAR}` resolution. Common uses: `{filename: qwen2.5-3b-instruct-q4_k_m.gguf, n_ctx: 4096}` for `local` provider; `{provider: rocm}` for `onnxruntime-genai` execution provider selection; `{drop_params: true}` for `litellm`. |
 
 #### Provider quick-reference
@@ -495,6 +509,13 @@ See [Configure OpenCTI Integration](../how-to/configure-opencti.md) for setup st
 | `ZETTELFORGE_LLM_MAX_RETRIES` | `llm.max_retries` | `2` |
 | `ZETTELFORGE_LLM_FALLBACK` | `llm.fallback` | `ollama` |
 | `ZETTELFORGE_LLM_LOCAL_BACKEND` | `llm.local_backend` | `onnxruntime-genai` |
+| `ZETTELFORGE_LLM_MAX_TOKENS` | `llm.max_tokens` | `400` |
+| `ZETTELFORGE_LLM_MAX_TOKENS_CAUSAL` | `llm.max_tokens_causal` | `8000` |
+| `ZETTELFORGE_LLM_MAX_TOKENS_SYNTHESIS` | `llm.max_tokens_synthesis` | `2500` |
+| `ZETTELFORGE_LLM_MAX_TOKENS_EXTRACTION` | `llm.max_tokens_extraction` | `2500` |
+| `ZETTELFORGE_LLM_MAX_TOKENS_NER` | `llm.max_tokens_ner` | `2500` |
+| `ZETTELFORGE_LLM_MAX_TOKENS_EVOLVE` | `llm.max_tokens_evolve` | `2500` |
+| `ZETTELFORGE_LLM_REASONING_MODEL` | `llm.reasoning_model` | `true` |
 
 ### Web UI configuration (RFC-015)
 

--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -55,6 +55,23 @@ def _resolve_env_refs(value: str) -> str:
     return _ENV_VAR_PATTERN.sub(_replace, value)
 
 
+def _env_bool(value: str) -> bool:
+    return value.lower() in ("1", "true", "yes", "on")
+
+
+def _parse_env_int(name: str, value: str) -> int | None:
+    try:
+        return int(value)
+    except ValueError:
+        get_logger("zettelforge.config").warning(
+            "invalid_env_int",
+            name=name,
+            value=value,
+            hint="Must be an int",
+        )
+        return None
+
+
 @dataclass
 class StorageConfig:
     data_dir: str = "~/.amem"
@@ -107,6 +124,13 @@ class LLMConfig:
     max_retries: int = 2
     fallback: str = ""  # empty preserves implicit local→ollama fallback
     local_backend: str = "llama-cpp-python"  # RFC-011: "llama-cpp-python" or "onnxruntime-genai"
+    max_tokens: int = 400
+    max_tokens_causal: int = 8000
+    max_tokens_synthesis: int = 2500
+    max_tokens_extraction: int = 2500
+    max_tokens_ner: int = 2500
+    max_tokens_evolve: int = 2500
+    reasoning_model: bool = False
     extra: dict[str, Any] = field(default_factory=dict)
 
     # Keys under ``extra`` that are commonly used for secrets. Matched
@@ -136,6 +160,13 @@ class LLMConfig:
             f"temperature={self.temperature}, timeout={self.timeout}, "
             f"max_retries={self.max_retries}, fallback={self.fallback!r}, "
             f"local_backend={self.local_backend!r}, "
+            f"max_tokens={self.max_tokens}, "
+            f"max_tokens_causal={self.max_tokens_causal}, "
+            f"max_tokens_synthesis={self.max_tokens_synthesis}, "
+            f"max_tokens_extraction={self.max_tokens_extraction}, "
+            f"max_tokens_ner={self.max_tokens_ner}, "
+            f"max_tokens_evolve={self.max_tokens_evolve}, "
+            f"reasoning_model={self.reasoning_model}, "
             f"extra={self._redact_extra()!r})"
         )
 
@@ -560,6 +591,22 @@ def _apply_env(cfg: ZettelForgeConfig):
     if v := os.environ.get("ZETTELFORGE_LLM_LOCAL_BACKEND"):
         cfg.llm.local_backend = v
 
+    llm_token_env = {
+        "ZETTELFORGE_LLM_MAX_TOKENS": "max_tokens",
+        "ZETTELFORGE_LLM_MAX_TOKENS_CAUSAL": "max_tokens_causal",
+        "ZETTELFORGE_LLM_MAX_TOKENS_SYNTHESIS": "max_tokens_synthesis",
+        "ZETTELFORGE_LLM_MAX_TOKENS_EXTRACTION": "max_tokens_extraction",
+        "ZETTELFORGE_LLM_MAX_TOKENS_NER": "max_tokens_ner",
+        "ZETTELFORGE_LLM_MAX_TOKENS_EVOLVE": "max_tokens_evolve",
+    }
+    for env_name, attr in llm_token_env.items():
+        if v := os.environ.get(env_name):
+            parsed = _parse_env_int(env_name, v)
+            if parsed is not None:
+                setattr(cfg.llm, attr, parsed)
+    if v := os.environ.get("ZETTELFORGE_LLM_REASONING_MODEL"):
+        cfg.llm.reasoning_model = _env_bool(v)
+
     # LLM NER
     if v := os.environ.get("ZETTELFORGE_LLM_NER_ENABLED"):
         cfg.llm_ner.enabled = v.lower() in ("true", "1", "yes")
@@ -610,6 +657,27 @@ def _apply_env(cfg: ZettelForgeConfig):
         cfg.web.ui_dir = v
 
 
+_REASONING_TOKEN_FLOORS = {
+    "max_tokens_causal": 8000,
+    "max_tokens_synthesis": 2500,
+    "max_tokens_extraction": 2500,
+    "max_tokens_ner": 2500,
+    "max_tokens_evolve": 2500,
+}
+
+
+def _apply_reasoning_model_scaling(cfg: ZettelForgeConfig) -> None:
+    """Raise LLM limits to known-good floors when reasoning models are enabled."""
+    if not cfg.llm.reasoning_model:
+        return
+
+    cfg.llm.timeout = max(float(cfg.llm.timeout), 180.0)
+    for attr, floor in _REASONING_TOKEN_FLOORS.items():
+        current = getattr(cfg.llm, attr)
+        if isinstance(current, int):
+            setattr(cfg.llm, attr, max(current, floor))
+
+
 # ── Singleton ──────────────────────────────────────────────
 
 _config: ZettelForgeConfig | None = None
@@ -629,6 +697,7 @@ def get_config() -> ZettelForgeConfig:
 
         # Layer 2: environment variables (override)
         _apply_env(_config)
+        _apply_reasoning_model_scaling(_config)
 
     return _config
 

--- a/src/zettelforge/entity_indexer.py
+++ b/src/zettelforge/entity_indexer.py
@@ -268,15 +268,14 @@ class EntityExtractor:
             return empty
 
         try:
+            from zettelforge.config import get_config
             from zettelforge.llm_client import generate
 
             prompt = f"Extract named entities from this text:\n\n{text[:2000]}\n\nJSON:"
-            # 2500-token budget for reasoning-model headroom (v2.5.2; pre-fix
-            # 300 was exhausted by qwen3.5+ <think> tokens, leaving the NER
-            # JSON empty and entity extraction silently no-opping).
+            max_tokens = get_config().llm.max_tokens_ner
             output = generate(
                 prompt,
-                max_tokens=2500,
+                max_tokens=max_tokens,
                 temperature=0.0,
                 system=self.NER_SYSTEM_PROMPT,
             )
@@ -285,7 +284,12 @@ class EntityExtractor:
             if parsed is None and output and output.strip():
                 _logger.info("retry_parse", site="entity_indexer_ner", attempt=2)
                 retry_prompt = prompt + "\n\nRespond with valid JSON only."
-                output = generate(retry_prompt, max_tokens=2500, temperature=0.3, json_mode=True)
+                output = generate(
+                    retry_prompt,
+                    max_tokens=max_tokens,
+                    temperature=0.3,
+                    json_mode=True,
+                )
                 parsed = extract_json(output, expect="object")
             return self._parse_ner_output_from_parsed(parsed, output, conversational_types)
 

--- a/src/zettelforge/fact_extractor.py
+++ b/src/zettelforge/fact_extractor.py
@@ -40,11 +40,14 @@ class FactExtractor:
         prompt = self._build_prompt(content, context)
 
         try:
+            from zettelforge.config import get_config
             from zettelforge.llm_client import generate
 
-            # 2500-token budget for reasoning-model headroom (see v2.5.2
-            # CHANGELOG; pre-fix 400 was exhausted by qwen3.5+ <think> tokens).
-            raw_output = generate(prompt, max_tokens=2500, temperature=0.1)
+            raw_output = generate(
+                prompt,
+                max_tokens=get_config().llm.max_tokens_extraction,
+                temperature=0.1,
+            )
             return self._parse_extraction_response(raw_output)
         except Exception:
             _logger.warning("llm_fact_extraction_failed", exc_info=True)

--- a/src/zettelforge/json_parse.py
+++ b/src/zettelforge/json_parse.py
@@ -12,6 +12,12 @@ import re
 _logger = logging.getLogger("zettelforge.json_parse")
 
 _parse_stats = {"success": 0, "failure": 0}
+_THINKING_TAG_RE = re.compile(r"<think(?:ing)?>.*?</think(?:ing)?>", re.DOTALL | re.IGNORECASE)
+
+
+def strip_thinking_tags(raw: str) -> str:
+    """Remove reasoning-model thinking blocks before JSON extraction."""
+    return _THINKING_TAG_RE.sub("", raw)
 
 
 def extract_json(raw: str | None, expect: str = "object") -> dict | list | None:
@@ -28,7 +34,7 @@ def extract_json(raw: str | None, expect: str = "object") -> dict | list | None:
         _parse_stats["failure"] += 1
         return None
 
-    text = _strip_code_fences(raw)
+    text = _strip_code_fences(strip_thinking_tags(raw))
 
     # Try to find JSON in the text
     if expect == "array":

--- a/src/zettelforge/llm_client.py
+++ b/src/zettelforge/llm_client.py
@@ -176,12 +176,21 @@ def _fallback_provider(primary: str) -> str | None:
     return None
 
 
+def _default_max_tokens() -> int:
+    try:
+        from zettelforge.config import get_config
+
+        return int(get_config().llm.max_tokens)
+    except Exception:
+        return 400
+
+
 # ── Public API ───────────────────────────────────────────────────────────────
 
 
 def generate(
     prompt: str,
-    max_tokens: int = 400,
+    max_tokens: int | None = None,
     temperature: float = 0.1,
     system: str | None = None,
     json_mode: bool = False,
@@ -200,6 +209,7 @@ def generate(
         fail recoverably. Configuration errors are propagated.
     """
     primary = get_llm_provider()
+    effective_max_tokens = _default_max_tokens() if max_tokens is None else max_tokens
 
     try:
         provider = registry.get(primary, **_provider_kwargs(primary))
@@ -214,7 +224,7 @@ def generate(
     try:
         return provider.generate(
             prompt,
-            max_tokens=max_tokens,
+            max_tokens=effective_max_tokens,
             temperature=temperature,
             system=system,
             json_mode=json_mode,
@@ -235,7 +245,7 @@ def generate(
         fallback = registry.get(fallback_name, **_provider_kwargs(fallback_name))
         return fallback.generate(
             prompt,
-            max_tokens=max_tokens,
+            max_tokens=effective_max_tokens,
             temperature=temperature,
             system=system,
             json_mode=json_mode,

--- a/src/zettelforge/memory_evolver.py
+++ b/src/zettelforge/memory_evolver.py
@@ -10,6 +10,7 @@ Based on: A-Mem (arXiv:2502.12110, NeurIPS 2025)
 
 from typing import Any
 
+from zettelforge.config import get_config
 from zettelforge.json_parse import extract_json
 from zettelforge.llm_client import generate
 from zettelforge.log import get_logger
@@ -91,9 +92,10 @@ class MemoryEvolver:
             neighbor_content=neighbor.content.raw[:1000],
             new_content=new_note.content.raw[:1000],
         )
+        max_tokens = get_config().llm.max_tokens_evolve
 
         # First attempt
-        output = generate(prompt, max_tokens=2500, temperature=0.2, json_mode=True)
+        output = generate(prompt, max_tokens=max_tokens, temperature=0.2, json_mode=True)
         result = extract_json(output, expect="object")
 
         # Single retry on parse failure (AD-2). Capture what the model
@@ -108,7 +110,7 @@ class MemoryEvolver:
                 raw_chars=len(output or ""),
                 prompt_preview=prompt[:240],
             )
-            output = generate(prompt, max_tokens=2500, temperature=0.1, json_mode=True)
+            output = generate(prompt, max_tokens=max_tokens, temperature=0.1, json_mode=True)
             result = extract_json(output, expect="object")
 
         if result is None:

--- a/src/zettelforge/memory_manager.py
+++ b/src/zettelforge/memory_manager.py
@@ -1073,11 +1073,11 @@ class MemoryManager:
     def _enrichment_loop(self) -> None:
         """Background worker: process enrichment jobs until process exits."""
         while True:
+            job = None
             try:
                 job = self._enrichment_queue.get(timeout=1.0)
                 if job.defer:
                     # Batch-deferred job — skip for now, will be swept later
-                    self._enrichment_queue.task_done()
                     continue
                 if job.job_type == "neighbor_evolution":
                     self._run_evolution(job)
@@ -1085,7 +1085,6 @@ class MemoryManager:
                     self._run_llm_ner(job)
                 else:
                     self._run_enrichment(job)
-                self._enrichment_queue.task_done()
             except queue.Empty:
                 continue
             except BackendClosedError:
@@ -1093,6 +1092,27 @@ class MemoryManager:
                 return
             except Exception:
                 self._logger.error("enrichment_worker_error", exc_info=True)
+            finally:
+                if job is not None:
+                    self._enrichment_queue.task_done()
+
+    def flush(self, timeout: float | None = None) -> bool:
+        """Wait until queued and in-flight enrichment jobs complete.
+
+        Returns ``True`` when all jobs are done. If ``timeout`` is provided
+        and expires first, returns ``False``.
+        """
+        deadline = None if timeout is None else time.monotonic() + timeout
+        with self._enrichment_queue.all_tasks_done:
+            while self._enrichment_queue.unfinished_tasks:
+                if deadline is None:
+                    self._enrichment_queue.all_tasks_done.wait()
+                    continue
+                remaining = deadline - time.monotonic()
+                if remaining <= 0:
+                    return False
+                self._enrichment_queue.all_tasks_done.wait(remaining)
+        return True
 
     def _run_enrichment(self, job: _EnrichmentJob) -> None:
         """Execute slow-path LLM causal triple extraction for one note."""
@@ -1212,10 +1232,10 @@ class MemoryManager:
         """atexit: process remaining enrichment jobs within a 10-second window."""
         deadline = time.monotonic() + 10.0
         while not self._enrichment_queue.empty() and time.monotonic() < deadline:
+            job = None
             try:
                 job = self._enrichment_queue.get_nowait()
                 if job.defer:
-                    self._enrichment_queue.task_done()
                     continue
                 if job.job_type == "neighbor_evolution":
                     self._run_evolution(job)
@@ -1223,7 +1243,6 @@ class MemoryManager:
                     self._run_llm_ner(job)
                 else:
                     self._run_enrichment(job)
-                self._enrichment_queue.task_done()
             except queue.Empty:
                 break
             except BackendClosedError:
@@ -1231,6 +1250,9 @@ class MemoryManager:
                 return
             except Exception:
                 self._logger.warning("enrichment_drain_failed", exc_info=True)
+            finally:
+                if job is not None:
+                    self._enrichment_queue.task_done()
 
     def evolve_note(self, note_id: str, sync: bool = False) -> dict | None:
         """Trigger neighbor evolution for an existing note.

--- a/src/zettelforge/note_constructor.py
+++ b/src/zettelforge/note_constructor.py
@@ -120,17 +120,14 @@ Text:
 JSON:"""
 
         try:
+            from zettelforge.config import get_config
             from zettelforge.llm_client import generate
 
-            # 8000 tokens for causal extraction — the highest cap in the
-            # codebase. This prompt asks the model to enumerate every causal
-            # relation in a passage, which triggers the longest reasoning
-            # chains anywhere in the system. Empirical: qwen3.5:9b at
-            # num_predict=4000 was *stochastically* sufficient (~70% success
-            # rate), eval_count varied between 2.8k (success) and 4k+ (still
-            # in <think> tags when budget exhausted). 8000 keeps the
-            # success rate >95% on the same model. v2.5.2 CHANGELOG.
-            output = generate(prompt, max_tokens=8000, temperature=0.1)
+            output = generate(
+                prompt,
+                max_tokens=get_config().llm.max_tokens_causal,
+                temperature=0.1,
+            )
 
             parsed = extract_json(output, expect="array")
             if parsed is None:

--- a/src/zettelforge/sigma/ingest.py
+++ b/src/zettelforge/sigma/ingest.py
@@ -42,6 +42,7 @@ def ingest_rule(
     *,
     domain: str = "detection",
     source_ref: str | None = None,
+    sync: bool = True,
 ) -> tuple[Any, list[dict[str, Any]]]:
     """Ingest a single Sigma rule.
 
@@ -51,6 +52,8 @@ def ingest_rule(
         domain: Memory domain for the note (default ``"detection"``).
         source_ref: Override ``source_ref`` on the note (defaults to the
             rule id for dict/str input, or the file path for Path input).
+        sync: Whether MemoryManager enrichment should run inline. Directory
+            bulk ingest passes ``False`` and drains once at the end.
 
     Returns:
         ``(note, relations)`` — the :class:`MemoryNote` persisted and the
@@ -86,7 +89,7 @@ def ingest_rule(
         source_type="sigma_rule",
         source_ref=effective_source_ref,
         domain=domain,
-        sync=True,
+        sync=sync,
     )
 
     _persist_relations(mm, relations, note_id=note.id)
@@ -99,6 +102,8 @@ def ingest_rules_dir(
     *,
     glob: str = "**/*.yml",
     domain: str = "detection",
+    bulk: bool = False,
+    flush_timeout: float | None = None,
 ) -> tuple[int, int]:
     """Walk a directory, ingesting every matching Sigma rule.
 
@@ -142,7 +147,7 @@ def ingest_rules_dir(
             skipped += 1
             continue
         try:
-            ingest_rule(fpath, mm, domain=domain)
+            ingest_rule(fpath, mm, domain=domain, sync=not bulk)
             ingested += 1
         except (SigmaParseError, SigmaValidationError) as exc:
             _log.warning("sigma_ingest_skip path=%s reason=%s", fpath, exc)
@@ -150,6 +155,10 @@ def ingest_rules_dir(
         except Exception as exc:  # pragma: no cover — defensive
             _log.warning("sigma_ingest_error path=%s reason=%s", fpath, exc)
             skipped += 1
+    if bulk and hasattr(mm, "flush"):
+        flushed = mm.flush(timeout=flush_timeout)
+        if not flushed:
+            _log.warning("sigma_bulk_flush_timeout path=%s timeout=%s", root, flush_timeout)
     return ingested, skipped
 
 

--- a/src/zettelforge/synthesis_generator.py
+++ b/src/zettelforge/synthesis_generator.py
@@ -141,13 +141,15 @@ class SynthesisGenerator:
         full_prompt = f"{user_prompt}\n\nRespond with valid JSON only."
 
         try:
+            from zettelforge.config import get_config
             from zettelforge.llm_client import generate
 
-            # 2500-token budget for reasoning-model headroom. Pre-2.5.2 the
-            # 800-token cap was exhausted by qwen3.5+/qwen3.6/nemotron-3
-            # <think> tokens before any JSON answer was emitted, dropping
-            # synthesis to its empty-result fallback on every call.
-            raw = generate(full_prompt, max_tokens=2500, temperature=0.1, system=system_prompt)
+            raw = generate(
+                full_prompt,
+                max_tokens=get_config().llm.max_tokens_synthesis,
+                temperature=0.1,
+                system=system_prompt,
+            )
             result = extract_json(raw, expect="object")
             if result is None:
                 _logger.warning("parse_failed", schema="synthesis", raw=(raw or "")[:200])

--- a/src/zettelforge/yara/cccs_metadata.py
+++ b/src/zettelforge/yara/cccs_metadata.py
@@ -62,12 +62,12 @@ CCCS_YARA_VALUES: dict[str, Any] = _load_yaml(_CCCS_VALUES_PATH)
 
 
 def _allowed_regexes(value_name: str) -> list[re.Pattern[str]]:
-    """Return compiled alternation regexes for a named value set."""
+    """Return whole-value regexes for a named CCCS value set."""
     entries = CCCS_YARA_VALUES.get(value_name, []) or []
     patterns: list[re.Pattern[str]] = []
     for entry in entries:
         if isinstance(entry, dict) and "value" in entry:
-            patterns.append(re.compile(entry["value"]))
+            patterns.append(re.compile(rf"\A(?:{entry['value']})\Z"))
     return patterns
 
 
@@ -79,13 +79,14 @@ _MALWARE_TYPE_REGEXES = _allowed_regexes("malware_types")
 _ACTOR_TYPE_REGEXES = _allowed_regexes("actor_types")
 _HASH_REGEXES = _allowed_regexes("hash_types")
 
-# From CCCS_YARA.yml: author's own regexExpression.
-_AUTHOR_REGEX = re.compile(r"^[a-zA-Z]+\@[A-Z]+$|^[A-Z\s._\-]+$|^.*$")
-_VERSION_REGEX = re.compile(r"^\d+\.\d+$")
-_DATE_REGEX = re.compile(r"^\d{4}-\d{2}-\d{2}$")
-_UUID_REGEX = re.compile(r"^[0-9A-Za-z]{16,}$")  # base62 UUID, generous lower bound.
-_FINGERPRINT_REGEX = re.compile(r"^[a-fA-F0-9]{40,64}$")  # SHA-1 / SHA-256-ish.
-_MITRE_ATT_REGEX = re.compile(r"^(TA|T|M|G|S)\d{4}(\.\d{3})?$")
+# The upstream author regex ends with ``^.*$`` and therefore accepts any
+# attacker-controlled string. Keep this field deliberately narrow.
+_AUTHOR_REGEX = re.compile(r"\A[A-Za-z0-9_.@+-]+\Z")
+_VERSION_REGEX = re.compile(r"\A\d+\.\d+\Z")
+_DATE_REGEX = re.compile(r"\A\d{4}-\d{2}-\d{2}\Z")
+_UUID_REGEX = re.compile(r"\A[0-9A-Za-z]{16,}\Z")  # base62 UUID, generous lower bound.
+_FINGERPRINT_REGEX = re.compile(r"\A[a-fA-F0-9]{40,64}\Z")  # SHA-1 / SHA-256-ish.
+_MITRE_ATT_REGEX = re.compile(r"\A(TA|T|M|G|S)\d{4}(\.\d{3})?\Z")
 
 
 # Fields whose ``optional: No`` makes them required under CCCS-strict.
@@ -133,7 +134,9 @@ REQUIRED_FIELDS: list[str] = _required_fields()
 def _regex_match(value: Any, patterns: list[re.Pattern[str]]) -> bool:
     if not isinstance(value, str):
         return False
-    return any(p.search(value) is not None for p in patterns)
+    if value != value.strip():
+        return False
+    return any(p.fullmatch(value) is not None for p in patterns)
 
 
 def _validate_field(name: str, value: Any) -> str | None:

--- a/src/zettelforge/yara/ingest.py
+++ b/src/zettelforge/yara/ingest.py
@@ -75,6 +75,7 @@ def ingest_rule(
     *,
     domain: str = "detection",
     tier: str = "warn",
+    sync: bool = True,
 ) -> tuple[MemoryNote | None, list[dict[str, Any]]]:
     """Ingest a single YARA rule (file, text, or pre-parsed dict).
 
@@ -89,6 +90,8 @@ def ingest_rule(
         domain: Memory domain for the note. Default ``"detection"``.
         tier: CCCS validation tier. ``"warn"`` (default), ``"strict"``,
             or ``"non_cccs"``.
+        sync: Whether MemoryManager enrichment should run inline. Directory
+            bulk ingest passes ``False`` and drains once at the end.
 
     Returns:
         ``(note, relations)``. ``note`` is ``None`` only when CCCS
@@ -102,7 +105,13 @@ def ingest_rule(
         return None, []
 
     rule_dict = rules[0]
-    note, relations, _is_new = _ingest_single(rule_dict, mm, domain=domain, tier=tier)
+    note, relations, _is_new = _ingest_single(
+        rule_dict,
+        mm,
+        domain=domain,
+        tier=tier,
+        sync=sync,
+    )
     return note, relations
 
 
@@ -113,6 +122,8 @@ def ingest_rules_dir(
     glob: str = "**/*.yar",
     tier: str = "warn",
     domain: str = "detection",
+    bulk: bool = False,
+    flush_timeout: float | None = None,
 ) -> dict[str, Any]:
     """Walk a directory tree and ingest every YARA rule file.
 
@@ -182,6 +193,7 @@ def ingest_rules_dir(
                         domain=domain,
                         tier=tier,
                         source_path=str(yar_path),
+                        sync=not bulk,
                     )
                 except Exception as exc:  # pragma: no cover — defensive
                     errors.append(f"{yar_path}:{rule_dict.get('rule_name')}: {exc}")
@@ -195,6 +207,11 @@ def ingest_rules_dir(
                 else:
                     # Already present (idempotent hit).
                     skipped += 1
+
+    if bulk and hasattr(mm, "flush"):
+        flushed = mm.flush(timeout=flush_timeout)
+        if not flushed:
+            _LOG.warning("yara_bulk_flush_timeout path=%s timeout=%s", root, flush_timeout)
 
     return {"ingested": ingested, "skipped": skipped, "errors": errors}
 
@@ -230,6 +247,7 @@ def _ingest_single(
     domain: str,
     tier: str,
     source_path: str | None = None,
+    sync: bool = True,
 ) -> tuple[MemoryNote | None, list[dict[str, Any]], bool]:
     """Ingest one rule. Returns ``(note_or_None, relations, is_new)``.
 
@@ -263,7 +281,7 @@ def _ingest_single(
         source_type="yara",
         source_ref=source_ref,
         domain=domain,
-        sync=True,
+        sync=sync,
     )
 
     # CR-B1: persist every relation as a KG edge keyed on the YaraRule's

--- a/src/zettelforge/yara/parser.py
+++ b/src/zettelforge/yara/parser.py
@@ -27,6 +27,7 @@ The parser preserves plyara's original keys and adds:
 
 from __future__ import annotations
 
+import threading
 from pathlib import Path
 from typing import Any
 
@@ -36,6 +37,8 @@ import plyara
 #: a few KB; a 1 MB ceiling catches runaway payloads without blocking normal
 #: multi-rule files.
 MAX_RULE_FILE_BYTES = 1_048_576  # 1 MB
+_PARSER_LOCK = threading.Lock()
+_PARSER: plyara.Plyara | None = None
 
 
 class YaraParseError(ValueError):
@@ -66,18 +69,29 @@ def _carve_raw_rule(source_lines: list[str], rule: dict[str, Any]) -> str:
     return "\n".join(source_lines[start - 1 : stop])
 
 
+def _get_parser() -> plyara.Plyara:
+    global _PARSER
+    if _PARSER is None:
+        _PARSER = plyara.Plyara()
+    return _PARSER
+
+
 def parse_yara(text: str) -> list[dict[str, Any]]:
     """Parse YARA source text into a list of normalized rule dicts.
 
     A single .yar file may contain multiple rules; one dict per rule.
     """
-    parser = plyara.Plyara()
-    try:
-        rules: list[dict[str, Any]] = parser.parse_string(text)
-    except Exception as exc:  # plyara raises generic Exception on syntax errors
-        raise ValueError(f"plyara parse error: {exc}") from exc
+    with _PARSER_LOCK:
+        parser = _get_parser()
+        parser.clear()
+        try:
+            rules: list[dict[str, Any]] = list(parser.parse_string(text))
+            parser_imports = sorted(getattr(parser, "imports", set()) or [])
+        except Exception as exc:  # plyara raises generic Exception on syntax errors
+            raise ValueError(f"plyara parse error: {exc}") from exc
+        finally:
+            parser.clear()
 
-    parser_imports = sorted(getattr(parser, "imports", set()) or [])
     source_lines = text.splitlines()
 
     for rule in rules:

--- a/tests/test_cccs_metadata.py
+++ b/tests/test_cccs_metadata.py
@@ -1,0 +1,51 @@
+"""Security regression tests for CCCS YARA metadata validation."""
+
+from zettelforge.yara.cccs_metadata import validate_metadata
+
+
+def _strict_meta(**overrides: str) -> dict[str, str]:
+    meta = {
+        "id": "validuuidstring01",
+        "fingerprint": "a" * 64,
+        "version": "1.0",
+        "modified": "2024-01-01",
+        "status": "RELEASED",
+        "sharing": "TLP:WHITE",
+        "source": "CCCS",
+        "author": "analyst@CCCS",
+        "description": "fixture",
+        "category": "TECHNIQUE",
+    }
+    meta.update(overrides)
+    return meta
+
+
+def test_cccs_value_regexes_reject_multiline_injection() -> None:
+    result = validate_metadata(
+        _strict_meta(sharing="TLP:WHITE\nid: hostile_id"),
+        tier="strict",
+    )
+
+    assert result.accepted is False
+    assert any("sharing" in error for error in result.errors)
+
+
+def test_cccs_value_regexes_reject_surrounding_whitespace() -> None:
+    result = validate_metadata(_strict_meta(status=" RELEASED "), tier="strict")
+
+    assert result.accepted is False
+    assert any("status" in error for error in result.errors)
+
+
+def test_cccs_author_rejects_shell_metacharacters() -> None:
+    result = validate_metadata(_strict_meta(author='analyst@CCCS"; rm -rf / #'), tier="strict")
+
+    assert result.accepted is False
+    assert any("author" in error for error in result.errors)
+
+
+def test_cccs_author_rejects_newline_suffix() -> None:
+    result = validate_metadata(_strict_meta(author="analyst@CCCS\n"), tier="strict")
+
+    assert result.accepted is False
+    assert any("author" in error for error in result.errors)

--- a/tests/test_json_parse.py
+++ b/tests/test_json_parse.py
@@ -1,7 +1,12 @@
 """Tests for shared JSON parsing utility."""
 
 import pytest
-from zettelforge.json_parse import extract_json, get_parse_stats, reset_parse_stats
+from zettelforge.json_parse import (
+    extract_json,
+    get_parse_stats,
+    reset_parse_stats,
+    strip_thinking_tags,
+)
 
 
 class TestExtractJson:
@@ -68,3 +73,15 @@ class TestExtractJson:
         raw = 'Here is the JSON:\n```json\n[{"a": 1}]\n```\nDone.'
         result = extract_json(raw, expect="array")
         assert result == [{"a": 1}]
+
+    def test_think_tags_are_removed_before_object_parse(self):
+        raw = '<think>private chain of thought {"not": "json"}</think>\n{"ok": true}'
+        assert extract_json(raw) == {"ok": True}
+
+    def test_thinking_tags_are_removed_before_array_parse(self):
+        raw = '<thinking>reasoning [0]</thinking>\n[{"ok": true}]'
+        assert extract_json(raw, expect="array") == [{"ok": True}]
+
+    def test_strip_thinking_tags_preserves_markdown_bold(self):
+        raw = '**thinking** is just markdown {"ok": true}'
+        assert strip_thinking_tags(raw) == raw

--- a/tests/test_max_tokens_budgets.py
+++ b/tests/test_max_tokens_budgets.py
@@ -1,0 +1,202 @@
+"""Regression tests for configurable LLM max-token budgets."""
+
+from __future__ import annotations
+
+import pytest
+
+
+_TOKEN_ENV_VARS = [
+    "ZETTELFORGE_LLM_MAX_TOKENS",
+    "ZETTELFORGE_LLM_MAX_TOKENS_CAUSAL",
+    "ZETTELFORGE_LLM_MAX_TOKENS_SYNTHESIS",
+    "ZETTELFORGE_LLM_MAX_TOKENS_EXTRACTION",
+    "ZETTELFORGE_LLM_MAX_TOKENS_NER",
+    "ZETTELFORGE_LLM_MAX_TOKENS_EVOLVE",
+    "ZETTELFORGE_LLM_REASONING_MODEL",
+]
+
+
+@pytest.fixture(autouse=True)
+def _clean_config(monkeypatch):
+    from zettelforge.config import reload_config
+
+    for name in _TOKEN_ENV_VARS:
+        monkeypatch.delenv(name, raising=False)
+    reload_config()
+    yield
+    reload_config()
+
+
+def test_llm_config_defaults_include_reasoning_budget_floors():
+    from zettelforge.config import LLMConfig
+
+    cfg = LLMConfig()
+
+    assert cfg.max_tokens == 400
+    assert cfg.max_tokens_causal == 8000
+    assert cfg.max_tokens_synthesis == 2500
+    assert cfg.max_tokens_extraction == 2500
+    assert cfg.max_tokens_ner == 2500
+    assert cfg.max_tokens_evolve == 2500
+    assert cfg.reasoning_model is False
+
+
+def test_llm_budget_env_overrides_and_reasoning_scaling(monkeypatch):
+    from zettelforge.config import reload_config
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS", "123")
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_CAUSAL", "16000")
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_SYNTHESIS", "100")
+    monkeypatch.setenv("ZETTELFORGE_LLM_TIMEOUT", "30")
+    monkeypatch.setenv("ZETTELFORGE_LLM_REASONING_MODEL", "true")
+
+    cfg = reload_config().llm
+
+    assert cfg.max_tokens == 123
+    assert cfg.max_tokens_causal == 16000
+    assert cfg.max_tokens_synthesis == 2500
+    assert cfg.timeout == 180.0
+    assert cfg.reasoning_model is True
+
+
+def test_generate_uses_config_default_when_max_tokens_omitted(monkeypatch):
+    from zettelforge import llm_client
+    from zettelforge.config import reload_config
+    from zettelforge.llm_providers import MockProvider, registry
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_PROVIDER", "mock")
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS", "321")
+    reload_config()
+
+    captured: dict[str, MockProvider] = {}
+
+    class CapturingMockProvider(MockProvider):
+        def __init__(self, **_kwargs):
+            super().__init__(responses=['{"ok": true}'])
+            captured["instance"] = self
+
+    original_cls = registry._registry.get("mock")
+    registry._registry["mock"] = CapturingMockProvider
+    llm_client.reload()
+    try:
+        assert llm_client.generate("hello") == '{"ok": true}'
+        assert captured["instance"].calls[-1]["max_tokens"] == 321
+    finally:
+        if original_cls is not None:
+            registry._registry["mock"] = original_cls
+        llm_client.reload()
+
+
+def test_causal_extraction_uses_configured_budget(monkeypatch):
+    from zettelforge.config import reload_config
+    from zettelforge.note_constructor import NoteConstructor
+
+    calls: list[dict] = []
+
+    def fake_generate(prompt: str, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return '[{"subject":"APT28","relation":"uses","object":"Cobalt Strike"}]'
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_CAUSAL", "9001")
+    reload_config()
+    monkeypatch.setattr("zettelforge.llm_client.generate", fake_generate)
+
+    triples = NoteConstructor().extract_causal_triples("APT28 uses Cobalt Strike")
+
+    assert triples
+    assert calls[-1]["max_tokens"] == 9001
+
+
+def test_synthesis_uses_configured_budget(monkeypatch):
+    from zettelforge.config import reload_config
+    from zettelforge.synthesis_generator import SynthesisGenerator
+
+    calls: list[dict] = []
+
+    def fake_generate(prompt: str, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return '{"answer":"ok","confidence":0.9,"sources":[]}'
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_SYNTHESIS", "3333")
+    reload_config()
+    monkeypatch.setattr("zettelforge.llm_client.generate", fake_generate)
+
+    result = SynthesisGenerator()._generate_synthesis("q", "context", "direct_answer")
+
+    assert result["answer"] == "ok"
+    assert calls[-1]["max_tokens"] == 3333
+
+
+def test_fact_extraction_uses_configured_budget(monkeypatch):
+    from zettelforge.config import reload_config
+    from zettelforge.fact_extractor import FactExtractor
+
+    calls: list[dict] = []
+
+    def fake_generate(prompt: str, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return '[{"fact":"APT28 uses Cobalt Strike","importance":8}]'
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_EXTRACTION", "3334")
+    reload_config()
+    monkeypatch.setattr("zettelforge.llm_client.generate", fake_generate)
+
+    facts = FactExtractor().extract("APT28 uses Cobalt Strike")
+
+    assert facts
+    assert calls[-1]["max_tokens"] == 3334
+
+
+def test_entity_ner_uses_configured_budget(monkeypatch):
+    from zettelforge.config import reload_config
+    from zettelforge.entity_indexer import EntityExtractor
+
+    calls: list[dict] = []
+
+    def fake_generate(prompt: str, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return '{"person":[],"location":[],"organization":["ACME"],"event":[],"activity":[],"temporal":[]}'
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_NER", "3335")
+    reload_config()
+    monkeypatch.setattr("zettelforge.llm_client.generate", fake_generate)
+
+    entities = EntityExtractor().extract_llm("ACME observed a campaign")
+
+    assert entities["organization"] == ["acme"]
+    assert calls[-1]["max_tokens"] == 3335
+
+
+def test_memory_evolution_uses_configured_budget(monkeypatch):
+    from zettelforge.config import reload_config
+    from zettelforge.memory_evolver import MemoryEvolver
+    from zettelforge.note_schema import Content, Embedding, MemoryNote, Metadata, Semantic
+
+    calls: list[dict] = []
+
+    def fake_generate(prompt: str, **kwargs):
+        calls.append({"prompt": prompt, **kwargs})
+        return '{"action":"keep","reason":"redundant","updated_content":""}'
+
+    def note(note_id: str, raw: str) -> MemoryNote:
+        return MemoryNote(
+            id=note_id,
+            created_at="2026-05-26T00:00:00",
+            updated_at="2026-05-26T00:00:00",
+            content=Content(raw=raw, source_type="test", source_ref=note_id),
+            semantic=Semantic(context="", keywords=[], tags=[], entities=[]),
+            embedding=Embedding(vector=[]),
+            metadata=Metadata(),
+        )
+
+    monkeypatch.setenv("ZETTELFORGE_LLM_MAX_TOKENS_EVOLVE", "3336")
+    reload_config()
+    monkeypatch.setattr("zettelforge.memory_evolver.generate", fake_generate)
+
+    result = MemoryEvolver(memory_manager=object()).evaluate_evolution(
+        note("new", "APT28"),
+        note("old", "APT29"),
+    )
+
+    assert result["action"] == "keep"
+    assert calls[-1]["max_tokens"] == 3336

--- a/tests/test_memory_manager_flush.py
+++ b/tests/test_memory_manager_flush.py
@@ -1,0 +1,63 @@
+"""Tests for MemoryManager enrichment queue draining."""
+
+import threading
+import time
+from pathlib import Path
+
+from zettelforge.memory_manager import MemoryManager, _EnrichmentJob
+
+
+def test_flush_waits_for_in_flight_enrichment_job(tmp_path: Path, monkeypatch) -> None:
+    mm = MemoryManager(
+        jsonl_path=str(tmp_path / "notes.jsonl"),
+        lance_path=str(tmp_path / "vec"),
+    )
+    started = threading.Event()
+    release = threading.Event()
+    done = threading.Event()
+
+    def slow_enrichment(_job):
+        started.set()
+        release.wait(timeout=1)
+        done.set()
+
+    monkeypatch.setattr(mm, "_run_enrichment", slow_enrichment)
+
+    mm._enrichment_queue.put_nowait(
+        _EnrichmentJob(note_id="n1", domain="cti", content_len=500),
+    )
+    assert started.wait(timeout=1)
+    assert mm._enrichment_queue.empty()
+    assert not done.is_set()
+
+    release.set()
+    assert mm.flush(timeout=1) is True
+    assert done.is_set()
+
+
+def test_flush_returns_false_on_timeout_for_in_flight_job(tmp_path: Path, monkeypatch) -> None:
+    mm = MemoryManager(
+        jsonl_path=str(tmp_path / "notes.jsonl"),
+        lance_path=str(tmp_path / "vec"),
+    )
+    started = threading.Event()
+    release = threading.Event()
+
+    def slow_enrichment(_job):
+        started.set()
+        release.wait(timeout=1)
+
+    monkeypatch.setattr(mm, "_run_enrichment", slow_enrichment)
+
+    mm._enrichment_queue.put_nowait(
+        _EnrichmentJob(note_id="n1", domain="cti", content_len=500),
+    )
+    assert started.wait(timeout=1)
+
+    assert mm.flush(timeout=0.01) is False
+    release.set()
+    for _ in range(100):
+        if mm.flush(timeout=0.01):
+            break
+        time.sleep(0.01)
+    assert mm.flush(timeout=1) is True

--- a/tests/test_sigma_ingest.py
+++ b/tests/test_sigma_ingest.py
@@ -22,6 +22,7 @@ import pytest
 
 import zettelforge.knowledge_graph as knowledge_graph_module
 from zettelforge import MemoryManager
+from zettelforge.note_schema import Content, Embedding, MemoryNote, Metadata, Semantic
 
 FIXTURES = Path(__file__).parent / "fixtures" / "sigma"
 
@@ -62,9 +63,7 @@ def mm() -> MemoryManager:
 def test_ingest_rule_single_file(mm: MemoryManager) -> None:
     from zettelforge.sigma.ingest import ingest_rule
 
-    note, relations = ingest_rule(
-        FIXTURES / "process_creation_example.yml", mm, domain="detection"
-    )
+    note, relations = ingest_rule(FIXTURES / "process_creation_example.yml", mm, domain="detection")
     # Note persisted → can be fetched back.
     assert note is not None
     fetched = mm.store.get_note_by_id(note.id)
@@ -83,9 +82,7 @@ def test_ingest_rule_emits_kg_edges_for_logsource(mm: MemoryManager) -> None:
     _note, _rels = ingest_rule(FIXTURES / "cloud_example.yml", mm)
 
     # cloud_example.yml → product=windows + service=security.
-    neighbors = mm.store.get_kg_neighbors(
-        "SigmaRule", "929a690e-bef0-4204-a928-ef5e620d6fcb"
-    )
+    neighbors = mm.store.get_kg_neighbors("SigmaRule", "929a690e-bef0-4204-a928-ef5e620d6fcb")
     targets = {(n["node"]["entity_type"], n["node"]["entity_value"]) for n in neighbors}
     assert ("LogSource", "product:windows") in targets
     assert ("LogSource", "service:security") in targets
@@ -141,6 +138,52 @@ def test_ingest_rules_dir_walks_tree(mm: MemoryManager) -> None:
     # Four fixtures: process_creation, cloud, correlation, tagged.
     assert ingested == 4
     assert skipped == 0
+
+
+def test_ingest_rules_dir_bulk_defers_enrichment_and_flushes() -> None:
+    from zettelforge.sigma.ingest import ingest_rules_dir
+
+    class _Store:
+        def get_note_by_source_ref(self, _source_ref):
+            return None
+
+        def add_kg_edge(self, **_kwargs):
+            return None
+
+    class _MM:
+        def __init__(self):
+            self.store = _Store()
+            self.calls = []
+            self.flushed = False
+
+        def remember(self, *, content, source_type, source_ref, domain, sync):
+            self.calls.append({"source_ref": source_ref, "sync": sync})
+            note = MemoryNote(
+                id=f"note-{len(self.calls)}",
+                created_at="2026-05-26T00:00:00",
+                updated_at="2026-05-26T00:00:00",
+                content=Content(raw=content, source_type=source_type, source_ref=source_ref),
+                semantic=Semantic(context="", keywords=[], tags=[], entities=[]),
+                embedding=Embedding(vector=[]),
+                metadata=Metadata(domain=domain),
+            )
+            return note, "created"
+
+        def flush(self, timeout=None):
+            self.flushed = True
+            self.flush_timeout = timeout
+            return True
+
+    mm = _MM()
+
+    ingested, skipped = ingest_rules_dir(FIXTURES, mm, bulk=True, flush_timeout=1.5)
+
+    assert ingested == 4
+    assert skipped == 0
+    assert mm.calls
+    assert all(call["sync"] is False for call in mm.calls)
+    assert mm.flushed is True
+    assert mm.flush_timeout == 1.5
 
 
 def test_ingest_rules_dir_skips_invalid_file(tmp_path: Path, mm: MemoryManager) -> None:

--- a/tests/test_yara_ingest.py
+++ b/tests/test_yara_ingest.py
@@ -5,6 +5,7 @@ from pathlib import Path
 import pytest
 
 from zettelforge.memory_manager import MemoryManager
+from zettelforge.note_schema import Content, Embedding, MemoryNote, Metadata, Semantic
 from zettelforge.yara.ingest import ingest_rule, ingest_rules_dir
 
 FIXTURES = Path(__file__).parent / "fixtures" / "yara"
@@ -48,6 +49,50 @@ def test_ingest_rules_dir_walks_tree(mm: MemoryManager) -> None:
     result = ingest_rules_dir(FIXTURES, mm, tier="warn")
     assert result["ingested"] >= 3
     assert result["errors"] == []
+
+
+def test_ingest_rules_dir_bulk_defers_enrichment_and_flushes() -> None:
+    class _Store:
+        def get_note_by_source_ref(self, _source_ref):
+            return None
+
+        def add_kg_edge(self, **_kwargs):
+            return None
+
+    class _MM:
+        def __init__(self):
+            self.store = _Store()
+            self.calls = []
+            self.flushed = False
+
+        def remember(self, *, content, source_type, source_ref, domain, sync):
+            self.calls.append({"source_ref": source_ref, "sync": sync})
+            note = MemoryNote(
+                id=f"note-{len(self.calls)}",
+                created_at="2026-05-26T00:00:00",
+                updated_at="2026-05-26T00:00:00",
+                content=Content(raw=content, source_type=source_type, source_ref=source_ref),
+                semantic=Semantic(context="", keywords=[], tags=[], entities=[]),
+                embedding=Embedding(vector=[]),
+                metadata=Metadata(domain=domain),
+            )
+            return note, "created"
+
+        def flush(self, timeout=None):
+            self.flushed = True
+            self.flush_timeout = timeout
+            return True
+
+    mm = _MM()
+
+    result = ingest_rules_dir(FIXTURES, mm, tier="warn", bulk=True, flush_timeout=1.5)
+
+    assert result["ingested"] >= 3
+    assert result["errors"] == []
+    assert mm.calls
+    assert all(call["sync"] is False for call in mm.calls)
+    assert mm.flushed is True
+    assert mm.flush_timeout == 1.5
 
 
 def test_ingest_rules_dir_second_run_skips_existing(mm: MemoryManager) -> None:

--- a/tests/test_yara_parser.py
+++ b/tests/test_yara_parser.py
@@ -1,6 +1,7 @@
 """Tests for zettelforge.yara.parser."""
 
 from pathlib import Path
+from concurrent.futures import ThreadPoolExecutor
 
 from zettelforge.yara.parser import parse_file, parse_text, parse_yara
 
@@ -75,6 +76,19 @@ rule Second {
     # raw_rule carved from source lines — non-empty for both.
     assert "rule First" in rules[0]["raw_rule"]
     assert "rule Second" in rules[1]["raw_rule"]
+
+
+def test_parse_yara_cached_parser_is_safe_under_concurrency() -> None:
+    """Concurrent parses must not clear shared plyara state mid-parse."""
+    src = (FIXTURES / "webshell.yar").read_text()
+
+    def parse_names() -> list[str]:
+        return [rule["rule_name"] for rule in parse_yara(src)]
+
+    with ThreadPoolExecutor(max_workers=4) as pool:
+        results = list(pool.map(lambda _i: parse_names(), range(12)))
+
+    assert results == [["SuspiciousWebShell"]] * 12
 
 
 def test_parse_text_raises_on_syntax_error() -> None:


### PR DESCRIPTION
## Summary
- Harden CCCS YARA metadata validation against multiline regex injection and permissive author values
- Add configurable LLM max-token budgets, reasoning-model floors, and `<think>` / `<thinking>` stripping before JSON extraction
- Add bulk Sigma/YARA ingest paths that defer enrichment and drain via `MemoryManager.flush()`
- Fix the known stale-PR hazards by making `flush()` wait for in-flight jobs and serializing cached `Plyara` parser access

## Issues
- Closes #125
- Closes #72
- Closes #73

## Notes
This intentionally recreates the useful scope from stale PR #146 on current `master` instead of merging the stale branch. It avoids the reviewed defects around queue draining and shared `Plyara` mutation.

## Validation
- `ruff check src/zettelforge/`
- `ruff format --check src/zettelforge/ tests/test_cccs_metadata.py tests/test_json_parse.py tests/test_max_tokens_budgets.py tests/test_memory_manager_flush.py tests/test_sigma_ingest.py tests/test_yara_ingest.py tests/test_yara_parser.py`
- Focused gate: `145 passed, 5 skipped, 1 warning`
- Full suite: `762 passed, 13 skipped, 5 warnings`
- `python3 -m build --outdir <tmp>` and `python3 -m twine check <tmp>/*`