### PR TITLE
security: fix CodeQL stack-trace-exposure and URL-sanitization findings

### DIFF
--- a/src/zettelforge/config.py
+++ b/src/zettelforge/config.py
@@ -349,7 +349,13 @@ class WebConfig:
     """
 
     enabled: bool = True
-    host: str = "0.0.0.0"
+    # Not currently read to open a socket — the actual bind address comes
+    # from web/app.py's `--host` CLI arg (default 127.0.0.1, gated behind
+    # an API key for wider binds) or an explicit `--host` in deployment
+    # tooling (e.g. the Docker image's 0.0.0.0). Kept here for the config
+    # editor UI; default matches the safe CLI default rather than
+    # advertising an all-interfaces bind.
+    host: str = "127.0.0.1"
     port: int = 8088
     ui_dir: str = ""  # defaults to web/ui/ relative to project root at runtime
 

--- a/tests/test_basic.py
+++ b/tests/test_basic.py
@@ -234,9 +234,7 @@ class TestEntityExtractor:
         text = "Malware beaconed to evil.example.com and c2.badactor.net."
         entities = extractor.extract_all(text)
 
-        assert any("example.com" in d for d in entities["domain"])
-        assert any("badactor.net" in d for d in entities["domain"])
-        assert "information" not in entities["domain"]
+        assert set(entities["domain"]) == {"evil.example.com", "c2.badactor.net"}
 
     def test_ioc_hash_extraction(self):
         """MD5, SHA1, and SHA256 hashes are extracted from IOC context."""
@@ -268,8 +266,8 @@ class TestEntityExtractor:
         text = "Download payload from https://evil.com/payload.exe and http://c2.net/gate.php"
         entities = extractor.extract_all(text)
 
-        assert any("evil.com" in u for u in entities["url"])
-        assert any("c2.net" in u for u in entities["url"])
+        assert "https://evil.com/payload.exe" in entities["url"]
+        assert "http://c2.net/gate.php" in entities["url"]
 
     def test_ioc_email_extraction(self):
         """Email addresses are extracted from phishing or threat context."""

--- a/web/app.py
+++ b/web/app.py
@@ -180,6 +180,25 @@ async def require_api_guard(
     _check_rate_limit(supplied_key or client_ip)
 
 
+def _log_and_get_error_id(event: str) -> str:
+    """Log the real exception server-side; return an opaque id for the client.
+
+    Must be called from inside an ``except`` block. Callers must never put
+    the exception's own text in the API response — only this id — since
+    exception detail can carry paths, SQL, or config values (CWE-209).
+    """
+    error_id = secrets.token_hex(8)
+    logger.exception(f"{event} error_id={error_id}")
+    return error_id
+
+
+def _error_response(event: str, *, status_code: int = 500, **extra: Any) -> JSONResponse:
+    """Build a generic 5xx JSON error response, logging the real exception."""
+    content: dict[str, Any] = {"error": "Internal server error", "error_id": _log_and_get_error_id(event)}
+    content.update(extra)
+    return JSONResponse(status_code=status_code, content=content)
+
+
 @app.post("/api/recall", dependencies=[Depends(require_api_guard)])
 async def recall(request: Request, req: RecallRequest):
     tenant_mm = get_mm_for_request(request)
@@ -446,9 +465,8 @@ async def health():
             "graph_node_count": len(kg._nodes),
             "graph_edge_count": len(kg._edges),
         }
-    except Exception as e:
-        logger.exception("health_check_failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("health_check_failed")
 
 
 @app.get("/api/config", dependencies=[Depends(require_api_guard)])
@@ -457,9 +475,8 @@ async def get_config_endpoint():
     try:
         cfg = get_config()
         return _redact_secrets(_config_to_dict(cfg))
-    except Exception as e:
-        logger.exception("get_config_failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("get_config_failed")
 
 
 @app.get("/api/config/meta", dependencies=[Depends(require_api_guard)])
@@ -507,9 +524,8 @@ async def update_config(req: dict):
             "pending_restart": pending_restart,
             "message": message,
         }
-    except Exception as e:
-        logger.exception("update_config_failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("update_config_failed")
 
 
 @app.get("/api/graph/nodes", dependencies=[Depends(require_api_guard)])
@@ -529,9 +545,8 @@ async def graph_nodes():
                 "created_at": node.get("created_at", ""),
             })
         return {"nodes": nodes, "count": len(nodes)}
-    except Exception as e:
-        logger.exception("graph_nodes_failed")
-        return JSONResponse(status_code=500, content={"error": str(e), "nodes": []})
+    except Exception:
+        return _error_response("graph_nodes_failed", nodes=[])
 
 
 @app.get("/api/graph/edges", dependencies=[Depends(require_api_guard)])
@@ -549,9 +564,8 @@ async def graph_edges():
                 "created_at": edge.get("created_at", ""),
             })
         return {"edges": edges, "count": len(edges)}
-    except Exception as e:
-        logger.exception("graph_edges_failed")
-        return JSONResponse(status_code=500, content={"error": str(e), "edges": []})
+    except Exception:
+        return _error_response("graph_edges_failed", edges=[])
 
 
 @app.get("/api/entities", dependencies=[Depends(require_api_guard)])
@@ -594,9 +608,8 @@ async def entities(
         total = len(all_entities)
         page = all_entities[offset:offset + limit]
         return {"entities": page, "total": total, "offset": offset, "limit": limit}
-    except Exception as e:
-        logger.exception("entities_failed")
-        return JSONResponse(status_code=500, content={"error": str(e), "entities": [], "total": 0, "offset": offset, "limit": limit})
+    except Exception:
+        return _error_response("entities_failed", entities=[], total=0, offset=offset, limit=limit)
 
 
 @app.get("/api/history", dependencies=[Depends(require_api_guard)])
@@ -640,9 +653,8 @@ async def history(
                         continue
 
         return entries
-    except Exception as e:
-        logger.exception("History endpoint failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("history_endpoint_failed")
 
 
 class BulkIngestItem(BaseModel):
@@ -691,14 +703,15 @@ async def ingest(request: Request, req: BulkIngestRequest):
                 "success": True,
                 "error": None,
             })
-        except Exception as e:
+        except Exception:
             failed += 1
             results.append({
                 "note_id": None,
                 "status": "error",
                 "entities": [],
                 "success": False,
-                "error": str(e),
+                "error": "Internal server error",
+                "error_id": _log_and_get_error_id("bulk_ingest_item_failed"),
             })
         finally:
             _write_slots.release()
@@ -782,9 +795,8 @@ async def telemetry_summary():
             "p95_ms": p95,
             "top_intents": top_intents,
         }
-    except Exception as e:
-        logger.exception("telemetry_summary_failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("telemetry_summary_failed")
 
 
 @app.get("/api/storage", dependencies=[Depends(require_api_guard)])
@@ -802,9 +814,8 @@ async def storage_stats():
             "graph_node_count": len(kg._nodes),
             "graph_edge_count": len(kg._edges),
         }
-    except Exception as e:
-        logger.exception("storage_stats_failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("storage_stats_failed")
 
 
 @app.get("/api/logs", dependencies=[Depends(require_api_guard)])
@@ -848,9 +859,8 @@ async def logs(
             parsed_logs.append(entry)
 
         return {"logs": parsed_logs, "truncated": truncated}
-    except Exception as e:
-        logger.exception("logs_failed")
-        return JSONResponse(status_code=500, content={"error": str(e), "logs": [], "truncated": False})
+    except Exception:
+        return _error_response("logs_failed", logs=[], truncated=False)
 
 
 @app.get("/api/logs/stream", dependencies=[Depends(require_api_guard)])
@@ -983,9 +993,8 @@ async def version_info():
             "notes": s.get("total_notes", 0),
             "edition": "enterprise" if is_enterprise() else "community",
         }
-    except Exception as e:
-        logger.exception("version_info_failed")
-        return JSONResponse(status_code=500, content={"error": str(e)})
+    except Exception:
+        return _error_response("version_info_failed")
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
## Summary

Clears all 15 open CodeQL alerts (verified locally with CodeQL CLI 2.25.6, same version/default suite the repo uses — this session's GitHub App token doesn't have `security_events` read access to confirm against the live dashboard).

## Related issue

Follow-up to manual triage of https://github.com/ThreatRecall/zettelforge/security/code-scanning

## Changes

- **`web/app.py`** — 11 `py/stack-trace-exposure` alerts: every 5xx handler returned raw `str(e)` to API callers, potentially leaking paths, SQL fragments, or config values. Added `_error_response()` / `_log_and_get_error_id()`: the real exception is still logged server-side via `logger.exception`, but the client now only sees a generic message plus an opaque `error_id` for correlating a support report with server logs. Swept all 12 sites with this pattern (including the per-item error in the bulk-ingest endpoint, which CodeQL's query didn't flag but has the identical shape).
- **`src/zettelforge/config.py`** — `WebConfig.host` defaulted to `"0.0.0.0"` but is never actually read to bind a socket; the real bind address comes from `web/app.py`'s `--host` CLI arg (already defaults to `127.0.0.1`, gated behind an API key for wider binds) or an explicit `--host` in deployment tooling (e.g. the Docker image passes `0.0.0.0` directly). Flipped the dead default so the config editor UI doesn't advertise an all-interfaces bind that isn't actually wired up.
- **`tests/test_basic.py`** — 4 `py/incomplete-url-substring-sanitization` false positives: CodeQL's heuristic flags domain/URL-shaped string literals used with `in`, even for exact list-membership assertions in test code. Rewrote as direct membership checks and a set-equality comparison — both are stronger assertions (they also catch unexpected extras) and no longer match the query's pattern.

## Testing

- [x] Tests pass (`pytest tests/ -v`) — 701 passed (excluded: an unrelated network-blocked embedding-model download test, and `test_osint_collectors.py`'s live-network tests, both environment issues in this sandbox unrelated to this change)
- [x] Linting passes (`ruff check src/zettelforge/`)
- [x] New tests added for new functionality — n/a, existing tests rewritten to fix false-positive alerts
- [x] No new external infrastructure dependencies without discussion

Verified via local CodeQL rebuild + rescan: 15 alerts → 0 (all three configured languages — Python, GitHub Actions, JavaScript/TypeScript — checked; the latter two had zero alerts before and after).

## Note

While rescanning, CodeQL also flagged `examples/athf_bridge.py:48` as unparseable (`SyntaxError: '{' was never closed`), which silently excludes that file from every scan, including the real GitHub Actions run. Pre-existing, unrelated to this change — flagging here rather than fixing, since it's out of scope for this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01TqYpmV8TABMzq27HBTLtNP)_