### PR TITLE
feat(osint): add passive executor, resolver scoping, and docs

### DIFF
--- a/docs/how-to/passive-osint-enrichment.md
+++ b/docs/how-to/passive-osint-enrichment.md
@@ -1,0 +1,70 @@
+---
+title: "Passive OSINT Enrichment"
+description: "Run the RFC-016 OSINT executor, persist collector output into the knowledge graph, and keep active scanning gated behind explicit opt-in."
+diataxis_type: "how-to"
+audience: "Python developers and CTI operators using ZettelForge"
+tags: [osint, enrichment, knowledge-graph, dns, whois, bgp, passive-recon]
+last_updated: "2026-06-08"
+version: "2.7.0"
+---
+
+# Passive OSINT Enrichment
+
+ZettelForge ships a passive OSINT executor that runs registered collectors, validates each tuple against the ontology, canonicalizes entity values, and persists nodes and edges into the knowledge graph.
+
+## Install
+
+Install the OSINT extra when you need DNS, WHOIS, or IP/ASN enrichment:
+
+```bash
+pip install "zettelforge[osint]"
+```
+
+The base package already includes `httpx`, so passive BGPView lookups work with the standard install. The OSINT extra adds `dnspython`, `python-whois`, and `ipwhois` for the DNS and WHOIS collectors.
+
+## Run a passive enrichment
+
+```python
+from zettelforge.osint import run_osint_collection
+
+result = run_osint_collection("DomainName", "Example.COM.")
+print(result.canonical_input_value)  # example.com
+print(result.persisted_count)
+print(result.error_count)
+```
+
+The executor accepts these seed types: `DomainName`, `IPv4Address`, `IPv6Address`, `ASNumber`, and `Netblock`.
+
+Common passive flows:
+
+- `DomainName` seeds drive DNS, WHOIS, and certificate transparency collectors.
+- `IPv4Address` and `IPv6Address` seeds drive WHOIS enrichment.
+- `ASNumber` seeds drive passive BGP prefix lookups.
+
+## Dry-run or narrow scope
+
+Pass `persist=False` to validate collector output without writing to the knowledge graph:
+
+```python
+from zettelforge.osint import run_osint_collection
+
+result = run_osint_collection("ASNumber", "AS15169", persist=False)
+```
+
+Use `collector_names=(...)` when you want to run only specific collectors from the registry.
+
+## Safety controls
+
+Active port scanning stays disabled unless the operator explicitly enables it:
+
+```bash
+export ZETTELFORGE_OSINT_ACTIVE_SCAN=1
+```
+
+Without that flag, the port scanner returns an empty result and no probe is sent. Keep that flag unset unless you own the target network or have explicit authorization to scan it.
+
+## What gets persisted
+
+The executor writes canonical entity values to the graph, so duplicate spellings collapse onto the same nodes. For example, `AS15169` and `15169` resolve to the same canonical ASN node, and alternate domain spellings register as aliases for the same canonical domain node.
+
+Errors are collected per collector or tuple. A single failing collector does not abort the run.

--- a/docs/rfcs/RFC-016-osint-layer.md
+++ b/docs/rfcs/RFC-016-osint-layer.md
@@ -1,8 +1,8 @@
 # RFC-016: ZettelForge OSINT Layer
 
-## Status (2026-04-28)
+## Status (2026-06-08)
 
-**Phase 1 (Infrastructure): functional. Phases 2-5: declared, collectors stubbed.**
+**Phase 1 (Infrastructure): functional. Phase 1.5: executor, resolver wiring, and passive BGP lookup shipped. Phases 2-5 remain declared/stubbed.**
 Branch: `rfc/osint-layer-scaffold` (PR #147 amended).
 
 What ships:
@@ -12,15 +12,17 @@ What ships:
   validates against. Auto-merged into the global ``ENTITY_TYPES`` /
   ``RELATION_TYPES`` at import time.
 - **Phase 1 collectors (functional)** — ``dns_collector`` (A/AAAA/NS/MX),
-  ``whois_collector`` (domain + IP RDAP), ``cert_collector`` (crt.sh).
-  All sync, all mocked in tests, no network at test time.
-- **Phase 1.5 + 2-5 collectors (stubs)** — ``bgp_collector``,
-  ``port_scanner`` (gated behind ``ZETTELFORGE_OSINT_ACTIVE_SCAN``),
-  Phase 2-4 collectors (Hunter, Holehe, Namechk, Wappalyzer, BuiltWith,
-  Twitter, Hashtag, HIBP, Breach Directory). Each registers metadata so
-  discovery works; each returns ``[]`` until its API integration lands.
-- **Tests** — 67 new mocked tests covering entity validation, edge
-  validation, canonicalization, and collector shape.
+  ``whois_collector`` (domain + IP RDAP), ``cert_collector`` (crt.sh), plus
+  the passive ``bgp_collector`` for ASN prefix lookups. All sync, all mocked
+  in tests, no network at test time.
+- **Phase 1.5 executor + resolver wiring** — ``run_osint_collection`` drives
+  registry discovery, ontology validation, canonicalization, and KG
+  persistence through ``entity_resolver`` and ``KnowledgeGraph``.
+  ``port_scanner`` remains gated behind ``ZETTELFORGE_OSINT_ACTIVE_SCAN``;
+  later Phase 2-4 collectors still register as stubs until their API
+  integrations land.
+- **Tests** — Focused mocked coverage for entity validation, edge
+  validation, canonicalization, executor ingest, and passive BGP lookup.
 - **Investigation / EntityResolver** — Phase 4 / 1.5 utility scaffolds.
 
 Three deviations from the literal text of this RFC are tracked in

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -67,6 +67,7 @@ nav:
     - Query APT Tools: how-to/query-apt-tools.md
     - Reproduce Benchmarks: how-to/reproduce-benchmarks.md
     - Resolve Aliases: how-to/resolve-aliases.md
+    - Passive OSINT Enrichment: how-to/passive-osint-enrichment.md
     - Run Temporal Query: how-to/run-temporal-query.md
     - Set Up MCP Server: how-to/set-up-mcp-server.md
     - Store Threat Actor: how-to/store-threat-actor.md

--- a/src/zettelforge/osint/__init__.py
+++ b/src/zettelforge/osint/__init__.py
@@ -6,22 +6,39 @@ ontology and imports each collector subpackage so collectors register with
 ``TRANSFORM_REGISTRY`` at module load time.
 
 Phase 1 (Infrastructure) ships functional collectors (DNS, WHOIS, crt.sh)
-plus stubs for BGP and port scanning. Phases 2-5 ship as graceful stubs:
-each collector registers its metadata so callers can discover it, and
-returns ``[]`` until the underlying API integration lands.
+plus the passive BGP collector. Phase 1.5 adds the OSINT executor and
+resolver wiring; active port scanning remains gated behind explicit
+operator opt-in. Later collectors stay as graceful stubs until their
+respective phases land.
 
 Public surface:
 
-- ``OSINT_ENTITY_TYPES`` / ``OSINT_RELATION_TYPES`` / ``ONTOLOGY`` — additive
+- ``OSINT_ENTITY_TYPES`` / ``OSINT_RELATION_TYPES`` / ``ONTOLOGY`` -- additive
   ontology declarations.
-- ``TRANSFORM_REGISTRY`` — the singleton registry.
-- ``CollectorTuple`` — collector return-row shape.
-- ``TransformMetadata`` / ``TransformRegistry`` — types for adding new
+- ``TRANSFORM_REGISTRY`` -- the singleton registry.
+- ``CollectorTuple`` -- collector return-row shape.
+- ``TransformMetadata`` / ``TransformRegistry`` -- types for adding new
   collectors.
-- ``Investigation`` / ``EntityResolver`` — Phase 4 / Phase 1.5 utilities
-  (re-exported from their modules).
+- ``add_resolved`` / ``canonicalise_value`` / ``resolve`` -- entity
+  resolver helpers.
+- ``run_osint_collection`` / ``collect_osint`` -- the passive ingest API.
 """
 
+from zettelforge.osint.entity_resolver import (
+    add_resolved,
+    canonicalise_organization,
+    canonicalise_value,
+    register_alias,
+    resolve,
+)
+from zettelforge.osint.executor import (
+    SUPPORTED_SEED_TYPES,
+    OSINTCollectionResult,
+    OSINTExecutionError,
+    PersistedOSINTTuple,
+    collect_osint,
+    run_osint_collection,
+)
 from zettelforge.osint.ontology import (
     ONTOLOGY,
     OSINT_ENTITY_TYPES,
@@ -46,7 +63,7 @@ from zettelforge.osint.transform_registry import (
 )
 
 # Merge OSINT types into the global ontology before any collector runs.
-# Idempotent — safe under repeated imports (pytest, REPL re-imports, etc.).
+# Idempotent -- safe under repeated imports (pytest, REPL re-imports, etc.).
 merge_into_global_ontology()
 
 # Trigger collector self-registration. Each subpackage's __init__ imports
@@ -62,11 +79,18 @@ __all__ = [
     "ONTOLOGY",
     "OSINT_ENTITY_TYPES",
     "OSINT_RELATION_TYPES",
+    "SUPPORTED_SEED_TYPES",
     "TRANSFORM_REGISTRY",
     "CollectorFn",
     "CollectorTuple",
+    "OSINTCollectionResult",
+    "OSINTExecutionError",
+    "PersistedOSINTTuple",
     "TransformMetadata",
     "TransformRegistry",
+    "add_resolved",
+    "canonicalise_organization",
+    "canonicalise_value",
     "canonicalize_asn",
     "canonicalize_cidr",
     "canonicalize_domain",
@@ -75,6 +99,10 @@ __all__ = [
     "canonicalize_port",
     "canonicalize_url",
     "canonicalize_web_title",
+    "collect_osint",
     "get_transform_registry",
     "merge_into_global_ontology",
+    "register_alias",
+    "resolve",
+    "run_osint_collection",
 ]

--- a/src/zettelforge/osint/collectors/infrastructure/bgp_collector.py
+++ b/src/zettelforge/osint/collectors/infrastructure/bgp_collector.py
@@ -1,14 +1,13 @@
 """
-BGP collector — Phase 1.5 stub (RFC-016 §5).
+BGP collector — Phase 1.5 passive enrichment (RFC-016 §5).
 
 Fetches ASN / netblock data from BGPView's public JSON API. Sync; matches
 the rest of the codebase. Returns ``[]`` on any HTTP / parse failure or
 when ``httpx`` is unavailable; the agent sees an empty result, never an
 exception.
 
-The Phase 1 PR ships this with the registration metadata and the live
-BGPView call wired up but treated as best-effort. Hardening (retry / caching
-/ rate-limit budget) lands with Phase 1.5.
+This collector is intentionally passive and best-effort. Hardening (retry /
+caching / rate-limit budget) is intentionally deferred.
 """
 
 from __future__ import annotations
@@ -114,7 +113,7 @@ def collect(input_entity_type: str, input_value: str) -> list[CollectorTuple]:
 
 _METADATA = TransformMetadata(
     name="bgp_collector",
-    description="BGPView lookup: enumerate netblocks announced by an ASN.",
+    description="Passive BGPView lookup: enumerate netblocks announced by an ASN.",
     input_types=("ASNumber",),
     output_types=(("Netblock", "part_of_as"),),
     api_dependencies=("bgpview",),

--- a/src/zettelforge/osint/entity_resolver.py
+++ b/src/zettelforge/osint/entity_resolver.py
@@ -22,7 +22,6 @@ from __future__ import annotations
 
 import ipaddress
 import re
-from datetime import datetime
 from typing import TYPE_CHECKING
 
 from zettelforge.osint.ontology import (
@@ -239,8 +238,7 @@ def add_resolved(
     if existing_id:
         node = kg.get_node_by_id(existing_id)
         if node and properties:
-            node["properties"].update(properties)
-            node["updated_at"] = datetime.now().isoformat()
+            kg.add_node(entity_type, canonical_value, properties)
         if canonical_value != entity_value:
             alias_reverse[entity_value] = canonical
         return existing_id, False

--- a/src/zettelforge/osint/entity_resolver.py
+++ b/src/zettelforge/osint/entity_resolver.py
@@ -236,8 +236,7 @@ def add_resolved(
     alias_index, alias_reverse = _alias_maps(kg)
     existing_id = alias_index.get(canonical)
     if existing_id:
-        node = kg.get_node_by_id(existing_id)
-        if node and properties:
+        if properties:
             kg.add_node(entity_type, canonical_value, properties)
         if canonical_value != entity_value:
             alias_reverse[entity_value] = canonical

--- a/src/zettelforge/osint/entity_resolver.py
+++ b/src/zettelforge/osint/entity_resolver.py
@@ -1,15 +1,16 @@
 """
-OSINT Entity Resolver — canonical key normalisation and alias index.
+OSINT Entity Resolver -- canonical key normalisation and alias index.
 
 Phase 1.5 utility scaffold. Provides merge-when-duplicate semantics for
 the OSINT layer:
 
 - Canonical key: ``(entity_type, normalised_value)``
-- Alias index: alternate representations → canonical node ID
+- Alias index: alternate representations -> canonical node ID
 - Merge strategy: LWW for properties, accumulate for edges
 
-Phase 1 collectors don't yet route through this module; the Phase 1.5
-work that wires it in lives behind the same RFC-016 umbrella.
+The passive OSINT executor wires these helpers into KG ingest; later
+workflow orchestration can reuse the same canonicalisation and aliasing
+logic.
 
 Note on canonical key conventions: this module mirrors the conventions
 in ``zettelforge.osint.ontology`` (``DomainName`` not ``Domain``,
@@ -28,6 +29,10 @@ from zettelforge.osint.ontology import (
     canonicalize_asn,
     canonicalize_cidr,
     canonicalize_domain,
+    canonicalize_mx,
+    canonicalize_port,
+    canonicalize_url,
+    canonicalize_web_title,
 )
 
 if TYPE_CHECKING:
@@ -86,7 +91,7 @@ def canonicalise_asn(value: str) -> str:
 
     Mirrors :func:`zettelforge.osint.ontology.canonicalize_asn`. Accepts
     ``AS12345``, ``as12345``, ``"12345"``, or an int. Raises
-    ``ValueError`` on hex (``0x3039``) or other non-decimal input —
+    ``ValueError`` on hex (``0x3039``) or other non-decimal input --
     earlier scaffold versions silently stripped non-digits which turned
     ``0x3039`` into ``0339`` instead of the hex value 12345.
     """
@@ -98,28 +103,68 @@ def canonicalise_netblock(value: str) -> str:
     return canonicalize_cidr(value)
 
 
-# Global alias index: canonical_key → node_id
+def canonicalise_url(value: str) -> str:
+    """Return the canonical URL form used by ``URL`` and ``Website`` nodes."""
+    return canonicalize_url(value)
+
+
+def canonicalise_organization(value: str) -> str:
+    """Return a stable canonical form for organization names.
+
+    WHOIS and RDAP sources vary in case and spacing. Normalising to a
+    lowercased, whitespace-collapsed form keeps duplicates from being
+    reinserted under cosmetic variations.
+    """
+    return re.sub(r"\s+", " ", value).strip().casefold()
+
+
+# Global alias index: canonical_key -> node_id. This bucket is the default
+# scope used when callers do not pass a KnowledgeGraph explicitly.
 _ALIAS_INDEX: dict[str, str] = {}
-# Reverse: alternate representation → canonical key
+# Reverse: alternate representation -> canonical key
 _ALIAS_REVERSE: dict[str, str] = {}
+_KG_ALIAS_INDEX_ATTR = "_osint_alias_index"
+_KG_ALIAS_REVERSE_ATTR = "_osint_alias_reverse"
 
 
-def resolve(entity_type: str, value: str) -> str | None:
-    """Return the canonical key for an entity if already indexed, else None."""
+def _alias_maps(kg: KnowledgeGraph | None) -> tuple[dict[str, str], dict[str, str]]:
+    if kg is None:
+        return _ALIAS_INDEX, _ALIAS_REVERSE
+    index = getattr(kg, _KG_ALIAS_INDEX_ATTR, None)
+    if index is None:
+        index = {}
+        setattr(kg, _KG_ALIAS_INDEX_ATTR, index)
+    reverse = getattr(kg, _KG_ALIAS_REVERSE_ATTR, None)
+    if reverse is None:
+        reverse = {}
+        setattr(kg, _KG_ALIAS_REVERSE_ATTR, reverse)
+    return index, reverse
+
+
+def resolve(entity_type: str, value: str, *, kg: KnowledgeGraph | None = None) -> str | None:
+    """Return the canonical node ID for an entity if already indexed, else None."""
     canonical = _canonical_key(entity_type, value)
-    return _ALIAS_INDEX.get(canonical)
+    alias_index, _ = _alias_maps(kg)
+    return alias_index.get(canonical)
 
 
-def register_alias(canonical_key: str, alternate: str, node_id: str) -> None:
+def register_alias(
+    canonical_key: str,
+    alternate: str,
+    node_id: str,
+    *,
+    kg: KnowledgeGraph | None = None,
+) -> None:
     """Record an alternate representation that maps to the canonical node."""
-    _ALIAS_REVERSE[alternate] = canonical_key
-    _ALIAS_INDEX[canonical_key] = node_id
+    alias_index, alias_reverse = _alias_maps(kg)
+    alias_reverse[alternate] = canonical_key
+    alias_index[canonical_key] = node_id
 
 
 def _canonical_key(entity_type: str, value: str) -> str:
     """Build a normalised ``"<entity_type>:<canonical-value>"`` string.
 
-    The entity type names match the global ``ENTITY_TYPES`` table —
+    The entity type names match the global ``ENTITY_TYPES`` table --
     ``DomainName`` and not ``Domain``. Unknown types fall through to a
     whitespace-trimmed value so callers don't have to special-case
     every possible type.
@@ -128,15 +173,52 @@ def _canonical_key(entity_type: str, value: str) -> str:
         return f"{entity_type}:{canonicalise_ipv4(value)}"
     if entity_type == "IPv6Address":
         return f"{entity_type}:{ipaddress.IPv6Address(value.strip())}"
-    if entity_type in ("DomainName", "Website"):
+    if entity_type == "DomainName":
         return f"{entity_type}:{canonicalise_domain(value)}"
+    if entity_type in ("URL", "Website"):
+        return f"{entity_type}:{canonicalise_url(value)}"
     if entity_type == "PhoneNumber":
         return f"{entity_type}:{canonicalise_phone(value)}"
     if entity_type == "ASNumber":
         return f"{entity_type}:{canonicalise_asn(value)}"
     if entity_type == "Netblock":
         return f"{entity_type}:{canonicalise_netblock(value)}"
+    if entity_type == "NSRecord":
+        return f"{entity_type}:{canonicalise_domain(value)}"
+    if entity_type == "Organization":
+        return f"{entity_type}:{canonicalise_organization(value)}"
+    if entity_type == "MXRecord":
+        raw = value.strip()
+        if " " not in raw:
+            raise ValueError(f"MXRecord must be 'priority exchange', got {value!r}")
+        priority, exchange = raw.split(None, 1)
+        return f"{entity_type}:{canonicalize_mx(priority, exchange)}"
+    if entity_type == "Port":
+        raw = value.strip()
+        if "/" not in raw:
+            raise ValueError(f"Port must be 'number/protocol', got {value!r}")
+        number, protocol = raw.split("/", 1)
+        return f"{entity_type}:{canonicalize_port(number, protocol)}"
+    if entity_type == "WebTitle":
+        raw = value.strip()
+        if "::" not in raw:
+            raise ValueError(f"WebTitle must be 'url::title', got {value!r}")
+        url, title = raw.split("::", 1)
+        return f"{entity_type}:{canonicalize_web_title(url, title)}"
     return f"{entity_type}:{value.strip()}"
+
+
+def canonicalise_value(entity_type: str, value: str) -> str:
+    """Return the canonical value portion for an entity type.
+
+    This is the public counterpart to ``_canonical_key`` for callers that
+    need to pass the same value to ``KnowledgeGraph.add_node()`` and
+    ``KnowledgeGraph.add_edge()``. Keeping KG values canonical avoids creating
+    duplicate nodes for equivalent OSINT entities such as ``AS15169`` and
+    ``15169``.
+    """
+    canonical = _canonical_key(entity_type, value)
+    return canonical.split(":", 1)[1]
 
 
 def add_resolved(
@@ -151,14 +233,35 @@ def add_resolved(
     on properties.
     """
     canonical = _canonical_key(entity_type, entity_value)
-    existing_id = _ALIAS_INDEX.get(canonical)
+    canonical_value = canonical.split(":", 1)[1]
+    alias_index, alias_reverse = _alias_maps(kg)
+    existing_id = alias_index.get(canonical)
     if existing_id:
         node = kg.get_node_by_id(existing_id)
         if node and properties:
             node["properties"].update(properties)
             node["updated_at"] = datetime.now().isoformat()
+        if canonical_value != entity_value:
+            alias_reverse[entity_value] = canonical
         return existing_id, False
 
-    node_id = kg.add_node(entity_type, entity_value, properties)
-    _ALIAS_INDEX[canonical] = node_id
+    node_id = kg.add_node(entity_type, canonical_value, properties)
+    alias_index[canonical] = node_id
+    if canonical_value != entity_value:
+        alias_reverse[entity_value] = canonical
     return node_id, True
+
+
+__all__ = [
+    "add_resolved",
+    "canonicalise_asn",
+    "canonicalise_domain",
+    "canonicalise_ipv4",
+    "canonicalise_netblock",
+    "canonicalise_organization",
+    "canonicalise_phone",
+    "canonicalise_url",
+    "canonicalise_value",
+    "register_alias",
+    "resolve",
+]

--- a/src/zettelforge/osint/executor.py
+++ b/src/zettelforge/osint/executor.py
@@ -1,0 +1,369 @@
+"""
+OSINT collector executor and KG ingestion path (RFC-016 Phase 1.5).
+
+This module turns registered collector functions into an end-to-end passive
+OSINT enrichment API:
+
+1. Resolve matching collectors from ``TRANSFORM_REGISTRY``.
+2. Run them fail-closed.
+3. Validate emitted ``CollectorTuple`` rows against the ontology.
+4. Canonicalize/dedupe entities via ``entity_resolver``.
+5. Persist nodes and edges through ``KnowledgeGraph.add_node`` / ``add_edge``.
+
+Collectors remain synchronous and directly testable. The executor owns the
+cross-cutting concerns that would otherwise be duplicated by every caller.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import Any
+
+from zettelforge.knowledge_graph import KnowledgeGraph, get_knowledge_graph
+from zettelforge.log import get_logger
+from zettelforge.ontology import OntologyValidator
+from zettelforge.osint.entity_resolver import add_resolved, canonicalise_value
+from zettelforge.osint.ontology import merge_into_global_ontology
+from zettelforge.osint.transform_registry import (
+    CollectorTuple,
+    TransformMetadata,
+    TransformRegistry,
+    get_transform_registry,
+)
+
+_logger = get_logger("zettelforge.osint.executor")
+
+SUPPORTED_SEED_TYPES = ("DomainName", "IPv4Address", "IPv6Address", "ASNumber", "Netblock")
+
+
+@dataclass(frozen=True)
+class OSINTExecutionError:
+    """Non-fatal executor error for a collector or tuple."""
+
+    collector_name: str
+    message: str
+    tuple_index: int | None = None
+
+
+@dataclass(frozen=True)
+class PersistedOSINTTuple:
+    """A validated collector tuple after KG persistence."""
+
+    collector_name: str
+    output_entity_type: str
+    output_value: str
+    output_node_id: str
+    edge_id: str
+    from_entity_type: str
+    from_value: str
+    to_entity_type: str
+    to_value: str
+    edge_type: str
+
+
+@dataclass
+class OSINTCollectionResult:
+    """Structured return value from ``run_osint_collection``."""
+
+    input_entity_type: str
+    input_value: str
+    canonical_input_value: str
+    seed_node_id: str | None
+    collectors_run: list[str] = field(default_factory=list)
+    tuples_collected: int = 0
+    persisted: list[PersistedOSINTTuple] = field(default_factory=list)
+    errors: list[OSINTExecutionError] = field(default_factory=list)
+    started_at: str = field(default_factory=lambda: datetime.now().isoformat())
+    finished_at: str | None = None
+
+    @property
+    def persisted_count(self) -> int:
+        return len(self.persisted)
+
+    @property
+    def error_count(self) -> int:
+        return len(self.errors)
+
+
+_ENDPOINT_PROP_KEYS: dict[str, tuple[str, ...]] = {
+    "ASNumber": ("asn", "number"),
+    "DomainName": ("domain", "value"),
+    "IPv4Address": ("ip", "address", "value"),
+    "IPv6Address": ("ip", "address", "value"),
+    "MXRecord": ("mx", "value", "exchange"),
+    "NSRecord": ("ns", "nsdname", "value"),
+    "Netblock": ("cidr", "netblock", "prefix"),
+    "Organization": ("organization", "org", "name"),
+    "Port": ("port", "value"),
+    "Website": ("url", "website", "value"),
+}
+
+
+def run_osint_collection(
+    input_entity_type: str,
+    input_value: str,
+    *,
+    kg: KnowledgeGraph | None = None,
+    registry: TransformRegistry | None = None,
+    validator: OntologyValidator | None = None,
+    collector_names: Sequence[str] | None = None,
+    persist: bool = True,
+) -> OSINTCollectionResult:
+    """Run registered OSINT collectors for one seed entity.
+
+    Parameters
+    ----------
+    input_entity_type:
+        Seed type. Phase 1.5 supports DomainName, IPv4Address, IPv6Address,
+        ASNumber, and Netblock.
+    input_value:
+        Seed value. It is canonicalized before KG writes.
+    kg:
+        Optional ``KnowledgeGraph`` instance. Defaults to the global KG.
+    registry:
+        Optional collector registry. Defaults to ``TRANSFORM_REGISTRY``.
+    validator:
+        Optional ontology validator.
+    collector_names:
+        Optional allow-list of collector names to run for this seed.
+    persist:
+        When false, collectors and validation run but no KG writes occur.
+    """
+    merge_into_global_ontology()
+
+    if input_entity_type not in SUPPORTED_SEED_TYPES:
+        raise ValueError(
+            f"unsupported OSINT seed type {input_entity_type!r}; "
+            f"expected one of {', '.join(SUPPORTED_SEED_TYPES)}"
+        )
+
+    registry = registry or get_transform_registry()
+    validator = validator or OntologyValidator()
+    kg = kg or get_knowledge_graph()
+    allowed_collectors = None if collector_names is None else set(collector_names)
+
+    canonical_input_value = canonicalise_value(input_entity_type, input_value)
+    seed_props = _entity_properties(input_entity_type, canonical_input_value)
+    _validate_entity_or_raise(validator, input_entity_type, seed_props)
+
+    seed_node_id: str | None = None
+    if persist:
+        seed_node_id, _ = add_resolved(kg, input_entity_type, canonical_input_value, seed_props)
+
+    result = OSINTCollectionResult(
+        input_entity_type=input_entity_type,
+        input_value=input_value,
+        canonical_input_value=canonical_input_value,
+        seed_node_id=seed_node_id,
+    )
+
+    matches = registry.find_by_input(input_entity_type)
+    if allowed_collectors is not None:
+        matches = [(meta, fn) for meta, fn in matches if meta.name in allowed_collectors]
+
+    for meta, fn in matches:
+        result.collectors_run.append(meta.name)
+        try:
+            tuples = fn(input_entity_type, canonical_input_value)
+        except Exception as exc:  # fail-closed; one bad collector cannot abort the run
+            _logger.warning("osint_collector_failed", collector=meta.name, error=str(exc))
+            result.errors.append(OSINTExecutionError(meta.name, str(exc)))
+            continue
+
+        result.tuples_collected += len(tuples)
+        for index, tup in enumerate(tuples):
+            try:
+                _validate_tuple(meta, tup, validator)
+                if persist:
+                    persisted = _persist_tuple(
+                        kg=kg,
+                        validator=validator,
+                        collector=meta,
+                        tup=tup,
+                        input_entity_type=input_entity_type,
+                        canonical_input_value=canonical_input_value,
+                    )
+                    result.persisted.append(persisted)
+            except ValueError as exc:
+                result.errors.append(OSINTExecutionError(meta.name, str(exc), tuple_index=index))
+
+    result.finished_at = datetime.now().isoformat()
+    return result
+
+
+def collect_osint(*args: Any, **kwargs: Any) -> OSINTCollectionResult:
+    """Compatibility alias for agents that prefer verb-first naming."""
+    return run_osint_collection(*args, **kwargs)
+
+
+def _validate_tuple(
+    collector: TransformMetadata,
+    tup: CollectorTuple,
+    validator: OntologyValidator,
+) -> None:
+    output_props = _entity_properties(tup.output_entity_type, tup.output_value, tup.output_props)
+    _validate_entity_or_raise(validator, tup.output_entity_type, output_props)
+
+    ok, errors = validator.validate_relation(
+        tup.from_entity_type, tup.edge_type, tup.to_entity_type
+    )
+    if not ok:
+        raise ValueError(
+            f"{collector.name} emitted invalid relation "
+            f"{tup.from_entity_type} -[{tup.edge_type}]-> {tup.to_entity_type}: "
+            + "; ".join(errors)
+        )
+
+
+def _persist_tuple(
+    *,
+    kg: KnowledgeGraph,
+    validator: OntologyValidator,
+    collector: TransformMetadata,
+    tup: CollectorTuple,
+    input_entity_type: str,
+    canonical_input_value: str,
+) -> PersistedOSINTTuple:
+    output_value = canonicalise_value(tup.output_entity_type, tup.output_value)
+    output_props = _entity_properties(tup.output_entity_type, output_value, tup.output_props)
+
+    from_value = _derive_endpoint_value(tup, "from", input_entity_type, canonical_input_value)
+    to_value = _derive_endpoint_value(tup, "to", input_entity_type, canonical_input_value)
+
+    from_props = _endpoint_properties(tup.from_entity_type, from_value, tup, input_entity_type)
+    to_props = _endpoint_properties(tup.to_entity_type, to_value, tup, input_entity_type)
+    _validate_entity_or_raise(validator, tup.from_entity_type, from_props)
+    _validate_entity_or_raise(validator, tup.to_entity_type, to_props)
+
+    output_node_id, _ = add_resolved(kg, tup.output_entity_type, output_value, output_props)
+    add_resolved(kg, tup.from_entity_type, from_value, from_props)
+    add_resolved(kg, tup.to_entity_type, to_value, to_props)
+
+    edge_props = dict(tup.edge_props)
+    edge_props.setdefault("collector", collector.name)
+    edge_props.setdefault("source", collector.name)
+    edge_props.setdefault("osint", True)
+    edge_props.setdefault("edge_type", "osint")
+
+    edge_id = kg.add_edge(
+        tup.from_entity_type,
+        from_value,
+        tup.to_entity_type,
+        to_value,
+        tup.edge_type,
+        edge_props,
+    )
+
+    return PersistedOSINTTuple(
+        collector_name=collector.name,
+        output_entity_type=tup.output_entity_type,
+        output_value=output_value,
+        output_node_id=output_node_id,
+        edge_id=edge_id,
+        from_entity_type=tup.from_entity_type,
+        from_value=from_value,
+        to_entity_type=tup.to_entity_type,
+        to_value=to_value,
+        edge_type=tup.edge_type,
+    )
+
+
+def _derive_endpoint_value(
+    tup: CollectorTuple,
+    side: str,
+    input_entity_type: str,
+    canonical_input_value: str,
+) -> str:
+    if side == "from":
+        endpoint_type = tup.from_entity_type
+        if endpoint_type == input_entity_type:
+            return canonical_input_value
+        if endpoint_type == tup.output_entity_type:
+            return canonicalise_value(endpoint_type, tup.output_value)
+    elif side == "to":
+        endpoint_type = tup.to_entity_type
+        if endpoint_type == tup.output_entity_type:
+            return canonicalise_value(endpoint_type, tup.output_value)
+        if endpoint_type == input_entity_type:
+            return canonical_input_value
+    else:
+        raise ValueError(f"unknown endpoint side {side!r}")
+
+    for key in _ENDPOINT_PROP_KEYS.get(endpoint_type, ("value",)):
+        raw = tup.edge_props.get(key) or tup.output_props.get(key)
+        if raw not in (None, ""):
+            return canonicalise_value(endpoint_type, str(raw))
+
+    raise ValueError(
+        f"cannot derive {side} endpoint value for {endpoint_type} from collector tuple "
+        f"{tup!r}; add an explicit edge property such as cidr/asn/value"
+    )
+
+
+def _endpoint_properties(
+    entity_type: str,
+    value: str,
+    tup: CollectorTuple,
+    input_entity_type: str,
+) -> dict[str, Any]:
+    if entity_type == tup.output_entity_type:
+        return _entity_properties(entity_type, value, tup.output_props)
+    return _entity_properties(entity_type, value)
+
+
+def _entity_properties(
+    entity_type: str,
+    value: str,
+    incoming: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    props = dict(incoming or {})
+    canonical = canonicalise_value(entity_type, value)
+
+    if entity_type in ("DomainName", "IPv4Address", "IPv6Address", "URL"):
+        props.setdefault("value", canonical)
+    elif entity_type == "ASNumber":
+        props.setdefault("number", int(canonical))
+    elif entity_type == "Netblock":
+        props.setdefault("cidr", canonical)
+    elif entity_type == "Organization":
+        props.setdefault("name", canonical)
+    elif entity_type == "NSRecord":
+        props.setdefault("nsdname", canonical)
+    elif entity_type == "MXRecord":
+        if "priority" not in props or "exchange" not in props:
+            priority, _, exchange = canonical.partition(" ")
+            if priority and exchange:
+                props.setdefault("priority", int(priority))
+                props.setdefault("exchange", exchange)
+    elif entity_type == "Port":
+        if "number" not in props or "protocol" not in props:
+            number, _, protocol = canonical.partition("/")
+            if number and protocol:
+                props.setdefault("number", int(number))
+                props.setdefault("protocol", protocol)
+    elif entity_type == "Website":
+        props.setdefault("url", canonical)
+
+    return props
+
+
+def _validate_entity_or_raise(
+    validator: OntologyValidator,
+    entity_type: str,
+    properties: dict[str, Any],
+) -> None:
+    ok, errors = validator.validate_entity(entity_type, properties)
+    if not ok:
+        raise ValueError(f"invalid {entity_type} properties: " + "; ".join(errors))
+
+
+__all__ = [
+    "SUPPORTED_SEED_TYPES",
+    "OSINTCollectionResult",
+    "OSINTExecutionError",
+    "PersistedOSINTTuple",
+    "collect_osint",
+    "run_osint_collection",
+]

--- a/src/zettelforge/osint/executor.py
+++ b/src/zettelforge/osint/executor.py
@@ -186,6 +186,15 @@ def run_osint_collection(
                         canonical_input_value=canonical_input_value,
                     )
                     result.persisted.append(persisted)
+                else:
+                    from_value = _derive_endpoint_value(
+                        tup, "from", input_entity_type, canonical_input_value
+                    )
+                    to_value = _derive_endpoint_value(tup, "to", input_entity_type, canonical_input_value)
+                    from_props = _endpoint_properties(tup.from_entity_type, from_value, tup, input_entity_type)
+                    to_props = _endpoint_properties(tup.to_entity_type, to_value, tup, input_entity_type)
+                    _validate_entity_or_raise(validator, tup.from_entity_type, from_props)
+                    _validate_entity_or_raise(validator, tup.to_entity_type, to_props)
             except ValueError as exc:
                 result.errors.append(OSINTExecutionError(meta.name, str(exc), tuple_index=index))
 

--- a/src/zettelforge/osint/executor.py
+++ b/src/zettelforge/osint/executor.py
@@ -23,7 +23,7 @@ from typing import Any
 
 from zettelforge.knowledge_graph import KnowledgeGraph, get_knowledge_graph
 from zettelforge.log import get_logger
-from zettelforge.ontology import OntologyValidator
+from zettelforge.ontology import RELATION_TYPES, OntologyValidator
 from zettelforge.osint.entity_resolver import add_resolved, canonicalise_value
 from zettelforge.osint.ontology import merge_into_global_ontology
 from zettelforge.osint.transform_registry import (
@@ -175,7 +175,13 @@ def run_osint_collection(
         result.tuples_collected += len(tuples)
         for index, tup in enumerate(tuples):
             try:
-                _validate_tuple(meta, tup, validator)
+                _validate_tuple(
+                    meta,
+                    tup,
+                    validator,
+                    input_entity_type,
+                    canonical_input_value,
+                )
                 if persist:
                     persisted = _persist_tuple(
                         kg=kg,
@@ -190,9 +196,15 @@ def run_osint_collection(
                     from_value = _derive_endpoint_value(
                         tup, "from", input_entity_type, canonical_input_value
                     )
-                    to_value = _derive_endpoint_value(tup, "to", input_entity_type, canonical_input_value)
-                    from_props = _endpoint_properties(tup.from_entity_type, from_value, tup, input_entity_type)
-                    to_props = _endpoint_properties(tup.to_entity_type, to_value, tup, input_entity_type)
+                    to_value = _derive_endpoint_value(
+                        tup, "to", input_entity_type, canonical_input_value
+                    )
+                    from_props = _endpoint_properties(
+                        tup.from_entity_type, from_value, tup, input_entity_type
+                    )
+                    to_props = _endpoint_properties(
+                        tup.to_entity_type, to_value, tup, input_entity_type
+                    )
                     _validate_entity_or_raise(validator, tup.from_entity_type, from_props)
                     _validate_entity_or_raise(validator, tup.to_entity_type, to_props)
             except ValueError as exc:
@@ -211,9 +223,27 @@ def _validate_tuple(
     collector: TransformMetadata,
     tup: CollectorTuple,
     validator: OntologyValidator,
+    input_entity_type: str,
+    canonical_input_value: str,
 ) -> None:
     output_props = _entity_properties(tup.output_entity_type, tup.output_value, tup.output_props)
     _validate_entity_or_raise(validator, tup.output_entity_type, output_props)
+
+    if tup.edge_type not in RELATION_TYPES and tup.edge_type not in validator.custom_relations:
+        raise ValueError(
+            f"{collector.name} emitted unregistered relation "
+            f"{tup.from_entity_type} -[{tup.edge_type}]-> {tup.to_entity_type}"
+        )
+
+    if (tup.output_entity_type, tup.edge_type) not in collector.output_types:
+        allowed = (
+            ", ".join(f"{entity}:{edge}" for entity, edge in collector.output_types) or "<none>"
+        )
+        raise ValueError(
+            f"{collector.name} emitted undeclared tuple "
+            f"{tup.output_entity_type} -[{tup.edge_type}]-> {tup.to_entity_type}; "
+            f"allowed outputs: {allowed}"
+        )
 
     ok, errors = validator.validate_relation(
         tup.from_entity_type, tup.edge_type, tup.to_entity_type
@@ -224,6 +254,13 @@ def _validate_tuple(
             f"{tup.from_entity_type} -[{tup.edge_type}]-> {tup.to_entity_type}: "
             + "; ".join(errors)
         )
+
+    _validate_tuple_endpoints(
+        tup=tup,
+        validator=validator,
+        input_entity_type=input_entity_type,
+        canonical_input_value=canonical_input_value,
+    )
 
 
 def _persist_tuple(
@@ -237,14 +274,14 @@ def _persist_tuple(
 ) -> PersistedOSINTTuple:
     output_value = canonicalise_value(tup.output_entity_type, tup.output_value)
     output_props = _entity_properties(tup.output_entity_type, output_value, tup.output_props)
-
-    from_value = _derive_endpoint_value(tup, "from", input_entity_type, canonical_input_value)
-    to_value = _derive_endpoint_value(tup, "to", input_entity_type, canonical_input_value)
-
+    from_value, to_value = _validate_tuple_endpoints(
+        tup=tup,
+        validator=validator,
+        input_entity_type=input_entity_type,
+        canonical_input_value=canonical_input_value,
+    )
     from_props = _endpoint_properties(tup.from_entity_type, from_value, tup, input_entity_type)
     to_props = _endpoint_properties(tup.to_entity_type, to_value, tup, input_entity_type)
-    _validate_entity_or_raise(validator, tup.from_entity_type, from_props)
-    _validate_entity_or_raise(validator, tup.to_entity_type, to_props)
 
     output_node_id, _ = add_resolved(kg, tup.output_entity_type, output_value, output_props)
     add_resolved(kg, tup.from_entity_type, from_value, from_props)
@@ -277,6 +314,23 @@ def _persist_tuple(
         to_value=to_value,
         edge_type=tup.edge_type,
     )
+
+
+def _validate_tuple_endpoints(
+    *,
+    tup: CollectorTuple,
+    validator: OntologyValidator,
+    input_entity_type: str,
+    canonical_input_value: str,
+) -> tuple[str, str]:
+    from_value = _derive_endpoint_value(tup, "from", input_entity_type, canonical_input_value)
+    to_value = _derive_endpoint_value(tup, "to", input_entity_type, canonical_input_value)
+
+    from_props = _endpoint_properties(tup.from_entity_type, from_value, tup, input_entity_type)
+    to_props = _endpoint_properties(tup.to_entity_type, to_value, tup, input_entity_type)
+    _validate_entity_or_raise(validator, tup.from_entity_type, from_props)
+    _validate_entity_or_raise(validator, tup.to_entity_type, to_props)
+    return from_value, to_value
 
 
 def _derive_endpoint_value(

--- a/tests/test_osint_entity_resolver.py
+++ b/tests/test_osint_entity_resolver.py
@@ -38,6 +38,11 @@ def test_add_resolved_registers_alias_for_existing_node(tmp_path, monkeypatch) -
     assert node['properties']['value'] == 'example.com'
     assert node['properties']['source'] == 'unit-test'
 
+    reloaded = KnowledgeGraph(data_dir=str(tmp_path))
+    reloaded_node = reloaded.get_node('DomainName', 'example.com')
+    assert reloaded_node is not None
+    assert reloaded_node['properties']['source'] == 'unit-test'
+
 
 def test_canonicalise_organization_normalizes_case_and_whitespace() -> None:
     assert entity_resolver.canonicalise_value('Organization', ' Example  Corp ') == 'example corp'

--- a/tests/test_osint_entity_resolver.py
+++ b/tests/test_osint_entity_resolver.py
@@ -1,0 +1,79 @@
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+import pytest
+
+from zettelforge import osint as _osint  # noqa: F401 -- side effects
+from zettelforge.knowledge_graph import KnowledgeGraph
+from zettelforge.osint import entity_resolver
+
+
+def test_add_resolved_registers_alias_for_existing_node(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    node_id, created = entity_resolver.add_resolved(
+        kg,
+        'DomainName',
+        'example.com',
+        {'value': 'example.com'},
+    )
+    assert created is True
+
+    resolved_id, created_again = entity_resolver.add_resolved(
+        kg,
+        'DomainName',
+        'Example.COM.',
+        {'value': 'example.com', 'source': 'unit-test'},
+    )
+    assert resolved_id == node_id
+    assert created_again is False
+    assert kg._osint_alias_reverse['Example.COM.'] == 'DomainName:example.com'
+    assert entity_resolver.resolve('DomainName', 'Example.COM.', kg=kg) == node_id
+
+    node = kg.get_node('DomainName', 'example.com')
+    assert node is not None
+    assert node['properties']['value'] == 'example.com'
+    assert node['properties']['source'] == 'unit-test'
+
+
+def test_canonicalise_organization_normalizes_case_and_whitespace() -> None:
+    assert entity_resolver.canonicalise_value('Organization', ' Example  Corp ') == 'example corp'
+
+
+@pytest.mark.parametrize(
+    ('entity_type', 'raw', 'expected'),
+    [
+        ('URL', 'HTTPS://Example.com/path', 'https://example.com/path'),
+        ('Website', 'HTTP://Example.com', 'http://example.com/'),
+        ('NSRecord', 'NS1.Example.com.', 'ns1.example.com'),
+        ('MXRecord', '10 MX.Example.com.', '10 mx.example.com'),
+        ('Port', '443/TCp', '443/tcp'),
+        ('WebTitle', 'HTTPS://Example.com/:: Title ', 'https://example.com/::Title'),
+    ],
+)
+def test_canonicalise_value_covers_common_osint_node_shapes(
+    entity_type: str,
+    raw: str,
+    expected: str,
+) -> None:
+    assert entity_resolver.canonicalise_value(entity_type, raw) == expected
+
+
+def test_add_resolved_scopes_aliases_to_each_knowledge_graph(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg_one = KnowledgeGraph(data_dir=str(tmp_path / 'one'))
+    kg_two = KnowledgeGraph(data_dir=str(tmp_path / 'two'))
+
+    node_one, created_one = entity_resolver.add_resolved(kg_one, 'DomainName', 'example.com')
+    node_two, created_two = entity_resolver.add_resolved(kg_two, 'DomainName', 'example.com')
+
+    assert created_one is True
+    assert created_two is True
+    assert node_one != node_two
+    assert entity_resolver.resolve('DomainName', 'example.com', kg=kg_one) == node_one
+    assert entity_resolver.resolve('DomainName', 'example.com', kg=kg_two) == node_two

--- a/tests/test_osint_executor.py
+++ b/tests/test_osint_executor.py
@@ -1,0 +1,197 @@
+# ruff: noqa: S101
+
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from zettelforge import osint as _osint  # noqa: F401 -- side effects
+from zettelforge.knowledge_graph import KnowledgeGraph
+from zettelforge.osint import entity_resolver
+from zettelforge.osint.collectors.infrastructure import bgp_collector
+from zettelforge.osint.executor import run_osint_collection
+from zettelforge.osint.transform_registry import (
+    CollectorTuple,
+    TransformMetadata,
+    TransformRegistry,
+)
+
+
+def _fake_dns_collect(input_entity_type: str, input_value: str) -> list[CollectorTuple]:
+    assert input_entity_type == 'DomainName'
+    assert input_value == 'example.com'
+    return [
+        CollectorTuple(
+            output_entity_type='IPv4Address',
+            output_value='1.2.3.4',
+            edge_type='resolves_to',
+            from_entity_type='DomainName',
+            to_entity_type='IPv4Address',
+            output_props={'value': '1.2.3.4'},
+            edge_props={'source': 'unit-test'},
+        )
+    ]
+
+
+def _boom_collect(input_entity_type: str, input_value: str) -> list[CollectorTuple]:
+    raise RuntimeError('collector boom')
+
+
+def test_run_osint_collection_persists_nodes_and_edges(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    registry = TransformRegistry()
+    registry.register(
+        TransformMetadata(
+            name='fake_dns',
+            description='Fake DNS collector for executor tests.',
+            input_types=('DomainName',),
+            output_types=(('IPv4Address', 'resolves_to'),),
+        ),
+        _fake_dns_collect,
+    )
+
+    result = run_osint_collection('DomainName', 'Example.COM.', kg=kg, registry=registry)
+
+    assert result.collectors_run == ['fake_dns']
+    assert result.canonical_input_value == 'example.com'
+    assert result.error_count == 0
+    assert result.persisted_count == 1
+    assert result.seed_node_id is not None
+    assert result.persisted[0].output_value == '1.2.3.4'
+
+    seed = kg.get_node('DomainName', 'example.com')
+    target = kg.get_node('IPv4Address', '1.2.3.4')
+    assert seed is not None
+    assert target is not None
+
+    neighbors = kg.get_neighbors('DomainName', 'example.com', 'resolves_to')
+    assert [item['node']['entity_value'] for item in neighbors] == ['1.2.3.4']
+
+
+def test_run_osint_collection_records_nonfatal_collector_errors(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    registry = TransformRegistry()
+    registry.register(
+        TransformMetadata(
+            name='boom',
+            description='Failing collector used to verify fail-closed handling.',
+            input_types=('DomainName',),
+            output_types=(('IPv4Address', 'resolves_to'),),
+        ),
+        _boom_collect,
+    )
+    registry.register(
+        TransformMetadata(
+            name='fake_dns',
+            description='Fake DNS collector for executor tests.',
+            input_types=('DomainName',),
+            output_types=(('IPv4Address', 'resolves_to'),),
+        ),
+        _fake_dns_collect,
+    )
+
+    result = run_osint_collection('DomainName', 'example.com', kg=kg, registry=registry)
+
+    assert result.collectors_run == ['boom', 'fake_dns']
+    assert result.error_count == 1
+    assert result.errors[0].collector_name == 'boom'
+    assert result.persisted_count == 1
+    assert result.tuples_collected == 1
+
+
+def test_run_osint_collection_respects_empty_allowlist(tmp_path, monkeypatch) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    registry = TransformRegistry()
+    registry.register(
+        TransformMetadata(
+            name='fake_dns',
+            description='Fake DNS collector for executor tests.',
+            input_types=('DomainName',),
+            output_types=(('IPv4Address', 'resolves_to'),),
+        ),
+        _fake_dns_collect,
+    )
+
+    result = run_osint_collection(
+        'DomainName',
+        'example.com',
+        kg=kg,
+        registry=registry,
+        collector_names=[],
+    )
+
+    assert result.collectors_run == []
+    assert result.tuples_collected == 0
+    assert result.error_count == 0
+    assert result.persisted_count == 0
+    assert result.seed_node_id is not None
+    assert kg.get_neighbors('DomainName', 'example.com', 'resolves_to') == []
+
+
+def _invalid_endpoint_collect(input_entity_type: str, input_value: str) -> list[CollectorTuple]:
+    return [
+        CollectorTuple(
+            output_entity_type='Organization',
+            output_value='Example Corp',
+            edge_type='owned_by',
+            from_entity_type='Netblock',
+            to_entity_type='Organization',
+            output_props={'name': 'Example Corp'},
+            edge_props={'cidr': 'not-a-cidr'},
+        )
+    ]
+
+
+def test_run_osint_collection_does_not_persist_partial_tuple_on_invalid_endpoint(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    registry = TransformRegistry()
+    registry.register(
+        TransformMetadata(
+            name='invalid_endpoint',
+            description='Collector that emits an invalid endpoint payload.',
+            input_types=('ASNumber',),
+            output_types=(('Organization', 'owned_by'),),
+        ),
+        _invalid_endpoint_collect,
+    )
+
+    result = run_osint_collection('ASNumber', 'AS15169', kg=kg, registry=registry)
+
+    assert result.collectors_run == ['invalid_endpoint']
+    assert result.error_count == 1
+    assert result.persisted_count == 0  # seed writes are not counted in the result
+    assert result.seed_node_id is not None
+    assert kg.get_node('Organization', 'example corp') is None
+    assert kg.get_neighbors('ASNumber', '15169', 'owned_by') == []
+
+
+def test_bgp_collector_emits_netblocks_from_asn() -> None:
+    payload = {
+        'owner': {'name': 'Google LLC'},
+        'prefixes': [
+            {'prefix': '8.8.8.0/24'},
+            {'prefix': '8.8.4.0/24'},
+            {'prefix': 'invalid'},
+        ],
+    }
+    with patch.object(bgp_collector, '_bgpview_get', return_value=payload):
+        out = bgp_collector.collect('ASNumber', 'AS15169')
+
+    assert [item.output_value for item in out] == ['8.8.8.0/24', '8.8.4.0/24']
+    assert all(item.from_entity_type == 'Netblock' for item in out)
+    assert all(item.to_entity_type == 'ASNumber' for item in out)
+    assert all(item.output_props['org'] == 'Google LLC' for item in out)

--- a/tests/test_osint_executor.py
+++ b/tests/test_osint_executor.py
@@ -150,6 +150,20 @@ def _invalid_endpoint_collect(input_entity_type: str, input_value: str) -> list[
     ]
 
 
+def _typo_relation_collect(input_entity_type: str, input_value: str) -> list[CollectorTuple]:
+    return [
+        CollectorTuple(
+            output_entity_type='IPv4Address',
+            output_value='1.2.3.4',
+            edge_type='reslove_to',
+            from_entity_type='DomainName',
+            to_entity_type='IPv4Address',
+            output_props={'value': '1.2.3.4'},
+            edge_props={},
+        )
+    ]
+
+
 def test_run_osint_collection_does_not_persist_partial_tuple_on_invalid_endpoint(
     tmp_path,
     monkeypatch,
@@ -177,6 +191,69 @@ def test_run_osint_collection_does_not_persist_partial_tuple_on_invalid_endpoint
     assert result.seed_node_id is not None
     assert kg.get_node('Organization', 'example corp') is None
     assert kg.get_neighbors('ASNumber', '15169', 'owned_by') == []
+
+
+def test_run_osint_collection_validates_endpoints_in_dry_run(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    registry = TransformRegistry()
+    registry.register(
+        TransformMetadata(
+            name='invalid_endpoint',
+            description='Collector that emits an invalid endpoint payload.',
+            input_types=('ASNumber',),
+            output_types=(('Organization', 'owned_by'),),
+        ),
+        _invalid_endpoint_collect,
+    )
+
+    result = run_osint_collection(
+        'ASNumber',
+        'AS15169',
+        kg=kg,
+        registry=registry,
+        persist=False,
+    )
+
+    assert result.collectors_run == ['invalid_endpoint']
+    assert result.error_count == 1
+    assert result.persisted_count == 0
+    assert result.seed_node_id is None
+    assert kg.get_node('Organization', 'example corp') is None
+    assert kg.get_neighbors('ASNumber', '15169', 'owned_by') == []
+
+
+def test_run_osint_collection_rejects_unregistered_relation_even_when_metadata_matches(
+    tmp_path,
+    monkeypatch,
+) -> None:
+    monkeypatch.setattr(entity_resolver, '_ALIAS_INDEX', {})
+    monkeypatch.setattr(entity_resolver, '_ALIAS_REVERSE', {})
+
+    kg = KnowledgeGraph(data_dir=str(tmp_path))
+    registry = TransformRegistry()
+    registry.register(
+        TransformMetadata(
+            name='typo_relation',
+            description='Collector that emits a typo relation.',
+            input_types=('DomainName',),
+            output_types=(('IPv4Address', 'reslove_to'),),
+        ),
+        _typo_relation_collect,
+    )
+
+    result = run_osint_collection('DomainName', 'example.com', kg=kg, registry=registry)
+
+    assert result.collectors_run == ['typo_relation']
+    assert result.error_count == 1
+    assert result.persisted_count == 0
+    assert result.seed_node_id is not None
+    assert kg.get_neighbors('DomainName', 'example.com', 'reslove_to') == []
 
 
 def test_bgp_collector_emits_netblocks_from_asn() -> None:


### PR DESCRIPTION
Implements RFC-016 Phase 1.5 OSINT ingest:

- adds a passive OSINT executor that validates collector tuples and persists KG writes
- scopes OSINT alias caching to each KnowledgeGraph instance
- canonicalizes Organization values to avoid WHOIS/RDAP duplicates
- treats an explicit empty collector allow-list as empty
- adds user-facing passive OSINT docs and mkdocs navigation
- adds focused regression tests for resolver scoping, empty allow-lists, and partial-write protection

Verification:
- pytest -q
- mkdocs build --strict -q
- ruff check on touched source and test files