### PR TITLE
docs: awesome-list submission kit and eligibility assessment

### DIFF
--- a/docs/awesome-lists/SUBMISSION_GUIDE.md
+++ b/docs/awesome-lists/SUBMISSION_GUIDE.md
@@ -1,0 +1,100 @@
+# Getting ZettelForge onto "awesome" lists — assessment & submission kit
+
+This directory holds ready-to-submit materials and an honest eligibility
+assessment for the two lists requested:
+
+- `awesome-selfhosted/awesome-selfhosted`
+- `sindresorhus/awesome`
+
+> **Two hard constraints up front.** (1) These are third-party repos; the
+> entries must be opened and merged by their maintainers via your own PR — they
+> cannot be pushed from this project. (2) **Both lists explicitly ban
+> AI-generated / AI-submitted entries** and will ban the contributor account for
+> violating it. So the PR must be opened and worded *by you, personally*. The
+> files here are a correctness aid (right format, right vocabulary, verified
+> against the live rules), not a copy-paste-from-a-bot shortcut — review and
+> rewrite the prose in your own voice before submitting.
+
+---
+
+## 1. awesome-selfhosted — **eligible, with one framing caveat**
+
+awesome-selfhosted now lives in a data repo:
+`github.com/awesome-selfhosted/awesome-selfhosted-data`. You add one YAML file
+under `software/`; a bot renders the list and auto-fills stats.
+
+### Criteria check (verified against the live CONTRIBUTING rules, 2026-06)
+
+| Requirement | ZettelForge | Status |
+|---|---|---|
+| FOSS license (SPDX in `licenses.yml`) | MIT | ✅ |
+| First released > 4 months ago, with tagged releases | v2.8.0, long release history | ✅ |
+| Self-hostable **server** software (not desktop/mobile/CLI) | FastAPI web service + management SPA + auth, `Dockerfile` exposing :8000, `docker-compose.yml` | ✅ |
+| No mandatory cloud / third-party dependency | Runs in-process (fastembed ONNX, llama-cpp, SQLite + LanceDB, Ollama on localhost); no API keys required | ✅ (so **no** `depends_3rdparty`) |
+| Valid platform tag | `Python`, `Docker` | ✅ |
+| Valid category tag (must already exist in `tags/`) | `Knowledge Management Tools` | ✅ (best existing fit) |
+| Description rules: no "self-hosted"/"open-source"/"free", concise, ends with a period | see `zettelforge.yml` | ✅ |
+
+**The one caveat — framing.** awesome-selfhosted explicitly excludes
+"libraries, SDKs, or frameworks requiring application code." ZettelForge's
+README leads with `pip install` + `from zettelforge import MemoryManager`, which
+reads as a library. Reviewers are strict about this. The entry here is
+therefore framed around the **self-hostable web service** (the FastAPI
+management UI + REST API + Docker image), which is a genuine end-user
+application and is what qualifies it. Keep that framing in the PR. If a reviewer
+still pushes back on the library angle, point them at the Docker image and the
+web UI screenshots/endpoints (`/`, `/api/recall`, `/api/graph/*`, config editor).
+
+### How to submit
+
+1. Fork `awesome-selfhosted/awesome-selfhosted-data`.
+2. Copy `zettelforge.yml` (this directory) to `software/zettelforge.yml` in your
+   fork. Do **not** add `stargazers_count`, `updated_at`, `current_release`,
+   `commit_history`, or `archived` — the bot fills those on merge.
+3. Optionally run their linter locally:
+   `make install && make` (it validates fields, tags, platforms, licenses).
+4. Open a PR. Tick the checklist boxes honestly (project age, license,
+   self-hostable, etc.). Write the PR description in your own words.
+5. If you want a `demo_url`, only add one that points at a live demo of the
+   *self-hosted software itself* (not the hosted ThreatRecall SaaS, which
+   reviewers may treat as promotion). Left out by default.
+
+---
+
+## 2. sindresorhus/awesome — **not eligible as a project; only via a new list**
+
+**ZettelForge cannot be listed here directly.** `sindresorhus/awesome` is a
+"list of awesome lists." Its PR template states it accepts **only curated
+awesome lists**, never individual tools or projects. There is no entry shape
+that puts a single piece of software on that list.
+
+The only legitimate route to appear there is to **create and submit your own
+awesome list** (e.g. `awesome-cti-memory`, `awesome-threat-intelligence-tooling`,
+or `awesome-agentic-memory`) in which ZettelForge is one of many entries. That
+list — not ZettelForge — becomes the `sindresorhus/awesome` entry. Requirements
+for such a list:
+
+- Repo named `awesome-<topic>`, **default branch `main`**.
+- At least **30 days old** (from first real commit / open-sourcing).
+- License must be **CC0 / Creative Commons** (a code license like MIT is
+  rejected); `LICENSE` file in root, no license section in the README.
+- Awesome badge on the right of the H1; `Contents` ToC; `contributing.md`.
+- Genuinely curated ("the best, not everything") and **not AI-generated**.
+- Curating a topic that prominently features your own project, with little else,
+  reads as self-promotion and gets rejected — the list has to be broadly useful
+  on its own merits.
+
+This is a real, multi-week effort and a separate decision from the
+awesome-selfhosted submission. It is **not** scaffolded here because doing it as
+a thin vehicle for one project is exactly what that list rejects. If you want to
+pursue it, build the topic list for its own sake first, let it mature 30+ days,
+then submit.
+
+---
+
+## Summary
+
+| List | Verdict | Action |
+|---|---|---|
+| awesome-selfhosted | Eligible (frame as a web service) | Submit `zettelforge.yml` as `software/zettelforge.yml` — by hand, in your own words |
+| sindresorhus/awesome | Not eligible for a single project | Only reachable by creating a separate, mature, CC0-licensed `awesome-<topic>` list |

--- a/docs/awesome-lists/zettelforge.yml
+++ b/docs/awesome-lists/zettelforge.yml
@@ -1,0 +1,25 @@
+# awesome-selfhosted-data entry for ZettelForge
+# Target file in the upstream repo: software/zettelforge.yml
+# Format reference: https://github.com/awesome-selfhosted/awesome-selfhosted-data/blob/master/.github/CONTRIBUTING.md
+#
+# NOTE: Only the human-authored fields below are submitted. The maintainer bot
+# auto-populates stargazers_count, updated_at, archived, current_release and
+# commit_history from the GitHub API on merge — do NOT add them by hand.
+
+name: ZettelForge
+website_url: https://docs.threatrecall.ai/
+source_code_url: https://github.com/rolandpg/zettelforge
+description: >-
+  Knowledge management and retrieval system for cyber threat intelligence.
+  Extracts CVEs, threat actors, IOCs and MITRE ATT&CK techniques from analyst
+  notes and reports, resolves actor aliases (APT28 = Fancy Bear), builds a
+  STIX 2.1 knowledge graph, and serves past investigations back through a web
+  management UI, REST API and an MCP server. Runs in-process with no external
+  API keys required.
+licenses:
+  - MIT
+platforms:
+  - Python
+  - Docker
+tags:
+  - Knowledge Management Tools


### PR DESCRIPTION
## Summary

Adds a ready-to-submit kit and an honest eligibility assessment for getting ZettelForge listed on the two requested "awesome" lists. These are third-party repos, so the actual PRs must be opened by the maintainer — and notably **both lists ban AI-generated/AI-submitted entries** — so this provides correct, spec-validated materials rather than an automated submission.

## Related issue

Fixes #

## Changes

- `docs/awesome-lists/zettelforge.yml` — awesome-selfhosted-data entry formatted to the live spec: verified existing tag `Knowledge Management Tools`, platforms `Python`/`Docker`, `MIT` license, and a description that avoids the banned words ("self-hosted"/"open-source"/"free") and is framed around the self-hostable web service (FastAPI management UI + REST API + Docker) to satisfy the "not a library/SDK" rule. Auto-populated stat fields are intentionally omitted (the upstream bot fills them on merge).
- `docs/awesome-lists/SUBMISSION_GUIDE.md` — per-list verdicts and process:
  - **awesome-selfhosted**: eligible (MIT, tagged releases >4 months old, self-hostable web service, no mandatory cloud dependency). Includes the library-vs-service framing caveat and step-by-step fork/submit instructions.
  - **sindresorhus/awesome**: a single project is **not** eligible — that list curates *awesome lists only*. Documents the only legitimate route (a separate, mature, CC0-licensed `awesome-<topic>` list) and why it isn't scaffolded here.

## Testing

- [ ] Tests pass (`pytest tests/ -v`) — N/A, docs-only change
- [ ] Linting passes (`ruff check src/zettelforge/`) — N/A, no source changes
- [ ] New tests added for new functionality — N/A
- [x] No new external infrastructure dependencies without discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_016DT6PywR8J5eZ3wJ1hpEJ6)_