### PR TITLE
ci(quality): add report-only Code Quality workflow (mypy + ruff → code scanning)

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,80 @@
+name: Code Quality
+
+# Non-blocking code-quality signals that complement the hard gates in
+# ci.yml (ruff lint + format, pip-audit, tests, coverage). This surfaces
+# the static-typing (mypy) and ruff annotation (ANN) backlogs so they can
+# be ratcheted down, and feeds ruff findings to the code-scanning
+# dashboard. Everything here is report-only: it never fails the build.
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+  schedule:
+    - cron: '17 6 * * 1'   # weekly Monday 06:17 UTC — catch drift on master
+
+permissions:
+  contents: read
+
+jobs:
+  mypy:
+    name: Type check (mypy)
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      with:
+        python-version: '3.12'
+
+    - name: Install project + dev tools
+      run: |
+        python -m pip install --upgrade pip
+        # See ci.yml: fall back to a bare install + mypy if the [dev]
+        # extra can't resolve. Type checking wants the deps importable.
+        pip install -e ".[dev]" || (pip install -e "." && pip install mypy)
+
+    - name: Run mypy (report-only)
+      # Report-only: the codebase has a known static-typing backlog
+      # (audit finding H-3) being ratcheted per-module, so surface type
+      # findings without failing the build. Drop continue-on-error to make
+      # mypy a hard gate once it is clean. Config lives in [tool.mypy].
+      continue-on-error: true
+      run: mypy src/zettelforge/
+
+  ruff-scan:
+    name: Ruff → code scanning
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      security-events: write   # upload SARIF to the code-scanning dashboard
+    steps:
+    - uses: actions/checkout@9c091bb21b7c1c1d1991bb908d89e4e9dddfe3e0
+
+    - name: Set up Python
+      uses: actions/setup-python@ece7cb06caefa5fff74198d8649806c4678c61a1
+      with:
+        python-version: '3.12'
+
+    - name: Install ruff
+      run: pip install ruff
+
+    - name: Ruff check -> SARIF
+      # ci.yml already hard-gates the active ruff rule set (so master is
+      # clean against it). Here we also --extend-select the deferred ANN
+      # (type-annotation) rules and emit SARIF so the ratchet backlog is
+      # visible in the code-scanning dashboard. The `|| true` is required:
+      # findings are expected and must not fail the job — they surface as
+      # code-scanning alerts instead.
+      run: |
+        ruff check --extend-select ANN --output-format sarif \
+          src/zettelforge/ > ruff.sarif || true
+
+    - name: Upload SARIF to code scanning
+      uses: github/codeql-action/upload-sarif@54f647b7e1bb85c95cddabcd46b0c578ec92bc1a
+      with:
+        sarif_file: ruff.sarif
+        category: ruff
+      continue-on-error: true


### PR DESCRIPTION
Adds `.github/workflows/code-quality.yml` — a **non-blocking** quality workflow that complements the hard gates already in `ci.yml` (ruff lint/format, pip-audit, tests, coverage). It runs on push to `master`, PRs, and weekly.

### Jobs
1. **`mypy` — static type check (report-only).** The repo configures mypy (`[tool.mypy]`, `disallow_untyped_defs = true`) but never ran it in CI. This surfaces type findings without failing the build, because there's a known typing backlog (audit **H-3**) to ratchet per-module. Flip `continue-on-error` off to make it a hard gate once clean.
2. **`ruff-scan` — ruff → SARIF → code scanning.** `ci.yml` already hard-gates the active ruff rule set, so this `--extend-select ANN` (the deferred type-annotation backlog) and uploads SARIF to the **code-scanning dashboard** (the `settings/code-quality` page). Non-blocking; findings appear as code-scanning alerts, not build failures.

### Why report-only / safe
- Both known backlogs (mypy, ruff `ANN`) would break a hard gate today, so this is deliberately non-gating — it makes them *visible* for ratcheting rather than blocking work.
- All actions are **SHA-pinned** to the exact versions already used in the repo (`checkout@9c091bb`, `setup-python@ece7cb06`, `upload-sarif@54f647b` — the same SARIF pattern as `snyk-security.yml`, which proves third-party SARIF uploads work under the default CodeQL setup).
- **No `GOV-NNN` labels**, so the `governance` spec-drift check stays green (no `controls.yaml` change needed).

### Notes / knobs
- The `ANN` upload will surface the annotation backlog (~120 findings) as dashboard alerts — that's intentional (a live view of the ratchet). If it's too noisy, drop `--extend-select ANN` and it'll only report new active-rule findings.
- Natural follow-ups: promote `mypy` to a hard gate as modules are annotated (ties into audit **H-3**), and the earlier-noted **Python 3.10 CI leg**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01E98zHqp7UdZGbMKS9M7yjo

---
_Generated by [Claude Code](https://claude.ai/code/session_01E98zHqp7UdZGbMKS9M7yjo)_
<!-- devin-review-badge-begin -->

---

<a href="https://app.devin.ai/review/threatrecall/zettelforge/pull/190" target="_blank">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://static.devin.ai/assets/gh-open-in-devin-review-dark.svg?v=1">
    <img src="https://static.devin.ai/assets/gh-open-in-devin-review-light.svg?v=1" alt="Open in Devin Review">
  </picture>
</a>
<!-- devin-review-badge-end -->