### PR TITLE
Skip PyPI publish for package releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -6,6 +6,9 @@ on:
 
 jobs:
   publish:
+    # Package-only releases (for example packages-v0.1.0) are not
+    # Python package releases and must not attempt a PyPI upload.
+    if: startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: read


### PR DESCRIPTION
## Summary
- restrict the PyPI publish job to release tags that start with v
- prevent package-only releases such as packages-v0.1.0 from attempting a duplicate Python package upload

## Validation
- parsed all workflow YAML files
- ran git diff --check