### PR TITLE
ci(publish): add workflow_dispatch trigger for one-click PyPI re-runs

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -3,12 +3,21 @@ name: Publish to PyPI
 on:
   release:
     types: [published]
+  # Manual re-run path (e.g. after fixing a trusted-publisher config or a
+  # transient upload failure). Provide the existing git tag to publish.
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Existing git tag to build and publish (e.g. v2.8.0)'
+        required: true
+        type: string
 
 jobs:
   publish:
     # Package-only releases (for example packages-v0.1.0) are not
-    # Python package releases and must not attempt a PyPI upload.
-    if: startsWith(github.event.release.tag_name, 'v')
+    # Python package releases and must not attempt a PyPI upload. Manual
+    # workflow_dispatch runs always proceed (the caller picks the tag).
+    if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')
     runs-on: ubuntu-latest
     permissions:
       contents: read
@@ -16,6 +25,9 @@ jobs:
 
     steps:
     - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+      with:
+        # release event: the published tag; manual run: the input tag.
+        ref: ${{ github.event.release.tag_name || inputs.tag }}
 
     - name: Set up Python
       uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1


### PR DESCRIPTION
Adds a manual re-run path to `publish.yml` so the PyPI publish can be retried without cutting a new release — e.g. after fixing a trusted-publisher config (like the current `ThreatRecall/zettelforge` OIDC mismatch) or a transient upload failure.

### Changes
- `on:` now also includes **`workflow_dispatch`** with a required **`tag`** input.
- Job condition permits manual runs: `if: github.event_name == 'workflow_dispatch' || startsWith(github.event.release.tag_name, 'v')`.
- Checkout uses `ref: ${{ github.event.release.tag_name || inputs.tag }}` — the published tag on release events, the input tag on manual runs.

**Release-event behavior is unchanged** (the checkout ref equals the release tag, exactly the previous default).

### How to re-publish v2.8.0 after fixing the PyPI publisher
Once this is merged and the PyPI trusted publisher is set for `ThreatRecall/zettelforge` + `publish.yml`: **Actions → "Publish to PyPI" → Run workflow**, with `tag = v2.8.0`. (Trusted publishing matches on owner/repo/workflow filename, not the ref, so dispatching from `master` still authenticates.)

> Note: `workflow_dispatch` lets anyone with write access trigger a publish of a given tag; the upload still only succeeds via trusted-publishing OIDC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E98zHqp7UdZGbMKS9M7yjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01E98zHqp7UdZGbMKS9M7yjo)_