### PR TITLE
docs(changelog): fold RFC-018 Phase 0 ledger into v2.8.0 release notes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,18 +6,14 @@ Versioning follows [Semantic Versioning](https://semver.org/).
 
 ## [Unreleased]
 
-### Added
-
-- RFC-018 Phase 0 enrichment job ledger foundation with SQLite job metadata, MemoryManager queue-state recording, and regression tests. (#171)
-- RFC-018 specifying the next ThreatRecall ingestion, enrichment, parser-safety, metadata-policy, operator-health, and build/push release-train improvements based on the latest recall hardening fixes. (#171)
-
 ## [2.8.0] - 2026-06-26
 
 Feature release. Extends the RFC-016 OSINT layer with passive ingest and
-live AGE-120 enrichers, and adds AGE-127 prompt-injection /
-retrieval-poisoning guardrails across the memory pipeline, alongside
-configurable LLM generation budgets and bulk detection-ingest hardening.
-No data migration is required.
+live AGE-120 enrichers, adds AGE-127 prompt-injection /
+retrieval-poisoning guardrails across the memory pipeline, and lays the
+RFC-018 Phase 0 enrichment job ledger foundation, alongside configurable
+LLM generation budgets and bulk detection-ingest hardening. No data
+migration is required.
 
 ### Added
 
@@ -40,6 +36,11 @@ No data migration is required.
   The network collectors are an opt-in `[osint]` extra, key-gated and
   fail-closed, and are never auto-triggered by `remember()`. Known
   fast-follow robustness items are tracked in #176. (#167)
+- **RFC-018 Phase 0 enrichment job ledger** (#178). Durable SQLite
+  job-metadata foundation with `MemoryManager` queue-state recording and
+  regression tests, plus the RFC-018 spec for the next ingestion,
+  enrichment, parser-safety, metadata-policy, operator-health, and
+  release-train improvements.
 - Configurable LLM generation budgets for causal extraction, synthesis,
   fact extraction, NER, and memory evolution, plus `reasoning_model` scaling
   floors and `<think>` / `<thinking>` JSON parse stripping. (#153)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -36,11 +36,11 @@ migration is required.
   The network collectors are an opt-in `[osint]` extra, key-gated and
   fail-closed, and are never auto-triggered by `remember()`. Known
   fast-follow robustness items are tracked in #176. (#167)
-- **RFC-018 Phase 0 enrichment job ledger** (#178). Durable SQLite
-  job-metadata foundation with `MemoryManager` queue-state recording and
-  regression tests, plus the RFC-018 spec for the next ingestion,
-  enrichment, parser-safety, metadata-policy, operator-health, and
-  release-train improvements.
+- **RFC-018 Phase 0 enrichment job ledger.** Durable SQLite job-metadata
+  foundation with `MemoryManager` queue-state recording and regression
+  tests, plus the RFC-018 spec for the next ingestion, enrichment,
+  parser-safety, metadata-policy, operator-health, and release-train
+  improvements. (#178)
 - Configurable LLM generation budgets for causal extraction, synthesis,
   fact extraction, NER, and memory evolution, plus `reasoning_model` scaling
   floors and `<think>` / `<thinking>` JSON parse stripping. (#153)


### PR DESCRIPTION
Per the decision to ship the RFC-018 Phase 0 enrichment ledger (#178) as part of **v2.8.0**, this moves its CHANGELOG entries from `[Unreleased]` into the `[2.8.0]` section and notes it in the release intro. **Changelog-only** — the ledger code already landed on master via #178.

After this merges, master HEAD is the complete 2.8.0 release contents, so the **`v2.8.0` GitHub release can be tagged at master HEAD** (no need to target an earlier commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E98zHqp7UdZGbMKS9M7yjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01E98zHqp7UdZGbMKS9M7yjo)_