### PR TITLE
feat(kg): standalone Neo4j sync/population job [AGE-121]

### DIFF
--- a/docs/how-to/configure-neo4j.md
+++ b/docs/how-to/configure-neo4j.md
@@ -110,6 +110,76 @@ path = find_shortest_path("ThreatActor", "APT28", "Vulnerability", "CVE-2017-014
 print(path)
 ```
 
+## Populate / sync the graph
+
+The path-query seam **queries** Neo4j but deliberately does **not** dual-write
+from the ingest hot path (that regressed the SQLite write/recall path). So with
+pathfinding enabled and an unpopulated Neo4j, path queries run against an empty
+graph. A standalone job mirrors the SQLite knowledge graph into Neo4j:
+
+```bash
+# Preview: read the source graph, connect read-only, report the delta (no writes)
+python -m zettelforge.scripts.neo4j_sync --data-dir ~/.zettelforge --dry-run
+
+# Incremental upsert (default) — safe to run repeatedly / on a schedule
+python -m zettelforge.scripts.neo4j_sync --data-dir ~/.zettelforge
+
+# Exact mirror: wipe the ZettelForge graph then reload (deletions included)
+python -m zettelforge.scripts.neo4j_sync --data-dir ~/.zettelforge --rebuild
+```
+
+The job reads `ZETTELFORGE_NEO4J_*` for the connection and emits a JSON report
+(node/edge counts before and after, plus a parity verdict); pass `--output` to
+also write it to a file. It populates Neo4j regardless of
+`ZETTELFORGE_NEO4J_PATHFINDING` (the gate controls query routing, not whether
+Neo4j may be loaded).
+
+### Consistency / staleness contract
+
+* **SQLite is the system of record.** Neo4j is a derived read-replica used only
+  by the path-query seam. The job is one-way (SQLite to Neo4j) and never writes
+  back.
+* **Default is incremental upsert.** Every current node/edge is MERGEd
+  (idempotent on `(entity_type, entity_value)` for nodes and
+  `(from, to, relationship)` for edges). The live graph is never emptied and is
+  always a superset-or-equal of SQLite. Upsert does **not** delete: entities or
+  edges removed from SQLite remain in Neo4j (the SQLite graph is append-mostly
+  and carries no deletion log).
+* **`--rebuild` is the exact mirror.** It deletes only `:Entity` nodes and their
+  `:REL` edges (in bounded sub-transactions), then reloads, so deletions
+  propagate. During a rebuild the graph is transiently partial: prefer it on a
+  quiesced window. Incremental upsert is the safe default for a live seam.
+* **Staleness.** Neo4j reflects SQLite as of the last successful sync; path
+  queries may miss edges added since. Bound staleness by scheduling the job, or
+  run it on demand for an immediate refresh. Because SQLite stays the system of
+  record, a stale or empty Neo4j only affects the opt-in path-query seam, never
+  storage or recall.
+* **Fail-loud.** A connection failure during a mutating run exits non-zero
+  (never reports a dropped sync as success). After the load, Neo4j counts are
+  verified against the source; a mismatch exits non-zero.
+
+### Schedule it
+
+The job is a plain idempotent command, so any scheduler works. Example systemd
+timer running an hourly incremental upsert:
+
+```ini
+# /etc/systemd/system/zettelforge-neo4j-sync.service
+[Service]
+Type=oneshot
+Environment=ZETTELFORGE_NEO4J_PASSWORD=...
+ExecStart=/usr/bin/python -m zettelforge.scripts.neo4j_sync --data-dir /var/lib/zettelforge
+
+# /etc/systemd/system/zettelforge-neo4j-sync.timer
+[Timer]
+OnCalendar=hourly
+Persistent=true
+[Install]
+WantedBy=timers.target
+```
+
+Equivalently as cron: `@hourly python -m zettelforge.scripts.neo4j_sync --data-dir /var/lib/zettelforge`.
+
 ## Failure behavior
 
 When Neo4j is unreachable or the credentials are wrong, `find_shortest_path`

--- a/docs/how-to/troubleshoot.md
+++ b/docs/how-to/troubleshoot.md
@@ -281,6 +281,7 @@ Tooling:
 | `python -m zettelforge.scripts.telemetry_aggregator --date YYYY-MM-DD` | Daily summary report (latency averages, tier distribution, unused notes, top utility notes) |
 | `python -m zettelforge.scripts.human_eval_sampler` | Sample 20 random synthesis briefings for the monthly human evaluation rubric (see `docs/human-evaluation-rubric.md`) |
 | `streamlit run src/zettelforge/scripts/telemetry_dashboard.py` | Optional visualization (query volume, latency p50/p95, tier/utility trends, unused notes warning) |
+| `python -m zettelforge.scripts.neo4j_sync --data-dir DIR [--rebuild\|--dry-run]` | Populate/sync the Neo4j path-query graph from SQLite (incremental upsert by default; see `docs/how-to/configure-neo4j.md`) |
 
 Raw note content is never persisted in telemetry — only IDs, tiers,
 source types, and domains. Query text is truncated to 200 chars at INFO

--- a/src/zettelforge/scripts/neo4j_sync.py
+++ b/src/zettelforge/scripts/neo4j_sync.py
@@ -1,0 +1,374 @@
+#!/usr/bin/env python3
+"""Standalone Neo4j sync/population job for the path-query backend (AGE-121).
+
+Follow-up to the AGE-117 path-query seam. ``find_shortest_path()`` routes
+undirected path-finding to Neo4j when ``ZETTELFORGE_NEO4J_PATHFINDING=true``,
+but the seam deliberately does NOT dual-write from the hot path (that regressed
+the SQLite write/recall path). So with pathfinding enabled and an unpopulated
+Neo4j, path queries run against an empty graph. This job populates/syncs the
+Neo4j graph from the default backend's knowledge graph (entities + edges).
+
+Consistency / staleness contract
+---------------------------------
+* SQLite (``kg_nodes`` / ``kg_edges``) is the system of record. Neo4j is a
+  DERIVED read-replica used only by the path-query seam. This job is one-way:
+  SQLite -> Neo4j. It never writes back to SQLite.
+* Default mode is INCREMENTAL UPSERT: every current node/edge is MERGEd into
+  Neo4j (idempotent on ``(entity_type, entity_value)`` for nodes and
+  ``(from, to, relationship)`` for edges, matching the backend's own write
+  identity). The live graph is never emptied and is always a superset-or-equal
+  of SQLite. Upsert does NOT delete: entities/edges removed from SQLite remain
+  in Neo4j (the SQLite graph is append-mostly and carries no deletion log).
+* ``--rebuild`` does a scoped clean-slate (deletes only ``:Entity`` nodes and
+  their ``:REL`` edges, in bounded sub-transactions) then re-loads. Use it for
+  an EXACT mirror including deletions. Note: during a rebuild the graph is
+  transiently partial, so prefer it on a quiesced window; incremental upsert is
+  the safe default for a live seam.
+* Staleness: Neo4j reflects SQLite as of the last successful sync. Path queries
+  may miss edges added since. Schedule this job (cron / systemd timer) to bound
+  staleness, or run on demand for an immediate refresh. SQLite stays the system
+  of record either way, so a stale or empty Neo4j only affects the opt-in
+  path-query seam, never storage or recall.
+
+Fail-loud (Law 4): a connection/auth failure raises ``Neo4jUnavailableError``
+and the job exits non-zero (never reports a dropped sync as success). After a
+mutating load the Neo4j node/edge counts are verified against the source; a
+mismatch exits non-zero.
+
+Usage::
+
+    # Preview: read source, connect read-only, report the delta (no writes)
+    python -m zettelforge.scripts.neo4j_sync --data-dir ~/.zettelforge --dry-run
+
+    # Incremental upsert (default) — safe to run repeatedly / on a schedule
+    python -m zettelforge.scripts.neo4j_sync --data-dir ~/.zettelforge
+
+    # Exact mirror: wipe the ZettelForge graph then reload (deletions included)
+    python -m zettelforge.scripts.neo4j_sync --data-dir ~/.zettelforge --rebuild
+
+Connection settings come from the standard ``ZETTELFORGE_NEO4J_*`` environment
+(``ZETTELFORGE_NEO4J_URI`` / ``_USER`` / ``_PASSWORD`` / ``_DATABASE``); this
+job populates Neo4j regardless of ``ZETTELFORGE_NEO4J_PATHFINDING`` (the gate
+controls whether queries are routed to Neo4j, not whether it may be populated).
+
+A JSON report is emitted to stdout and, with ``--output``, to a file.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import sys
+from datetime import datetime
+from typing import TYPE_CHECKING, Any
+
+from zettelforge.log import get_logger
+
+if TYPE_CHECKING:
+    from zettelforge.neo4j_knowledge_graph import Neo4jKnowledgeGraph
+    from zettelforge.sqlite_backend import SQLiteBackend
+
+_logger = get_logger("zettelforge.scripts.neo4j_sync")
+
+
+# ── Source read ────────────────────────────────────────────────────────────
+
+
+def read_source_graph(backend: SQLiteBackend) -> dict[str, Any]:
+    """Read the full KG from the SQLite system of record.
+
+    Returns a dict with the node rows, the edge rows DEDUPED to the Neo4j
+    write identity ``(from, to, relationship)``, and the orphan-edge count
+    (edges dropped because an endpoint node is missing). Deduping here means
+    the reported ``edges`` count equals the number of ``:REL`` relationships
+    the load will produce, so the post-load parity check is exact.
+    """
+    nodes = backend.get_all_kg_nodes()
+    raw_edges = backend.get_all_kg_edges()
+    _, total_edges = backend.count_kg()
+
+    deduped: dict[tuple[str, str, str, str, str], dict[str, Any]] = {}
+    for e in raw_edges:
+        key = (e["from_type"], e["from_value"], e["to_type"], e["to_value"], e["relationship"])
+        # Last writer wins, mirroring the backend's MERGE-on-identity semantics.
+        deduped[key] = e
+
+    return {
+        "nodes": nodes,
+        "edges": list(deduped.values()),
+        # Edges whose endpoints are missing from kg_nodes: dropped by the INNER
+        # JOIN. Surfaced so a graph with dangling edges is visible, not silent.
+        "orphan_edges": total_edges - len(raw_edges),
+    }
+
+
+# ── Neo4j load ──────────────────────────────────────────────────────────────
+
+
+def _wipe_entity_graph(kg: Neo4jKnowledgeGraph, batch_size: int) -> None:
+    """Delete only ``:Entity`` nodes and their ``:REL`` edges, in batches.
+
+    Scoped so the job never nukes unrelated data sharing the database. A single
+    ``DETACH DELETE`` can exhaust the transaction memory pool on a large graph
+    (silently leaving stale nodes), so deletion runs in bounded sub-transactions.
+    """
+    driver = kg._get_driver()
+    with driver.session(database=kg._database) as session:
+        session.run(
+            "MATCH (n:Entity) CALL { WITH n DETACH DELETE n } "
+            f"IN TRANSACTIONS OF {int(batch_size)} ROWS"
+        ).consume()
+        rec = session.run("MATCH (n:Entity) RETURN count(n) AS c").single()
+        remaining = rec["c"] if rec else 0
+        if remaining:
+            raise RuntimeError(
+                f"Neo4j not clean after rebuild wipe: {remaining} :Entity nodes remain"
+            )
+
+
+def _load_graph(kg: Neo4jKnowledgeGraph, source: dict[str, Any], batch_size: int) -> None:
+    """UNWIND-batch MERGE the source nodes then edges into Neo4j (idempotent).
+
+    Node ids / edge ids and ``created_at`` come from the source so re-runs are
+    deterministic and cross-store traceable; ``updated_at`` stamps this sync.
+    Properties are JSON-encoded to match the backend's on-graph encoding.
+    """
+    now = datetime.now().isoformat()
+    node_rows = [
+        {
+            "t": n["entity_type"],
+            "v": n["entity_value"],
+            "nid": n["node_id"],
+            "props": json.dumps(n.get("properties") or {}),
+            "created": n.get("created_at") or now,
+            "now": now,
+        }
+        for n in source["nodes"]
+    ]
+    edge_rows = [
+        {
+            "ft": e["from_type"],
+            "fv": e["from_value"],
+            "tt": e["to_type"],
+            "tv": e["to_value"],
+            "rel": e["relationship"],
+            "eid": e["edge_id"],
+            "etype": e.get("edge_type") or "heuristic",
+            "note_id": e.get("note_id") or "",
+            "props": json.dumps(e.get("properties") or {}),
+            "now": now,
+        }
+        for e in source["edges"]
+    ]
+
+    bs = max(1, int(batch_size))
+    driver = kg._get_driver()
+    with driver.session(database=kg._database) as session:
+        for i in range(0, len(node_rows), bs):
+            session.run(
+                "UNWIND $rows AS row "
+                "MERGE (n:Entity {entity_type: row.t, entity_value: row.v}) "
+                "ON CREATE SET n.node_id = row.nid, n.properties = row.props, "
+                "n.created_at = row.created, n.updated_at = row.now "
+                "ON MATCH SET n.properties = row.props, n.updated_at = row.now",
+                rows=node_rows[i : i + bs],
+            ).consume()
+        for i in range(0, len(edge_rows), bs):
+            session.run(
+                "UNWIND $rows AS row "
+                "MATCH (a:Entity {entity_type: row.ft, entity_value: row.fv}) "
+                "MATCH (b:Entity {entity_type: row.tt, entity_value: row.tv}) "
+                "MERGE (a)-[r:REL {relationship: row.rel}]->(b) "
+                "ON CREATE SET r.edge_id = row.eid, r.from_node_id = a.node_id, "
+                "r.to_node_id = b.node_id, r.edge_type = row.etype, r.note_id = row.note_id, "
+                "r.properties = row.props, r.created_at = row.now, r.updated_at = row.now "
+                "ON MATCH SET r.edge_type = row.etype, r.note_id = row.note_id, "
+                "r.properties = row.props, r.updated_at = row.now",
+                rows=edge_rows[i : i + bs],
+            ).consume()
+
+
+def _count_neo4j(kg: Neo4jKnowledgeGraph) -> tuple[int, int]:
+    """Return ``(entity_node_count, rel_edge_count)`` currently in Neo4j."""
+    driver = kg._get_driver()
+    with driver.session(database=kg._database) as session:
+        n_rec = session.run("MATCH (n:Entity) RETURN count(n) AS c").single()
+        e_rec = session.run("MATCH ()-[r:REL]->() RETURN count(r) AS c").single()
+    return int(n_rec["c"]) if n_rec else 0, int(e_rec["c"]) if e_rec else 0
+
+
+# ── Orchestration ────────────────────────────────────────────────────────────
+
+
+def sync(
+    *,
+    data_dir: str | None,
+    rebuild: bool,
+    dry_run: bool,
+    batch_size: int,
+) -> dict[str, Any]:
+    """Run the sync and return a JSON-serializable report.
+
+    Raises ``Neo4jUnavailableError`` on a connection failure during a mutating
+    run, or ``RuntimeError`` if post-load verification fails.
+    """
+    from zettelforge.neo4j_knowledge_graph import Neo4jKnowledgeGraph, Neo4jUnavailableError
+    from zettelforge.sqlite_backend import SQLiteBackend
+
+    backend = SQLiteBackend(data_dir=data_dir)
+    backend.initialize()
+    try:
+        source = read_source_graph(backend)
+    finally:
+        backend.close()
+
+    report: dict[str, Any] = {
+        "mode": "dry-run" if dry_run else ("rebuild" if rebuild else "incremental"),
+        "data_dir": data_dir,
+        "source": {
+            "nodes": len(source["nodes"]),
+            "edges": len(source["edges"]),
+            "orphan_edges": source["orphan_edges"],
+        },
+        "neo4j": {},
+        "ok": False,
+    }
+    if source["orphan_edges"]:
+        _logger.warning("neo4j_sync_orphan_edges_dropped", count=source["orphan_edges"])
+
+    # Skip schema init at construction; we control connect/init explicitly so a
+    # dry-run can connect read-only without writing constraints.
+    kg = Neo4jKnowledgeGraph(_skip_init_schema=True)
+    try:
+        if dry_run:
+            # Read-only preview: report the current Neo4j state and the delta.
+            try:
+                before_nodes, before_edges = _count_neo4j(kg)
+                report["neo4j"] = {
+                    "reachable": True,
+                    "before": {"nodes": before_nodes, "edges": before_edges},
+                    "would_upsert": {
+                        "nodes": len(source["nodes"]),
+                        "edges": len(source["edges"]),
+                    },
+                }
+            except Neo4jUnavailableError as exc:
+                # Preview is informational; surface unreachability without failing.
+                report["neo4j"] = {"reachable": False, "error": str(exc)}
+            report["ok"] = True
+            return report
+
+        # Mutating run: a connection failure here is fail-loud (propagates).
+        kg._init_schema()
+        before_nodes, before_edges = _count_neo4j(kg)
+        if rebuild:
+            _wipe_entity_graph(kg, batch_size)
+        _load_graph(kg, source, batch_size)
+        after_nodes, after_edges = _count_neo4j(kg)
+
+        expected_nodes = len(source["nodes"])
+        expected_edges = len(source["edges"])
+        if rebuild:
+            verified = after_nodes == expected_nodes and after_edges == expected_edges
+        else:
+            # Upsert never deletes, so Neo4j must hold at least the source set.
+            verified = after_nodes >= expected_nodes and after_edges >= expected_edges
+
+        report["neo4j"] = {
+            "reachable": True,
+            "before": {"nodes": before_nodes, "edges": before_edges},
+            "after": {"nodes": after_nodes, "edges": after_edges},
+            "expected": {"nodes": expected_nodes, "edges": expected_edges},
+            "verified": verified,
+        }
+        if not verified:
+            raise RuntimeError(
+                f"Neo4j sync verification failed (mode={report['mode']}): "
+                f"after={after_nodes} nodes / {after_edges} edges, "
+                f"expected={expected_nodes} / {expected_edges}"
+            )
+        report["ok"] = True
+        _logger.info(
+            "neo4j_sync_complete",
+            mode=report["mode"],
+            nodes=after_nodes,
+            edges=after_edges,
+        )
+        return report
+    finally:
+        kg.close()
+
+
+# ── CLI ──────────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str] | None = None) -> argparse.Namespace:
+    p = argparse.ArgumentParser(
+        description="Populate/sync the Neo4j path-query graph from the SQLite knowledge graph.",
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+    )
+    p.add_argument(
+        "--data-dir",
+        default=None,
+        help="ZettelForge data directory (the SQLite store). Defaults to the standard data dir.",
+    )
+    p.add_argument(
+        "--rebuild",
+        action="store_true",
+        help="Scoped clean-slate (delete :Entity/:REL) then reload — exact mirror including deletions.",
+    )
+    p.add_argument(
+        "--dry-run",
+        action="store_true",
+        help="Read source and report the delta vs Neo4j without writing anything.",
+    )
+    p.add_argument(
+        "--batch-size",
+        type=int,
+        default=5000,
+        help="UNWIND batch size for load and wipe sub-transactions.",
+    )
+    p.add_argument(
+        "--output",
+        default=None,
+        help="Optional path to also write the JSON report to.",
+    )
+    return p.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    from zettelforge.neo4j_knowledge_graph import Neo4jUnavailableError
+
+    args = _parse_args(argv)
+    if args.rebuild and args.dry_run:
+        print("--rebuild and --dry-run are mutually exclusive.", file=sys.stderr)
+        return 2
+
+    try:
+        report = sync(
+            data_dir=args.data_dir,
+            rebuild=args.rebuild,
+            dry_run=args.dry_run,
+            batch_size=args.batch_size,
+        )
+    except Neo4jUnavailableError as exc:
+        print(f"Neo4j unavailable: {exc}", file=sys.stderr)
+        return 3
+    except RuntimeError as exc:
+        print(f"Sync failed: {exc}", file=sys.stderr)
+        return 1
+
+    text = json.dumps(report, indent=2, default=str)
+    print(text)
+    if args.output:
+        try:
+            with open(args.output, "w") as f:
+                f.write(text + "\n")
+        except OSError as exc:
+            print(f"warning: could not write report to {args.output}: {exc}", file=sys.stderr)
+
+    return 0 if report["ok"] else 1
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/src/zettelforge/sqlite_backend.py
+++ b/src/zettelforge/sqlite_backend.py
@@ -624,6 +624,74 @@ class SQLiteBackend(StorageBackend):
             for row in rows
         ]
 
+    def get_all_kg_nodes(self) -> list[dict]:
+        """Every KG node (full-graph export for the Neo4j sync job).
+
+        Materializes the whole ``kg_nodes`` table. Used by the standalone
+        ``scripts.neo4j_sync`` population job, not the recall hot path.
+        """
+        with self._write_lock:
+            self._check_open()
+            cur = self._conn.execute(
+                "SELECT node_id, entity_type, entity_value, properties, "
+                "created_at, updated_at FROM kg_nodes"
+            )
+            rows = cur.fetchall()
+        return [
+            {
+                "node_id": row["node_id"],
+                "entity_type": row["entity_type"],
+                "entity_value": row["entity_value"],
+                "properties": json.loads(row["properties"] or "{}"),
+                "created_at": row["created_at"],
+                "updated_at": row["updated_at"],
+            }
+            for row in rows
+        ]
+
+    def get_all_kg_edges(self) -> list[dict]:
+        """Every KG edge with resolved endpoint identities (Neo4j sync export).
+
+        Joins ``kg_edges`` to ``kg_nodes`` on both endpoints so each edge
+        carries ``(from_type, from_value, to_type, to_value)`` — the identity
+        the Neo4j backend MERGEs on. An INNER JOIN intentionally drops edges
+        whose endpoints are missing from ``kg_nodes`` (orphans cannot be
+        MERGEd by type/value); the sync job reports any such gap.
+        """
+        with self._write_lock:
+            self._check_open()
+            cur = self._conn.execute(
+                "SELECT e.edge_id, e.relationship, e.edge_type, e.note_id, e.properties, "
+                "nf.entity_type AS from_type, nf.entity_value AS from_value, "
+                "nt.entity_type AS to_type, nt.entity_value AS to_value "
+                "FROM kg_edges e "
+                "JOIN kg_nodes nf ON e.from_node_id = nf.node_id "
+                "JOIN kg_nodes nt ON e.to_node_id = nt.node_id"
+            )
+            rows = cur.fetchall()
+        return [
+            {
+                "edge_id": row["edge_id"],
+                "from_type": row["from_type"],
+                "from_value": row["from_value"],
+                "to_type": row["to_type"],
+                "to_value": row["to_value"],
+                "relationship": row["relationship"],
+                "edge_type": row["edge_type"],
+                "note_id": row["note_id"],
+                "properties": json.loads(row["properties"] or "{}"),
+            }
+            for row in rows
+        ]
+
+    def count_kg(self) -> tuple[int, int]:
+        """Return ``(node_count, edge_count)`` for the KG (sync parity check)."""
+        with self._write_lock:
+            self._check_open()
+            n = self._conn.execute("SELECT count(*) AS c FROM kg_nodes").fetchone()["c"]
+            e = self._conn.execute("SELECT count(*) AS c FROM kg_edges").fetchone()["c"]
+        return int(n), int(e)
+
     def get_kg_neighbors(
         self,
         entity_type: str,

--- a/tests/integration/test_neo4j_sync.py
+++ b/tests/integration/test_neo4j_sync.py
@@ -1,0 +1,62 @@
+"""Integration tests for the standalone Neo4j sync job (AGE-121).
+
+Round-trips a small SQLite knowledge graph into Neo4j via the sync job and
+asserts parity, idempotency, and that the populated graph answers path queries.
+Gated by ``requires_neo4j``.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from zettelforge.scripts.neo4j_sync import sync
+from zettelforge.sqlite_backend import SQLiteBackend
+
+pytestmark = pytest.mark.requires_neo4j
+
+
+_EDGES = [
+    ("ThreatActor", "APT28", "Malware", "X-Agent", "uses"),
+    ("Malware", "X-Agent", "Vulnerability", "CVE-2017-0144", "exploits"),
+    ("Vulnerability", "CVE-2017-0144", "Asset", "SMBv1", "affects"),
+]
+
+
+def _seed(data_dir: Path) -> None:
+    backend = SQLiteBackend(data_dir=str(data_dir))
+    backend.initialize()
+    for ft, fv, tt, tv, rel in _EDGES:
+        backend.add_kg_edge(ft, fv, tt, tv, rel)
+    backend.close()
+
+
+def test_rebuild_populates_and_verifies(neo4j_kg: object, tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = sync(data_dir=str(tmp_path), rebuild=True, dry_run=False, batch_size=5000)
+    assert report["ok"] is True
+    assert report["neo4j"]["verified"] is True
+    # 4 distinct entities, 3 edges.
+    assert report["neo4j"]["after"] == {"nodes": 4, "edges": 3}
+    # The populated graph answers an undirected path query end-to-end.
+    path = neo4j_kg.shortest_path("ThreatActor", "APT28", "Asset", "SMBv1")  # type: ignore[attr-defined]
+    assert path is not None and len(path) == 3
+
+
+def test_incremental_is_idempotent(neo4j_kg: object, tmp_path: Path) -> None:
+    _seed(tmp_path)
+    first = sync(data_dir=str(tmp_path), rebuild=False, dry_run=False, batch_size=5000)
+    second = sync(data_dir=str(tmp_path), rebuild=False, dry_run=False, batch_size=5000)
+    assert first["ok"] and second["ok"]
+    # Re-running the upsert must not duplicate nodes or edges.
+    assert second["neo4j"]["after"] == {"nodes": 4, "edges": 3}
+
+
+def test_dry_run_writes_nothing(neo4j_kg: object, tmp_path: Path) -> None:
+    _seed(tmp_path)
+    report = sync(data_dir=str(tmp_path), rebuild=False, dry_run=True, batch_size=5000)
+    assert report["ok"] is True
+    assert report["neo4j"]["reachable"] is True
+    assert report["neo4j"]["before"] == {"nodes": 0, "edges": 0}
+    assert report["neo4j"]["would_upsert"] == {"nodes": 4, "edges": 3}

--- a/tests/unit/test_neo4j_sync.py
+++ b/tests/unit/test_neo4j_sync.py
@@ -1,0 +1,103 @@
+"""Unit tests for the Neo4j sync source-read path (no Neo4j needed).
+
+Covers the SQLite bulk KG readers added for the standalone sync job and
+``read_source_graph``'s edge dedup / orphan accounting. The Neo4j load itself
+is exercised by ``tests/integration/test_neo4j_sync.py`` (requires_neo4j).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+from zettelforge.scripts.neo4j_sync import read_source_graph
+from zettelforge.sqlite_backend import SQLiteBackend
+
+
+def _seeded_backend(tmp_path: Path) -> SQLiteBackend:
+    backend = SQLiteBackend(data_dir=str(tmp_path))
+    backend.initialize()
+    backend.add_kg_node("ThreatActor", "APT28", {"aka": "Fancy Bear"})
+    backend.add_kg_edge("ThreatActor", "APT28", "Malware", "X-Agent", "uses")
+    backend.add_kg_edge(
+        "Malware",
+        "X-Agent",
+        "Vulnerability",
+        "CVE-2017-0144",
+        "exploits",
+        properties={"edge_type": "causal", "confidence": 0.9},
+    )
+    return backend
+
+
+def test_get_all_kg_nodes_returns_parsed_properties(tmp_path: Path) -> None:
+    backend = _seeded_backend(tmp_path)
+    try:
+        nodes = backend.get_all_kg_nodes()
+    finally:
+        backend.close()
+    by_value = {n["entity_value"]: n for n in nodes}
+    # Endpoints created by add_kg_edge are present alongside the explicit node.
+    assert set(by_value) == {"APT28", "X-Agent", "CVE-2017-0144"}
+    assert by_value["APT28"]["properties"] == {"aka": "Fancy Bear"}
+    assert by_value["APT28"]["entity_type"] == "ThreatActor"
+
+
+def test_get_all_kg_edges_resolves_endpoint_identities(tmp_path: Path) -> None:
+    backend = _seeded_backend(tmp_path)
+    try:
+        edges = backend.get_all_kg_edges()
+    finally:
+        backend.close()
+    edges_by_rel = {e["relationship"]: e for e in edges}
+    assert edges_by_rel["uses"]["from_type"] == "ThreatActor"
+    assert edges_by_rel["uses"]["from_value"] == "APT28"
+    assert edges_by_rel["uses"]["to_value"] == "X-Agent"
+    # edge_type column surfaced; remaining props in the parsed dict.
+    assert edges_by_rel["exploits"]["edge_type"] == "causal"
+    assert edges_by_rel["exploits"]["properties"] == {"confidence": 0.9}
+
+
+def test_count_kg(tmp_path: Path) -> None:
+    backend = _seeded_backend(tmp_path)
+    try:
+        nodes, edges = backend.count_kg()
+    finally:
+        backend.close()
+    assert (nodes, edges) == (3, 2)
+
+
+def test_read_source_graph_dedups_edges_by_neo4j_identity(tmp_path: Path) -> None:
+    backend = SQLiteBackend(data_dir=str(tmp_path))
+    backend.initialize()
+    # Same (from, to, relationship) but distinct note_id: two SQLite rows
+    # (UNIQUE includes note_id) that collapse to ONE Neo4j relationship.
+    backend.add_kg_edge("a", "1", "b", "2", "rel", note_id="note_x")
+    backend.add_kg_edge("a", "1", "b", "2", "rel", note_id="note_y")
+    try:
+        src = read_source_graph(backend)
+    finally:
+        backend.close()
+    assert len(src["edges"]) == 1
+    assert src["orphan_edges"] == 0
+
+
+def test_read_source_graph_counts_orphan_edges(tmp_path: Path) -> None:
+    backend = SQLiteBackend(data_dir=str(tmp_path))
+    backend.initialize()
+    backend.add_kg_edge("a", "1", "b", "2", "rel")
+    # Inject an edge with a dangling endpoint (no matching kg_nodes row). The
+    # INNER JOIN drops it; the orphan count must make that visible.
+    with backend._write_lock:
+        backend._conn.execute(
+            "INSERT INTO kg_edges (edge_id, from_node_id, to_node_id, relationship, "
+            "edge_type, note_id, properties, created_at, updated_at) "
+            "VALUES ('edge_orphan', 'node_missing', 'node_missing2', 'rel', "
+            "'heuristic', '', '{}', '', '')"
+        )
+        backend._conn.commit()
+    try:
+        src = read_source_graph(backend)
+    finally:
+        backend.close()
+    assert len(src["edges"]) == 1
+    assert src["orphan_edges"] == 1


### PR DESCRIPTION
## AGE-121: standalone Neo4j sync/population job

Follow-up to the AGE-117 path-query seam (PR #164, `f848a2f`). The seam routes undirected path-finding to Neo4j when `ZETTELFORGE_NEO4J_PATHFINDING=true` but deliberately does **not** dual-write from the ingest hot path. So with pathfinding enabled and an unpopulated Neo4j, path queries hit an empty graph. This PR ships the population side.

### What changed
- **`scripts/neo4j_sync.py`** — one-way SQLite → Neo4j population job, runnable on demand and schedulable (`python -m zettelforge.scripts.neo4j_sync`).
  - **Default = incremental upsert** (UNWIND/MERGE on the backend's own write identity), idempotent, never empties the live graph.
  - **`--rebuild`** = scoped clean-slate (`:Entity`/`:REL` only, bounded sub-transactions) → exact mirror including deletions.
  - **`--dry-run`** = read-only delta preview. `--output` writes the JSON report to a file.
- **`SQLiteBackend`** gains `get_all_kg_nodes` / `get_all_kg_edges` (endpoint-resolving JOIN) / `count_kg` for full-graph export — sync-only, off the recall hot path.
- **Docs** — consistency/staleness contract + scheduling (systemd/cron) in `docs/how-to/configure-neo4j.md`; runbook entry in `troubleshoot.md`.

### Consistency / staleness contract
- SQLite (`kg_nodes`/`kg_edges`) is the system of record. Neo4j is a **derived read-replica** used only by the path-query seam.
- Incremental upsert converges Neo4j to a superset-or-equal of SQLite and never deletes (the SQLite graph is append-mostly, no deletion log); use `--rebuild` for an exact mirror.
- Neo4j reflects SQLite as of the last successful sync; schedule the job to bound staleness. A stale/empty Neo4j only affects the opt-in seam, never storage or recall.
- **Fail-loud (Law 4):** connection failure on a mutating run exits non-zero; post-load counts are verified against the source, mismatch exits non-zero; orphan edges are reported, not silently dropped.

### Testing
- `ruff check` + `ruff format --check` (src, CI scope): clean
- `mypy --strict` on the new module: clean
- Unit tests (no Neo4j): bulk readers + edge dedup/orphan accounting — 5 passed
- Existing `test_storage_backend.py`: 10 passed (additive change, no regression)
- Integration tests (`requires_neo4j`): full round trip, idempotency, dry-run — written, run with `ZETTELFORGE_NEO4J_PASSWORD` against a live Neo4j
- CLI smoke test: dry-run (exit 0), `--rebuild --dry-run` guard (exit 2), mutating-without-Neo4j fail-loud (exit 3)

### Risks
- Storage/recall paths untouched; the job is additive and SQLite-sourced. No new mandatory deps (uses the existing `[neo4j]` extra).
- Edges sharing `(from, to, relationship)` but differing only by `note_id` collapse to one `:REL` (matches the Neo4j backend's existing write identity); documented and unit-tested.

Base: `perf/cti-memory-40` (where the AGE-117 seam lives; not yet on `master`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)