### PR TITLE
docs: awesome-list entries + repoint star-history badge to ThreatRecall

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@ It extracts CVEs, threat actors, IOCs, and ATT&CK techniques from analyst notes 
 
 [![PyPI](https://img.shields.io/pypi/v/zettelforge)](https://pypi.org/project/zettelforge/)
 [![Downloads/month](https://static.pepy.tech/personalized-badge/zettelforge?period=month&units=international_system&left_color=grey&right_color=blue&left_text=downloads%2Fmonth)](https://pepy.tech/projects/zettelforge)
-[![Star History](https://api.star-history.com/svg?repos=rolandpg/zettelforge&type=Date)](https://star-history.com/#rolandpg/zettelforge&Date)
+[![Star History](https://api.star-history.com/svg?repos=ThreatRecall/zettelforge&type=Date)](https://star-history.com/#ThreatRecall/zettelforge&Date)
 [![Python 3.10+](https://img.shields.io/badge/python-3.10%2B-blue)](https://www.python.org/downloads/)
 [![License: MIT](https://img.shields.io/badge/license-MIT-green)](https://opensource.org/licenses/MIT)
 [![CI](https://github.com/rolandpg/zettelforge/actions/workflows/ci.yml/badge.svg)](https://github.com/rolandpg/zettelforge/actions)

--- a/docs/awesome-lists/EXISTING_LISTS_ENTRIES.md
+++ b/docs/awesome-lists/EXISTING_LISTS_ENTRIES.md
@@ -1,0 +1,62 @@
+# Paste-ready entries for existing curated lists
+
+`sindresorhus/awesome` lists *awesome lists*, never individual projects, and the
+two topics ZettelForge fits (threat intelligence, AI/agent memory) **already
+have established lists** — so creating a new one would be rejected as a
+duplicate. The realistic route into that ecosystem is to be an **entry inside an
+existing, already-curated list**. Below are entries formatted to each target
+list's exact convention.
+
+> Same caveats as the selfhosted submission: these are third-party repos, so you
+> open the PRs yourself, and you should reword the prose in your own voice.
+> Verify the target section/columns against the neighbours at submit time — list
+> formats drift.
+
+---
+
+## A. `hslatman/awesome-threat-intelligence` — the flagship CTI list
+
+Section: **Frameworks & Platforms**. Entries are HTML table rows (name cell +
+description cell). Drop this row in, alphabetically, matching the surrounding
+`<tr>`/`<td>` structure:
+
+```html
+<tr>
+    <td>
+        <a href="https://github.com/rolandpg/zettelforge" target="_blank">ZettelForge</a>
+    </td>
+    <td>
+        ZettelForge is an in-process memory and knowledge-graph system for cyber
+        threat intelligence. It extracts CVEs, threat actors, IOCs and MITRE
+        ATT&amp;CK techniques from analyst notes and reports, resolves actor
+        aliases (APT28 = Fancy Bear), and builds a STIX 2.1 knowledge graph
+        queryable through a web UI, REST API and an MCP server.
+    </td>
+</tr>
+```
+
+## B. `topoteretes/awesome-ai-memory` — the AI-memory list (maintained by the Cognee team)
+
+Pipe-table format with columns
+`| Name | Description | URL | Open / Close | GitHub URL | Category | Storage |`.
+Add, alphabetically:
+
+```
+| ZettelForge | In-process memory + knowledge graph purpose-built for cyber threat intelligence: extracts CVEs, actors, IOCs and ATT&CK techniques, resolves actor aliases, builds a STIX 2.1 graph, blended vector + graph retrieval, served over web UI / REST / MCP | https://docs.threatrecall.ai/ | Managed, Open source | https://github.com/rolandpg/zettelforge | Memory Tool | Graph, Vector |
+```
+
+(ZettelForge is already named as a peer of Mem0/Graphiti/Cognee in its own
+README comparison table, so it slots naturally next to those entries here.)
+
+---
+
+## Why this, and not a new list
+
+| Candidate new list | Blocker |
+|---|---|
+| `awesome-threat-intelligence` | `hslatman/awesome-threat-intelligence` is the established, widely-referenced one — a second is a duplicate reject. |
+| `awesome-ai-memory` / `awesome-agent-memory` | Saturated: `topoteretes/awesome-ai-memory` plus ~6 others (TeleAI-UAGI, cxxz, tfatykhov, TsinghuaC3I, DEEP-PolyU). Duplicate reject. |
+
+Landing in list **A** or **B** puts ZettelForge inside the same curated-list
+ecosystem that `sindresorhus/awesome` indexes — which is the achievable version
+of "listed on sindresorhus/awesome" for a single tool.

--- a/docs/awesome-lists/EXISTING_LISTS_ENTRIES.md
+++ b/docs/awesome-lists/EXISTING_LISTS_ENTRIES.md
@@ -26,11 +26,11 @@ description cell). Drop this row in, alphabetically, matching the surrounding
         <a href="https://github.com/rolandpg/zettelforge" target="_blank">ZettelForge</a>
     </td>
     <td>
-        ZettelForge is an in-process memory and knowledge-graph system for cyber
-        threat intelligence. It extracts CVEs, threat actors, IOCs and MITRE
-        ATT&amp;CK techniques from analyst notes and reports, resolves actor
-        aliases (APT28 = Fancy Bear), and builds a STIX 2.1 knowledge graph
-        queryable through a web UI, REST API and an MCP server.
+        ZettelForge is a threat-intelligence knowledge base that extracts CVEs,
+        threat actors, IOCs and MITRE ATT&amp;CK techniques from analyst notes
+        and reports, resolves actor aliases (APT28 = Fancy Bear), and builds a
+        STIX 2.1 knowledge graph queryable through a web UI, REST API and an
+        MCP server.
     </td>
 </tr>
 ```
@@ -42,7 +42,7 @@ Pipe-table format with columns
 Add, alphabetically:
 
 ```
-| ZettelForge | In-process memory + knowledge graph purpose-built for cyber threat intelligence: extracts CVEs, actors, IOCs and ATT&CK techniques, resolves actor aliases, builds a STIX 2.1 graph, blended vector + graph retrieval, served over web UI / REST / MCP | https://docs.threatrecall.ai/ | Managed, Open source | https://github.com/rolandpg/zettelforge | Memory Tool | Graph, Vector |
+| ZettelForge | Threat-intelligence memory and knowledge graph: extracts CVEs, actors, IOCs and ATT&CK techniques from analyst notes, resolves actor aliases, builds a STIX 2.1 graph with blended vector + graph retrieval, served over web UI, REST and MCP | https://docs.threatrecall.ai/ | Managed, Open source | https://github.com/rolandpg/zettelforge | Memory Tool | Graph, Vector |
 ```
 
 (ZettelForge is already named as a peer of Mem0/Graphiti/Cognee in its own

--- a/docs/awesome-lists/SUBMISSION_GUIDE.md
+++ b/docs/awesome-lists/SUBMISSION_GUIDE.md
@@ -61,34 +61,24 @@ web UI screenshots/endpoints (`/`, `/api/recall`, `/api/graph/*`, config editor)
 
 ---
 
-## 2. sindresorhus/awesome — **not eligible as a project; only via a new list**
+## 2. sindresorhus/awesome — **not eligible as a project; reach it via an existing list**
 
 **ZettelForge cannot be listed here directly.** `sindresorhus/awesome` is a
-"list of awesome lists." Its PR template states it accepts **only curated
-awesome lists**, never individual tools or projects. There is no entry shape
-that puts a single piece of software on that list.
+"list of awesome lists." Its PR template accepts **only curated awesome lists**,
+never individual tools. There is no entry shape for a single piece of software.
 
-The only legitimate route to appear there is to **create and submit your own
-awesome list** (e.g. `awesome-cti-memory`, `awesome-threat-intelligence-tooling`,
-or `awesome-agentic-memory`) in which ZettelForge is one of many entries. That
-list — not ZettelForge — becomes the `sindresorhus/awesome` entry. Requirements
-for such a list:
+**Creating a new list is a dead end too.** The two topics ZettelForge fits both
+already have established lists, and `sindresorhus/awesome` rejects duplicate
+topics:
 
-- Repo named `awesome-<topic>`, **default branch `main`**.
-- At least **30 days old** (from first real commit / open-sourcing).
-- License must be **CC0 / Creative Commons** (a code license like MIT is
-  rejected); `LICENSE` file in root, no license section in the README.
-- Awesome badge on the right of the H1; `Contents` ToC; `contributing.md`.
-- Genuinely curated ("the best, not everything") and **not AI-generated**.
-- Curating a topic that prominently features your own project, with little else,
-  reads as self-promotion and gets rejected — the list has to be broadly useful
-  on its own merits.
+- Threat intelligence → `hslatman/awesome-threat-intelligence` (the widely-used one).
+- AI/agent memory → `topoteretes/awesome-ai-memory` plus ~6 others.
 
-This is a real, multi-week effort and a separate decision from the
-awesome-selfhosted submission. It is **not** scaffolded here because doing it as
-a thin vehicle for one project is exactly what that list rejects. If you want to
-pursue it, build the topic list for its own sake first, let it mature 30+ days,
-then submit.
+**The achievable path: become an entry inside one of those existing lists**,
+which are themselves part of the awesome ecosystem `sindresorhus/awesome`
+indexes. Paste-ready, correctly-formatted entries for both are in
+[`EXISTING_LISTS_ENTRIES.md`](EXISTING_LISTS_ENTRIES.md). You open those PRs
+against the third-party repos yourself and reword them in your own voice.
 
 ---
 
@@ -97,4 +87,14 @@ then submit.
 | List | Verdict | Action |
 |---|---|---|
 | awesome-selfhosted | Eligible (frame as a web service) | Submit `zettelforge.yml` as `software/zettelforge.yml` — by hand, in your own words |
-| sindresorhus/awesome | Not eligible for a single project | Only reachable by creating a separate, mature, CC0-licensed `awesome-<topic>` list |
+| sindresorhus/awesome (directly) | Impossible for a single tool; new list = duplicate reject | — |
+| via `hslatman/awesome-threat-intelligence` | Achievable | Submit the HTML-table entry from `EXISTING_LISTS_ENTRIES.md` |
+| via `topoteretes/awesome-ai-memory` | Achievable | Submit the pipe-table entry from `EXISTING_LISTS_ENTRIES.md` |
+
+## What only you can do (why nothing here is the final step)
+
+Every actual *listing* is a merge into a repo neither this agent nor its
+GitHub scope can touch (`awesome-selfhosted/*`, `hslatman/*`, `topoteretes/*`,
+`sindresorhus/*`), and all of these lists **ban AI-submitted entries**. So the
+agent's job ends at "correct, validated, paste-ready materials"; opening and
+merging the PRs is inherently yours.

--- a/docs/awesome-lists/zettelforge.yml
+++ b/docs/awesome-lists/zettelforge.yml
@@ -9,13 +9,14 @@
 name: ZettelForge
 website_url: https://docs.threatrecall.ai/
 source_code_url: https://github.com/rolandpg/zettelforge
+# description must be < 250 characters, sentence case, and must NOT contain
+# "self-hosted", "open-source" or "free" (linter rejects those). Current
+# length is ~235 chars — keep any edits under the limit.
 description: >-
-  Knowledge management and retrieval system for cyber threat intelligence.
-  Extracts CVEs, threat actors, IOCs and MITRE ATT&CK techniques from analyst
-  notes and reports, resolves actor aliases (APT28 = Fancy Bear), builds a
-  STIX 2.1 knowledge graph, and serves past investigations back through a web
-  management UI, REST API and an MCP server. Runs in-process with no external
-  API keys required.
+  Threat-intelligence knowledge base that extracts CVEs, threat actors, IOCs
+  and MITRE ATT&CK techniques from analyst notes and reports, resolves actor
+  aliases, and builds a STIX 2.1 knowledge graph served over a web UI, REST
+  API and MCP.
 licenses:
   - MIT
 platforms:


### PR DESCRIPTION
## Summary

Two documentation fixes:

1. **Repoint the star-history counter** to the repo's current home. The README star-history badge still queried the old `rolandpg/zettelforge`; the repo now lives at `github.com/ThreatRecall/zettelforge` (public, 53 stars). Both the badge image (`api.star-history.com/svg?repos=...`) and its link target are updated to `ThreatRecall/zettelforge` so the counter tracks the current repository.
2. **Ready-to-submit entries for existing curated lists** (follow-up to #180). `sindresorhus/awesome` curates *awesome lists* only, and a new list on either fitting topic would be a duplicate reject (`hslatman/awesome-threat-intelligence` for CTI; `topoteretes/awesome-ai-memory` + ~6 others for AI/agent memory), so the achievable route for a single tool is to be an entry inside an existing list.

## Related issue

Fixes #

## Changes

- `README.md` — star-history badge repointed `rolandpg/zettelforge` → `ThreatRecall/zettelforge` (image + link).
- `docs/awesome-lists/EXISTING_LISTS_ENTRIES.md` — paste-ready, format-matched entries for `hslatman/awesome-threat-intelligence` (HTML-table, Frameworks & Platforms) and `topoteretes/awesome-ai-memory` (pipe-table, Memory Tool / Graph+Vector).
- `docs/awesome-lists/SUBMISSION_GUIDE.md` — section 2 points at existing-list entries; notes that every actual listing is an external merge the maintainer must perform (these lists ban AI-submitted entries).
- `docs/awesome-lists/zettelforge.yml` — description tightened to 236 chars (under the awesome-selfhosted <250-char, sentence-case limit) and verified free of the rejected words.

## Testing

- [ ] Tests pass (`pytest tests/ -v`) — N/A, docs-only change
- [ ] Linting passes (`ruff check src/zettelforge/`) — N/A, no source changes
- [ ] New tests added for new functionality — N/A
- [x] No new external infrastructure dependencies without discussion

🤖 Generated with [Claude Code](https://claude.com/claude-code)